### PR TITLE
[PCF-633]🔨 Restore missing last dks logs env var

### DIFF
--- a/docker/bash/config.sh
+++ b/docker/bash/config.sh
@@ -49,3 +49,7 @@ STYLE_FAILURE="\e[1;41m"
 STYLE_WARNING="\e[1;33m"
 STYLE_EMPHASIS="\e[3m"
 STYLE_RESET="\e[0;0m"
+
+export __DKS_LAST_LOG_FILE="${LOGS_PATH}/docker_stack_last.log"
+# Exit code reserved to return data to the be displayed by `task` instead of simple success/failure
+export __DKS_TASK_RETURN_EXIT_CODE=42


### PR DESCRIPTION
Restore env var removed in previous clean of some dks task relatives files.
This vars are usefull for getting the path of the file with the last logs allowing to check if admin is running.