### PR TITLE
🧪 test: add missing app module test files

### DIFF
--- a/back/apps/bridge-http-proxy/src/bridge-http-proxy.module.spec.ts
+++ b/back/apps/bridge-http-proxy/src/bridge-http-proxy.module.spec.ts
@@ -1,0 +1,26 @@
+import { Test } from '@nestjs/testing';
+
+import { ConfigModule } from '@fc/config';
+import { LoggerModule } from '@fc/logger';
+
+import { getConfigMock } from '@mocks/config';
+
+import { BridgeHttpProxyModule } from './bridge-http-proxy.module';
+
+describe('BridgeHttpProxyModule Dependency Validation', () => {
+  it('should compile successfully with minimal config', async () => {
+    const configServiceMock = getConfigMock();
+    configServiceMock.get.mockReturnValue({ threshold: 'info' });
+
+    const moduleFixture = await Test.createTestingModule({
+      imports: [
+        BridgeHttpProxyModule,
+        ConfigModule.forRoot(configServiceMock as any),
+        LoggerModule.forRoot([]),
+      ],
+    }).compile();
+
+    expect(moduleFixture).toBeDefined();
+    expect(moduleFixture.get(BridgeHttpProxyModule)).toBeDefined();
+  });
+});

--- a/back/apps/csmr-http-proxy/src/csmr-http-proxy.module.spec.ts
+++ b/back/apps/csmr-http-proxy/src/csmr-http-proxy.module.spec.ts
@@ -1,0 +1,32 @@
+import { Test } from '@nestjs/testing';
+
+import { ConfigModule } from '@fc/config';
+import { LoggerModule } from '@fc/logger';
+
+import { getConfigMock } from '@mocks/config';
+
+import { CsmrHttpProxyModule } from './csmr-http-proxy.module';
+
+describe('CsmrHttpProxyModule Dependency Validation', () => {
+  it('should compile successfully with minimal config', async () => {
+    const configServiceMock = getConfigMock();
+    configServiceMock.get.mockImplementation(
+      (key: string) =>
+        ({
+          Logger: { threshold: 'info' },
+          HttpProxyBroker: { requestTimeout: 5000 },
+        })[key] || {},
+    );
+
+    const moduleFixture = await Test.createTestingModule({
+      imports: [
+        CsmrHttpProxyModule,
+        ConfigModule.forRoot(configServiceMock as any),
+        LoggerModule.forRoot([]),
+      ],
+    }).compile();
+
+    expect(moduleFixture).toBeDefined();
+    expect(moduleFixture.get(CsmrHttpProxyModule)).toBeDefined();
+  });
+});

--- a/back/apps/mock-data-provider/src/mock-data-provider.module.spec.ts
+++ b/back/apps/mock-data-provider/src/mock-data-provider.module.spec.ts
@@ -1,0 +1,35 @@
+import { Test } from '@nestjs/testing';
+
+import { ConfigModule } from '@fc/config';
+import { LoggerModule } from '@fc/logger';
+
+import { getConfigMock } from '@mocks/config';
+
+import { MockDataProviderModule } from './mock-data-provider.module';
+
+describe('MockDataProviderModule Dependency Validation', () => {
+  it('should compile successfully with minimal config', async () => {
+    const configServiceMock = getConfigMock();
+    configServiceMock.get.mockImplementation(
+      (key: string) =>
+        ({
+          Logger: { threshold: 'info' },
+          Jwt: {
+            secretOrPublicKey: 'test-secret',
+            signOptions: { expiresIn: '1h' },
+          },
+        })[key] || {},
+    );
+
+    const moduleFixture = await Test.createTestingModule({
+      imports: [
+        MockDataProviderModule,
+        ConfigModule.forRoot(configServiceMock as any),
+        LoggerModule.forRoot([]),
+      ],
+    }).compile();
+
+    expect(moduleFixture).toBeDefined();
+    expect(moduleFixture.get(MockDataProviderModule)).toBeDefined();
+  });
+});


### PR DESCRIPTION
<div align=center><img src="https://media.giphy.com/media/l0HlRnAWXxn0MhKLK/giphy.gif" /></div>

---

## Problem

NestJS throws dependency resolution errors when loading app modules during testing, preventing proper module validation and causing build failures.

## Proposed solution

Add basic module test files for bridge-http-proxy, csmr-http-proxy, and mock-data-provider apps to provide proper test context.