### PR TITLE
🔨 Add a dks command for cleaning node modules and dist

### DIFF
--- a/docker/bash/commands/node.sh
+++ b/docker/bash/commands/node.sh
@@ -142,3 +142,19 @@ _log_rotate() {
   $DOCKER_COMPOSE exec core-fcp-high pkill -SIGUSR2 -f '/usr/bin/node -r source-map-support/register --inspect=0.0.0.0:9235 /var/www/app/dist/instances/core-fcp-high/main'
   echo "... Signal done"
 }
+
+_clean() {
+  echo "Cleaning node_modules and dist directories"
+  cd ${FEDERATION_DIR}
+
+  rm -rf back/node_modules
+  rm -rf admin/node_modules
+  rm -rf admin/fc-exploitation/node_modules
+  rm -rf admin/shared/node_modules
+
+  rm -rf admin/fc-exploitation/dist
+  rm -rf admin/shared/dist
+  rm -rf back/dist
+
+  echo "Done cleaning"
+}

--- a/docker/docker-stack
+++ b/docker/docker-stack
@@ -59,6 +59,8 @@ _command_register "run-prod" "_run_prod" "" # Description to be defined
 
 ## General / utils
 _command_register "help" "_command_list" "Display this help: help <search term>"
+_command_register "clean" "_clean" "Remove node_modules, yarn cache and dist directories"
+
 _command_register "reload-rp" "_reload_rp" "Reload Reverse proxy"
 _command_register "compose" "_compose" "Run a docker compose command on project"
 _command_register "llng-configure" "_llng_configure" "Restore LemonLDAP configuration from ./docker/volumes/llng/llng-conf.json dump file"


### PR DESCRIPTION
This command helps clean the Node.js stack by removing node_modules folders and built JavaScript files. It is particularly helpful when working with the Admin which is composed of multiple apps:
- the parent admin app
- shared
- fc-exploitation

Each of these apps has its own node_modules folder.