### PR TITLE
🩹 Disable resource server tests on integration

### DIFF
--- a/quality/fca/cypress/integration/usager/fournisseur-données.feature
+++ b/quality/fca/cypress/integration/usager/fournisseur-données.feature
@@ -1,7 +1,6 @@
 #language: fr
+@ignoreInteg01
 Fonctionnalité: Fournisseur Données
-
-  @ignoreInteg01
   Scénario: Access token valide avec un scope groups
     Etant donné que je navigue sur la page fournisseur de service "éligible au scope groups"
     Et que le fournisseur de service requiert l'accès aux informations des scopes "obligatoires et groups"


### PR DESCRIPTION
Resource servers are now standard `oidc-provider` clients. On the integration environment, legacy data providers are provisioned differently than classic service providers, making migration to the new configuration complex and costly.

I propose disabling these tests on the integration environment, as they cover very little and introduce significant configuration overhead. We can restore full end-to-end coverage once the new infrastructure is in place.