### PR TITLE
🔧 ci(labeler): add issues write permission to fix label creation

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -8,6 +8,7 @@ jobs:
     permissions:
       contents: read
       pull-requests: write
+      issues: write
     runs-on: ubuntu-latest
     steps:
       - uses: actions/labeler@8558fd74291d67161a8a78ce36a881fa63b766a9 # v5


### PR DESCRIPTION
Added `issues: write` permission to the labeler workflow to fix the "You do not have permission to create labels" error.