### PR TITLE
🔒️ security: avoid changing directory in bash scripts

### DIFF
--- a/docker/bash/commands/up.sh
+++ b/docker/bash/commands/up.sh
@@ -15,7 +15,7 @@ function _hook_fc_apps() {
     ${DOCKER_COMPOSE} exec ${NO_TTY} "${app}" yarn migrations:run
     ${DOCKER_COMPOSE} exec ${NO_TTY} "${app}" yarn fixtures:load
 
-    cd ${FEDERATION_DIR}/docker/volumes/src/federation-admin/shared/cypress/support/ && ./db.sh ${db_container} create
+    (cd ${FEDERATION_DIR}/docker/volumes/src/federation-admin/shared/cypress/support/ && ./db.sh ${db_container} create)
   done
 }
 


### PR DESCRIPTION
<div align=center><img src="https://media.giphy.com/media/3o7btPCcdNniyf0ArS/giphy.gif" /></div>

---

\from @jonathanperret [comments](https://github.com/proconnect-gouv/federation/pull/168#discussion_r2183317916)
Bash scripts no longer change directories to prevent security issues and unexpected behavior.
