### PR TITLE
Stop using published custom NodeJS image

### DIFF
--- a/docker/bash/commands/docker.sh
+++ b/docker/bash/commands/docker.sh
@@ -2,7 +2,7 @@
 
 # Find which nodejs containers are running and store it into $NODEJS_CONTAINERS
 _get_running_containers() {
-  local raw_nodejs_containers=$(docker ps --format '{{.Names}}' -f ancestor=${PC_DOCKER_REGISTRY}/nodejs:${NODE_VERSION}-dev)
+  local raw_nodejs_containers=$(docker ps --format '{{.Names}}' -f ancestor=pc-nodejs)
   local raw_all_containers=$(docker ps --format '{{.Names}}')
 
   NODEJS_CONTAINERS=$(_container_to_compose_name "${raw_nodejs_containers}")

--- a/docker/bash/commands/up.sh
+++ b/docker/bash/commands/up.sh
@@ -57,7 +57,7 @@ _up() {
 
   # Find which nodejs containers are running and store it into $NODEJS_CONTAINERS
   echo " * Populate global variables"
-  local raw_nodejs_containers=$(docker ps --format '{{.Names}}' -f ancestor=${PC_DOCKER_REGISTRY}/nodejs:${NODE_VERSION}-dev)
+  local raw_nodejs_containers=$(docker ps --format '{{.Names}}' -f ancestor=pc-nodejs)
 
   echo " * Found nodejs containers: ${raw_nodejs_containers}"
 

--- a/docker/builds/node/Dockerfile
+++ b/docker/builds/node/Dockerfile
@@ -1,3 +1,45 @@
-ARG NODE_IMAGE_VERSION=node:lts-alpine
+# the different stages of this Dockerfile are meant to be built into separate images
+# https://docs.docker.com/compose/compose-file/#target
 
-FROM ${NODE_IMAGE_VERSION}
+ARG NODE_VERSION=22.13.0
+ARG DEBIAN_VERSION=bullseye
+
+FROM node:${NODE_VERSION#v}-${DEBIAN_VERSION}-slim AS prod
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update && \
+    apt-get install -y curl gnupg
+
+RUN echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list && \
+    curl -sL https://dl.yarnpkg.com/debian/pubkey.gpg | gpg --dearmor | tee /usr/share/keyrings/yarnkey.gpg >/dev/null && \
+    echo "deb [signed-by=/usr/share/keyrings/yarnkey.gpg] https://dl.yarnpkg.com/debian stable main" | tee /etc/apt/sources.list.d/yarn.list && \
+    apt update && \
+    apt install -y python3 \
+                   python3-pip \
+                   yarn \
+                   git \
+                   procps \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN ln -s /usr/bin/python3 /usr/bin/python
+
+RUN npm install -g npm && \
+    npm set progress=false && \
+    npm install -g pm2 && \
+    echo "alias ll=\"ls -lahF --color\"" >> ~/.bashrc
+
+RUN mkdir -p /var/www
+
+FROM prod AS dev
+
+RUN yarn global add node-gyp
+
+RUN apt update && \
+    apt install -y build-essential \
+                   jq \
+                   openssl \
+                   python \
+                   wget \
+                   bc \
+    && rm -rf /var/lib/apt/lists/*

--- a/docker/compose/fca-low/core-rie.yml
+++ b/docker/compose/fca-low/core-rie.yml
@@ -3,7 +3,8 @@
 services:
   core-fca-rie:
     hostname: core-fca-rie
-    image: ${PC_DOCKER_REGISTRY}/nodejs:${NODE_VERSION}-dev
+    image: pc-nodejs
+    build: { context: "${COMPOSE_DIR}/../builds/node", args: { NODE_VERSION: "${NODE_VERSION}" } }
     user: ${CURRENT_UID}
     working_dir: /var/www/app
     depends_on:

--- a/docker/compose/fca-low/core.yml
+++ b/docker/compose/fca-low/core.yml
@@ -3,8 +3,8 @@
 services:
   core-fca-low:
     hostname: core-fca-low
-    # image: node:lts-alpine
-    image: ${PC_DOCKER_REGISTRY}/nodejs:${NODE_VERSION}-dev
+    image: pc-nodejs
+    build: { context: "${COMPOSE_DIR}/../builds/node", args: { NODE_VERSION: "${NODE_VERSION}" } }
     user: ${CURRENT_UID}
     working_dir: /var/www/app
     depends_on:

--- a/docker/compose/fca-low/exploitation-fca-low.yml
+++ b/docker/compose/fca-low/exploitation-fca-low.yml
@@ -1,7 +1,8 @@
 services:
   exploitation-fca-low:
     hostname: exploitation-fca-low
-    image: ${PC_DOCKER_REGISTRY}/nodejs:${NODE_VERSION}-dev
+    image: pc-nodejs
+    build: { context: "${COMPOSE_DIR}/../builds/node", args: { NODE_VERSION: "${NODE_VERSION}" } }
     user: ${CURRENT_UID}
     working_dir: /var/www/app/fc-exploitation
     depends_on:

--- a/docker/compose/fca-low/hybridge.yml
+++ b/docker/compose/fca-low/hybridge.yml
@@ -20,7 +20,8 @@ services:
 
   bridge-proxy-rie:
     hostname: bridge-proxy-rie
-    image: ${PC_DOCKER_REGISTRY}/nodejs:${NODE_VERSION}-dev
+    image: pc-nodejs
+    build: { context: "${COMPOSE_DIR}/../builds/node", args: { NODE_VERSION: "${NODE_VERSION}" } }
     user: ${CURRENT_UID}
     working_dir: /var/www/app
     volumes:
@@ -46,7 +47,8 @@ services:
   ####################
   csmr-rie:
     hostname: csmr-rie
-    image: ${PC_DOCKER_REGISTRY}/nodejs:${NODE_VERSION}-dev
+    image: pc-nodejs
+    build: { context: "${COMPOSE_DIR}/../builds/node", args: { NODE_VERSION: "${NODE_VERSION}" } }
     user: ${CURRENT_UID}
     working_dir: /var/www/app
     depends_on:
@@ -80,7 +82,8 @@ services:
 
   fia-rie-low:
     hostname: fia-rie-low
-    image: ${PC_DOCKER_REGISTRY}/nodejs:${NODE_VERSION}-dev
+    image: pc-nodejs
+    build: { context: "${COMPOSE_DIR}/../builds/node", args: { NODE_VERSION: "${NODE_VERSION}" } }
     user: ${CURRENT_UID}
     working_dir: /var/www/app
     depends_on:

--- a/docker/compose/fca-low/mocks.yml
+++ b/docker/compose/fca-low/mocks.yml
@@ -7,7 +7,8 @@ services:
 
   fsa1-low:
     hostname: fsa1-low
-    image: ${PC_DOCKER_REGISTRY}/nodejs:${NODE_VERSION}-dev
+    image: pc-nodejs
+    build: { context: "${COMPOSE_DIR}/../builds/node", args: { NODE_VERSION: "${NODE_VERSION}" } }
     user: ${CURRENT_UID}
     working_dir: /var/www/app
     depends_on:
@@ -31,7 +32,8 @@ services:
 
   fsa2-low:
     hostname: fsa2-low
-    image: ${PC_DOCKER_REGISTRY}/nodejs:${NODE_VERSION}-dev
+    image: pc-nodejs
+    build: { context: "${COMPOSE_DIR}/../builds/node", args: { NODE_VERSION: "${NODE_VERSION}" } }
     user: ${CURRENT_UID}
     working_dir: /var/www/app
     depends_on:
@@ -55,7 +57,8 @@ services:
 
   fsa3-low:
     hostname: fsa3-low
-    image: ${PC_DOCKER_REGISTRY}/nodejs:${NODE_VERSION}-dev
+    image: pc-nodejs
+    build: { context: "${COMPOSE_DIR}/../builds/node", args: { NODE_VERSION: "${NODE_VERSION}" } }
     user: ${CURRENT_UID}
     working_dir: /var/www/app
     depends_on:
@@ -79,8 +82,8 @@ services:
 
   fsa4-low:
     hostname: fsa4-low
-    image: ${PC_DOCKER_REGISTRY}/nodejs:${NODE_VERSION}-dev
-    user: ${CURRENT_UID}
+    image: pc-nodejs
+    build: { context: "${COMPOSE_DIR}/../builds/node", args: { NODE_VERSION: "${NODE_VERSION}" } }
     working_dir: /var/www/app
     depends_on:
       redis-pwd:
@@ -107,7 +110,8 @@ services:
 
   fia1-low:
     hostname: fia1-low
-    image: ${PC_DOCKER_REGISTRY}/nodejs:${NODE_VERSION}-dev
+    image: pc-nodejs
+    build: { context: "${COMPOSE_DIR}/../builds/node", args: { NODE_VERSION: "${NODE_VERSION}" } }
     user: ${CURRENT_UID}
     working_dir: /var/www/app
     depends_on:
@@ -132,7 +136,8 @@ services:
 
   fia2-low:
     hostname: fia2-low
-    image: ${PC_DOCKER_REGISTRY}/nodejs:${NODE_VERSION}-dev
+    image: pc-nodejs
+    build: { context: "${COMPOSE_DIR}/../builds/node", args: { NODE_VERSION: "${NODE_VERSION}" } }
     user: ${CURRENT_UID}
     working_dir: /var/www/app
     depends_on:
@@ -157,7 +162,8 @@ services:
 
   moncomptepro:
     hostname: moncomptepro
-    image: ${PC_DOCKER_REGISTRY}/nodejs:${NODE_VERSION}-dev
+    image: pc-nodejs
+    build: { context: "${COMPOSE_DIR}/../builds/node", args: { NODE_VERSION: "${NODE_VERSION}" } }
     user: ${CURRENT_UID}
     working_dir: /var/www/app
     depends_on:
@@ -186,7 +192,8 @@ services:
 
   dpa1-low:
     hostname: dpa1-low
-    image: ${PC_DOCKER_REGISTRY}/nodejs:${NODE_VERSION}-dev
+    image: pc-nodejs
+    build: { context: "${COMPOSE_DIR}/../builds/node", args: { NODE_VERSION: "${NODE_VERSION}" } }
     user: ${CURRENT_UID}
     working_dir: /var/www/app
     volumes:
@@ -205,7 +212,8 @@ services:
 
   dpa2-low:
     hostname: dpa2-low
-    image: ${PC_DOCKER_REGISTRY}/nodejs:${NODE_VERSION}-dev
+    image: pc-nodejs
+    build: { context: "${COMPOSE_DIR}/../builds/node", args: { NODE_VERSION: "${NODE_VERSION}" } }
     user: ${CURRENT_UID}
     working_dir: /var/www/app
     volumes:

--- a/docker/compose/shared/shared.yml
+++ b/docker/compose/shared/shared.yml
@@ -78,7 +78,8 @@ services:
 
   log-hub:
     hostname: log-hub
-    image: ${PC_DOCKER_REGISTRY}/nodejs:${NODE_VERSION}-dev
+    image: pc-nodejs
+    build: { context: "${COMPOSE_DIR}/../builds/node", args: { NODE_VERSION: "${NODE_VERSION}" } }
     user: ${CURRENT_UID}
     working_dir: /var/www/app
     volumes:


### PR DESCRIPTION
This PR replaces the use of the `ghcr.io/proconnect-gouv/federation/nodejs:v22.13.0-dev` (copied from `registry.gitlab.dev-franceconnect.fr/france-connect/fc/nodejs:v22.13.0-dev`) with locally-built image based on the official NodeJS Docker image.

This avoids a dependency on a custom Docker registry, and also automatically builds an image that is compatible with the local platform (i.e. `arm64` on Apple Silicon laptops).