### PR TITLE
Make docker-stack print help when no command is given

### DIFF
--- a/docker/bash/utils/commands.sh
+++ b/docker/bash/utils/commands.sh
@@ -16,10 +16,8 @@ function _command_run() {
   local key=$1
 
   if [ -z "${key}" ]; then
-    echo "No command found"
-    echo "Start dks switch medium"
-    _command_run switch medium
-    exit 1
+    _command_list
+    exit 0
   fi
 
   local cmd=${__CMD_COMMANDS[${key}]}
@@ -27,7 +25,7 @@ function _command_run() {
   if [ -z "${cmd}" ]; then
     echo "Command not found: <${key}>"
     echo "Use help to see all available commands:"
-    echo " > ./docker-stack help"
+    echo " > docker-stack help"
     exit 1
   fi
 


### PR DESCRIPTION
## Problem

Since #79 typing `docker-stack` (or `dks`) by itself restarts a complete stack (does a `docker-stack switch medium`).

Consensus seems to be that this is not very friendly to new users who are unfamiliar with `docker-stack` and would prefer to be shown the command list. It is sometimes appropriate for a program to have a default action when invoked without arguments (see `ls`, `yarn`) but it is not applicable to every program. I submit that this is only appropriate when the default action has no persistent effects (as with `ls`) or it is idempotent (as with `yarn`).

## Proposed solution

Make `docker-stack` print the command list when not given a command.