### PR TITLE
🔥 remove unused oidc provider conf

### DIFF
--- a/back/libs/oidc-provider/src/dto/oidc-provider-config.dto.ts
+++ b/back/libs/oidc-provider/src/dto/oidc-provider-config.dto.ts
@@ -58,11 +58,6 @@ export type FindAccountCallback = (
   sub: string,
   token?: any,
 ) => CanBePromise<any>;
-export type PairwiseIdentifierCallbacK = (
-  ctx: KoaContextWithOIDC,
-  accountId: string,
-  client: any,
-) => CanBePromise<string>;
 export type RenderErrorCallback = (
   ctx: KoaContextWithOIDC,
   out: ErrorOut,
@@ -760,24 +755,6 @@ export class Configuration {
    */
   @IsOptional()
   readonly findAccount?: FindAccountCallback;
-
-  /**
-   * pairwiseIdentifier is a function
-   * This is not something that should live in a DTO.
-   * Although this is the way `oidc-provider` library offers
-   * to implement our sub generator
-   *
-   * We do not actually generate our sub in this function, since we want to be able
-   * to control this mechanism at the application level (ie. in the apps/** folder).
-   * We just provide a passthru implementation that will override default implementation,
-   * and forward the sub provided in the identity (retrieved by `findAccount` (information about this function just above))
-   * @see https://github.com/panva/node-oidc-provider/blob/master/docs/README.md#pairwiseidentifier
-   *
-   * This property is optional because it is injected by the module
-   * rather than by real configuration.
-   */
-
-  readonly pairwiseIdentifier?: PairwiseIdentifierCallbacK;
 
   /**
    * `renderError` is a function.

--- a/back/libs/oidc-provider/src/services/oidc-provider-config.service.spec.ts
+++ b/back/libs/oidc-provider/src/services/oidc-provider-config.service.spec.ts
@@ -135,7 +135,6 @@ describe('OidcProviderConfigService', () => {
         'configuration.features.rpInitiatedLogout.postLogoutSuccessSource',
       );
       expect(result).toHaveProperty('configuration.findAccount');
-      expect(result).toHaveProperty('configuration.pairwiseIdentifier');
       expect(result).toHaveProperty('configuration.renderError');
       expect(result).toHaveProperty('configuration.clientBasedCORS');
       expect(result).toHaveProperty('configuration.interactions.url');
@@ -162,18 +161,6 @@ describe('OidcProviderConfigService', () => {
 
       // Then
       expect(result).toEqual('/prefix/interaction/123');
-    });
-  });
-
-  describe('pairwiseIdentifier()', () => {
-    it('should return second argument as is', () => {
-      // Given
-      const ctx = {};
-      const accountId = 'accountIdValue';
-      // When
-      const result = service['pairwiseIdentifier'](ctx, accountId);
-      // Then
-      expect(result).toBe(accountId);
     });
   });
 

--- a/back/libs/oidc-provider/src/services/oidc-provider-config.service.ts
+++ b/back/libs/oidc-provider/src/services/oidc-provider-config.service.ts
@@ -86,7 +86,6 @@ export class OidcProviderConfigService {
     const findAccount = this.oidcProviderConfigApp.findAccount.bind(
       this.oidcProviderConfigApp,
     );
-    const pairwiseIdentifier = this.pairwiseIdentifier.bind(this);
     const renderError = this.errorService.renderError.bind(this.errorService);
     const clientBasedCORS = this.clientBasedCORS.bind(this);
     const url = this.url.bind(this, prefix);
@@ -111,7 +110,6 @@ export class OidcProviderConfigService {
         },
         adapter,
         findAccount,
-        pairwiseIdentifier,
         renderError,
         clientBasedCORS,
         interactions: { url },
@@ -125,21 +123,6 @@ export class OidcProviderConfigService {
     };
 
     return oidcProviderConfig;
-  }
-
-  /**
-   * Pass through original identifier (sub).
-   *
-   * While we could imagine that `accountId` would carry the value set by the `findAccount` method above,
-   * it actually carries the sub.
-   *
-   * We kept the parameter name to be consistent with documentation and original function signature
-   * Note that the function receives a third parameter `client` but it is of no use for our implementation.
-   *
-   * @see https://github.com/panva/node-oidc-provider/blob/master/docs/README.md#pairwiseidentifier
-   */
-  private pairwiseIdentifier(_ctx, accountId: string) {
-    return accountId;
   }
 
   private clientBasedCORS(


### PR DESCRIPTION
pairwiseIdentifier is used when resolving pairwise ID Token and Userinfo sub claim values. We do not use pairwise ID in ProConnect but only public ones.