### PR TITLE
feat(hybridge): add liveness probes

### DIFF
--- a/back/apps/bridge-http-proxy/src/controllers/bridge-http-proxy.controller.ts
+++ b/back/apps/bridge-http-proxy/src/controllers/bridge-http-proxy.controller.ts
@@ -25,6 +25,12 @@ export class BridgeHttpProxyController {
     private readonly broker: BridgeHttpProxyService,
   ) {}
 
+  @Get(BridgeHttpProxyRoutes.HEALTHCHECK_LIVE)
+  healthcheck(): string {
+    console.log("ping...");
+    return "ok";
+  }
+
   /**
    * Catch all 'GET' routes needed for a cinematic
    * * /.well-known/openid-configuration
@@ -64,7 +70,7 @@ export class BridgeHttpProxyController {
     const { originalUrl, method } = req;
     const { host, 'x-forwarded-proto': xForwardedProto } = headers;
 
-    this.logger.info(`${method} ${xForwardedProto}://${host}${originalUrl}`);
+    this.logger.info(`${method} ${xForwardedProto || 'https'}://${host}${originalUrl}`);
 
     const response: BridgeProtocol<object> = await this.broker.proxyRequest(
       originalUrl,

--- a/back/apps/bridge-http-proxy/src/controllers/bridge-http-proxy.controller.ts
+++ b/back/apps/bridge-http-proxy/src/controllers/bridge-http-proxy.controller.ts
@@ -27,7 +27,6 @@ export class BridgeHttpProxyController {
 
   @Get(BridgeHttpProxyRoutes.HEALTHCHECK_LIVE)
   healthcheck(): string {
-    console.log("ping...");
     return "ok";
   }
 

--- a/back/apps/bridge-http-proxy/src/enums/bridge-http-proxy-routes.enum.ts
+++ b/back/apps/bridge-http-proxy/src/enums/bridge-http-proxy-routes.enum.ts
@@ -1,3 +1,4 @@
 export enum BridgeHttpProxyRoutes {
+  HEALTHCHECK_LIVE = '/livez',
   WILDCARD = '*',
 }

--- a/back/apps/bridge-http-proxy/src/services/bridge-http-proxy.service.ts
+++ b/back/apps/bridge-http-proxy/src/services/bridge-http-proxy.service.ts
@@ -84,7 +84,7 @@ export class BridgeHttpProxyService {
     data?: string,
   ): BridgePayload {
     const { host, 'x-forwarded-proto': xForwardedProto } = headers;
-    const url = `${xForwardedProto}://${host}${originalUrl}`;
+    const url = `${xForwardedProto || 'https'}://${host}${originalUrl}`;
 
     return {
       headers,

--- a/back/apps/csmr-http-proxy/src/controllers/csmr-http-proxy.controller.ts
+++ b/back/apps/csmr-http-proxy/src/controllers/csmr-http-proxy.controller.ts
@@ -1,4 +1,4 @@
-import { Controller, UsePipes, ValidationPipe } from '@nestjs/common';
+import { Controller, Get, UsePipes, ValidationPipe } from '@nestjs/common';
 import { MessagePattern, Payload } from '@nestjs/microservices';
 
 import { ValidationException } from '@fc/exceptions';
@@ -20,6 +20,12 @@ export class CsmrHttpProxyController {
     private readonly logger: LoggerService,
     private readonly proxy: CsmrHttpProxyService,
   ) {}
+
+  @Get("/livez")
+  healthcheck(): string {
+    console.log("ping...");
+    return "ok";
+  }
 
   @MessagePattern(HttpProxyProtocol.Commands.HTTP_PROXY)
   @UsePipes(

--- a/back/apps/csmr-http-proxy/src/controllers/csmr-http-proxy.controller.ts
+++ b/back/apps/csmr-http-proxy/src/controllers/csmr-http-proxy.controller.ts
@@ -23,7 +23,6 @@ export class CsmrHttpProxyController {
 
   @Get("/livez")
   healthcheck(): string {
-    console.log("ping...");
     return "ok";
   }
 


### PR DESCRIPTION
Concerne uniquement la hybridge

## Liveness probe

Ajout de point d'API `/livez` qui peuvent être utilisés comme LivenessProbe par Kube ou comme healthcheck par Docker Compose (la nomenclature `/livez` reprend celle proposée par Kube https://kubernetes.io/docs/reference/using-api/health-checks/)

## Valeur par défaut de `X-Forwarded-Proto`

Au sein des messages traités par l'hybridge, on assume également que le `X-Forwarded-Proto` est du HTTPS par défaut lorsque celui-ci n'est pas défini (suite à proposition d'Acton)
