### PR TITLE
[PCF-633]🐛 Debug wait command for docker with new naming convention

### DIFF
--- a/docker/bash/utils/wait.sh
+++ b/docker/bash/utils/wait.sh
@@ -24,7 +24,7 @@ _wait_for_nodejs_fail() {
   echo "$(format_failure " Failed ") Service DOWN: $1"
   echo ""
   echo "--- PM2 Logs for ${1} ---------------------------"
-  docker exec "fc_${1}_1" bash -c 'cat /tmp/.pm2/logs/*.log' || true
+  docker exec "pc_${1}-1" bash -c 'cat /tmp/.pm2/logs/*.log' || true
   echo "--- End of PM2 Logs for ${1} --------------------"
   echo ""
   echo "--- curl Logs for ${1} ---------------------------"


### PR DESCRIPTION
federation-admin use this script for CI.

Because we don't use anymore the docker compose 1 version for naming the containers, we need to adapt the name of the container.