### PR TITLE
Improve OIDC compliance

### DIFF
--- a/back/.eslintrc.js
+++ b/back/.eslintrc.js
@@ -53,6 +53,7 @@ const allowedSnakeCaseParameters = [
   'redirect_uris',
   'refresh_token',
   'rep_scope',
+  'response_mode',
   'response_type',
   'response_types',
   'revocation_endpoint_auth_method',

--- a/back/apps/core-fca/src/dto/authorize-params.dto.ts
+++ b/back/apps/core-fca/src/dto/authorize-params.dto.ts
@@ -37,6 +37,10 @@ export class AuthorizeParamsDto {
 
   @IsOptional()
   @IsString()
+  readonly response_mode: string;
+
+  @IsOptional()
+  @IsString()
   @IsAscii({ message: 'Le nonce doit être composé de caractères ASCII' })
   @Length(1, 512)
   readonly nonce?: string;

--- a/quality/fca/cypress/integration/api/api-authorize.feature
+++ b/quality/fca/cypress/integration/api/api-authorize.feature
@@ -113,6 +113,15 @@ Fonctionnalité: API - authorize
     Et le corps de la réponse contient une page web
     Et je suis redirigé vers la page interaction
 
+Scénario: API authorize - Cas nominal avec response_mode (ignoré)
+    Etant donné que je prépare une requête "authorize"
+    Et que je mets "fragment" dans le paramètre "response_mode" de la requête
+    Quand je lance la requête
+    Alors le statut de la réponse est 200
+    Et l'entête de la réponse a une propriété "content-type" contenant "text/html"
+    Et le corps de la réponse contient une page web
+    Et je suis redirigé vers la page interaction
+
   @ignoreInteg01
   Scénario: API authorize - Cas nominal sans login_hint
     Etant donné que je prépare une requête "authorize"


### PR DESCRIPTION
Improve OIDC compliance by allowing (and ignoring) response_mode param in authorize