### PR TITLE
[PCF-696]🗃 Correct and optimize accountFca fetch

### DIFF
--- a/back/libs/account-fca/src/services/account-fca.service.spec.ts
+++ b/back/libs/account-fca/src/services/account-fca.service.spec.ts
@@ -54,8 +54,12 @@ describe('AccountFcaService', () => {
       });
 
       expect(modelMock.findOne).toHaveBeenCalledWith({
-        'idpIdentityKeys.idpSub': 'sub',
-        'idpIdentityKeys.idpUid': 'uid',
+        idpIdentityKeys: {
+          $elemMatch: {
+            idpSub: 'sub',
+            idpUid: 'uid',
+          },
+        },
       });
       expect(result).toEqual(mockAccount);
     });

--- a/back/libs/account-fca/src/services/account-fca.service.ts
+++ b/back/libs/account-fca/src/services/account-fca.service.ts
@@ -17,8 +17,12 @@ export class AccountFcaService {
     idpIdentityKeys: IIdpAgentKeys,
   ): Promise<AccountFca> {
     return await this.model.findOne({
-      'idpIdentityKeys.idpSub': idpIdentityKeys.idpSub,
-      'idpIdentityKeys.idpUid': idpIdentityKeys.idpUid,
+      idpIdentityKeys: {
+        $elemMatch: {
+          idpSub: idpIdentityKeys.idpSub,
+          idpUid: idpIdentityKeys.idpUid,
+        },
+      },
     });
   }
 

--- a/quality/fca/cypress/integration/usager/connexion-sub.feature
+++ b/quality/fca/cypress/integration/usager/connexion-sub.feature
@@ -38,6 +38,17 @@ Fonctionnalité: Connexion Usager - Sub
     Et que je suis connecté au fournisseur de service
     Alors le sub transmis au fournisseur de service est identique au sub mémorisé
 
+  Scénario: vérifie qu'un account n'est pas retrouvé si un FI utilise un sub existant dans un autre FI
+    Etant donné que je navigue sur la page fournisseur de service "premier FS"
+    Et que je clique sur le bouton ProConnect
+    Et que je suis redirigé vers la page interaction
+    Et que j'entre l'email "test@fia1.fr"
+    Et que je clique sur le bouton de connexion
+    # Le sub "s7Ht2K9pL5mN8vX3cR4wQ" correspond au fia2 dans un accountFca existant
+    Quand j'utilise l'identité avec le sub "s7Ht2K9pL5mN8vX3cR4wQ"
+    Et que je m'authentifie
+    Alors le sub transmis au fournisseur de service n'est pas le suivant "d68cec59-ed65-48ab-bfbf-1ca65dd807f8"
+
   @ignoreInteg01
   Scénario: retourne le sub déjà enregistré pour deux identités connues qui sont rattachées à un même sub dans ProConnect
     Etant donné que je navigue sur la page fournisseur de service "premier FS"

--- a/quality/fca/cypress/support/usager/steps/service-provider-steps.ts
+++ b/quality/fca/cypress/support/usager/steps/service-provider-steps.ts
@@ -191,6 +191,13 @@ Then(
 );
 
 Then(
+  /^le sub transmis au fournisseur de service n'est pas le suivant {string}$/,
+  function (sub: string) {
+    getUserInfoProperty('sub').should.not('be.equal', sub);
+  },
+);
+
+Then(
   'le siret transmis au fournisseur de service est le suivant {string}',
   function (siret: string) {
     getUserInfoProperty('siret').should('be.equal', siret);

--- a/quality/fca/cypress/support/usager/steps/service-provider-steps.ts
+++ b/quality/fca/cypress/support/usager/steps/service-provider-steps.ts
@@ -191,9 +191,9 @@ Then(
 );
 
 Then(
-  /^le sub transmis au fournisseur de service n'est pas le suivant {string}$/,
+  "le sub transmis au fournisseur de service n'est pas le suivant {string}",
   function (sub: string) {
-    getUserInfoProperty('sub').should.not('be.equal', sub);
+    getUserInfoProperty('sub').should('not.be.equal', sub);
   },
 );
 


### PR DESCRIPTION
Correct the following problem:
```js
db.accountFca.insertOne({
  active: true,
  idpIdentityKeys: [{ idpSub: "<A>", idpUid: "Curasso" }],
  sub: 1,
});
db.accountFca.insertOne({
  active: true,
  idpIdentityKeys: [
    { idpSub: "<A>", idpUid: "MonComptePro" },
    { idpSub: "<B>", idpUid: "Curasso" },
  ],
  sub: 2,
});

db.accountFca.find({
  "idpIdentityKeys.idpSub": "<A>",
  "idpIdentityKeys.idpUid": "Curasso",
});
```

The last request returns the two accounts.