### PR TITLE
🔨 dks prune-all only remove docker contents

### DIFF
--- a/docker/bash/commands/docker.sh
+++ b/docker/bash/commands/docker.sh
@@ -64,11 +64,6 @@ _prune_all() {
   docker image prune -af
   docker system prune -af --volumes
   docker system df
-  npm cache clean --force
-  yarn cache clean
-  sudo du -sh /var/cache/apt/archives
-  cd $PC_ROOT
-  find . -name "node_modules" -type d -prune -exec rm -rf '{}' +
 }
 
 _prune_ci() {


### PR DESCRIPTION
Actually, the `dks prune-all` command requires sudo access.
I propose modifying it to only handle Docker content deletion, removing the need for elevated privileges.