### PR TITLE
[PCF-689]🔨 Shortcut for starting default stack with dks

### DIFF
--- a/docker/bash/utils/commands.sh
+++ b/docker/bash/utils/commands.sh
@@ -17,8 +17,8 @@ function _command_run() {
 
   if [ -z "${key}" ]; then
     echo "No command found"
-    echo "Use help to see all available commands:"
-    echo " > ./docker-stack help"
+    echo "Start dks switch medium"
+    _command_run switch medium
     exit 1
   fi
 


### PR DESCRIPTION
When only writing dks, the default behaviour is to start the default stack.
You can still write

```sh
dks switch medium
```

Or simply:

```sh
dks
```