### PR TITLE
refactor: use transformed object

### DIFF
--- a/back/libs/fqdn-to-idp-adapter-mongo/src/service/fqdn-to-idp-adapter-mongo.service.ts
+++ b/back/libs/fqdn-to-idp-adapter-mongo/src/service/fqdn-to-idp-adapter-mongo.service.ts
@@ -1,11 +1,12 @@
+import { plainToInstance } from 'class-transformer';
+import { validate } from 'class-validator';
 import * as deepFreeze from 'deep-freeze';
+import { filter } from 'lodash';
 import { Model } from 'mongoose';
 
 import { Injectable } from '@nestjs/common';
 import { InjectModel } from '@nestjs/mongoose';
 
-import { asyncFilter, validateDto } from '@fc/common';
-import { validationOptions } from '@fc/config';
 import { LoggerService } from '@fc/logger';
 import { MongooseCollectionOperationWatcherHelper } from '@fc/mongoose';
 
@@ -63,7 +64,7 @@ export class FqdnToIdpAdapterMongoService
       this.logger.debug('Refresh FqdnToIdentityProvider cache from DB');
 
       this.fqdnToIdpCache = deepFreeze(
-        await this.fetchFqdnToIdps(),
+        await this.findAllFqdnToIdentityProvider(),
       ) as FqdnToIdentityProvider[];
 
       this.logger.debug({
@@ -80,48 +81,46 @@ export class FqdnToIdpAdapterMongoService
     return this.fqdnToIdpCache;
   }
 
-  /**
-   * Fetches in Mongo all Idps for all domains
-   * in mongo corresponding collection.
-   * Then it checks all returned rows with dto validation
-   * and eventually returns only validated rows
-   */
-  private async fetchFqdnToIdps(): Promise<FqdnToIdentityProvider[]> {
-    const fqdnToProviderRaw = await this.FqdnToIdentityProviderModel.find(
-      {},
-      {
-        _id: false,
-        fqdn: true,
-        identityProvider: true,
-        acceptsDefaultIdp: true,
-      },
-    )
-      .sort({ fqdn: 1, identityProvider: 1 })
-      .lean();
+  private async findAllFqdnToIdentityProvider() {
+    const rawFqdnToIdentityProviders =
+      await this.FqdnToIdentityProviderModel.find(
+        {},
+        {
+          _id: false,
+          fqdn: true,
+          identityProvider: true,
+          acceptsDefaultIdp: true,
+        },
+      )
+        .sort({ fqdn: 1, identityProvider: 1 })
+        .lean();
 
-    const fqdnToProvider = await asyncFilter<FqdnToIdentityProvider[]>(
-      // because fqdnToProvidr entity == fqdnToProvider dto
-      // we don't need to transform fqdnToProviderRow into a dto
-      fqdnToProviderRaw,
-      async (doc: FqdnToIdentityProvider) => {
-        const errors = await validateDto(
-          doc,
+    const fqdnToIdentityProviders = await Promise.all(
+      rawFqdnToIdentityProviders.map(async (rawFqdnToIdentityProvider) => {
+        const fqdnToIdentityProvider = plainToInstance(
           GetFqdnToIdentityProviderMongoDto,
-          validationOptions,
+          rawFqdnToIdentityProvider,
         );
+        const errors = await validate(fqdnToIdentityProvider, {
+          forbidNonWhitelisted: true,
+          skipMissingProperties: false,
+          whitelist: true,
+        });
 
-        if (errors.length > 0) {
-          this.logger.warning(
-            `fqdnToProvider with domain "${doc.fqdn}" and provider uuid "${doc.identityProvider}" was excluded from the result at DTO validation.`,
-          );
-          this.logger.err({ errors });
+        const { fqdn, identityProvider } = rawFqdnToIdentityProvider;
+
+        if (errors.length) {
+          this.logger.alert({
+            msg: `fqdnToProvider with domain "${fqdn}" and provider uuid "${identityProvider}" was excluded from the result at DTO validation.`,
+            validationErrors: errors,
+          });
         }
 
-        return errors.length === 0;
-      },
+        return !errors.length ? fqdnToIdentityProvider : undefined;
+      }),
     );
 
-    return fqdnToProvider;
+    return filter(fqdnToIdentityProviders);
   }
 
   fetchFqdnToIdpByEmail(email: string): Promise<FqdnToIdentityProvider[]> {

--- a/back/libs/service-provider-adapter-mongo/src/interfaces/index.ts
+++ b/back/libs/service-provider-adapter-mongo/src/interfaces/index.ts
@@ -1,1 +1,0 @@
-export * from './mongo-request-filter-argument';

--- a/back/libs/service-provider-adapter-mongo/src/interfaces/mongo-request-filter-argument.ts
+++ b/back/libs/service-provider-adapter-mongo/src/interfaces/mongo-request-filter-argument.ts
@@ -1,3 +1,0 @@
-export interface MongoRequestFilterArgument {
-  active: boolean;
-}


### PR DESCRIPTION
The previous implementation did not whitelist object property as the result of validation was droped. Also no transformation by class-transformer was possible for the same reason.

Proposal

Use the class-transformer and class-validator results as object passed to the application.