### PR TITLE
🧱 Add a new stack for testing prod docker image

### DIFF
--- a/docker/compose/fca-low/.env/core-prod.env
+++ b/docker/compose/fca-low/.env/core-prod.env
@@ -1,0 +1,85 @@
+DEFAULT_MODE=dev
+PM2_SCRIPT=node dist/instances/app/main.js
+NESTJS_INSTANCE=core-fca-low
+PM2_CI_SCRIPT=yarn start:ci core-fca-low
+VIRTUAL_HOST=core-fca-low.docker.dev-franceconnect.fr
+REQUEST_TIMEOUT=6000
+# Session configuration
+SESSION_SECRET=fAh8Seik4_ahcH-3ahth/eiG@huéfuuva=opa
+SESSION_NAME=fc_session
+SESSION_TTL=600000 # 10 minutes
+
+# LoggerLegacy
+LoggerLegacy_FILE=/var/log/app/core-fca-low.log
+# OidcProvider
+FQDN=core-fca-low.docker.dev-franceconnect.fr
+OidcProvider_PREFIX=/api/v2
+App_PROTOCOL=https
+App_HTTPS_SERVER_CERT=/etc/ssl/docker_host/app.crt
+App_HTTPS_SERVER_KEY=/etc/ssl/docker_host/app.key
+App_ASSETS_PATHS=[""]
+App_VIEWS_PATHS=[""]
+App_DSFR_ASSETS_PATHS=[{"assetPath":"../../../node_modules/@gouvfr/dsfr/dist/dsfr","prefix":"/dsfr"},{"assetPath":"../../../node_modules/@gouvfr/dsfr/dist/fonts","prefix":"/fonts"},{"assetPath":"../../../node_modules/@gouvfr/dsfr/dist/icons","prefix":"/icons"}, {"assetPath":"../../../node_modules/@gouvfr/dsfr/dist/utility/icons","prefix":"/utility"}]
+App_ASSETS_CACHE_TTL=3600
+App_DEFAULT_IDP_UID=71144ab3-ee1a-4401-b7b3-79b44f7daeeb
+App_SP_AUTHORIZED_FQDNS_CONFIGS=[{"spId": "6495f347513b860e6b931fae4a1ba70c8489a558a0fc74ecdc094d48a4035e77", "spName":"FS4","spContact":"serviceclient@fsa4-low.fr","authorizedFqdns":["fia1.fr","fia2.fr"]}]
+App_DEFAULT_EMAIL_RENATER=test@renater.agentconnect.gouv.fr
+App_CSP_DEFAULT_SRC=["'self'", "*.crisp.chat", "*.crisp.help"]
+## unsafe-inline src allows inline CSS and JS
+## @TODO #168 remove this header once the UI is properly implemented to forbid the use of inline CSS or JS
+## @see https://gitlab.dev-franceconnect.fr/france-connect/fc/-/issues/168
+App_CSP_STYLE_SRC=["'self'", "'unsafe-inline'", "client.crisp.chat"]
+App_CSP_SCRIPT_SRC=["'self'", "stats.data.gouv.fr", "'unsafe-inline'", "client.crisp.chat"]
+App_CSP_CONNECT_SRC=["'self'", "stats.data.gouv.fr", "https://client.crisp.chat", "wss://client.relay.crisp.chat", "storage.crisp.chat"]
+App_CSP_FRAME_ANCESTORS=[]
+App_CSP_IMG_SRC=["'self'", "data:", "stats.data.gouv.fr", "client.crisp.chat", "image.crisp.chat", "storage.crisp.chat", "wss://client.relay.crisp.chat"]
+
+## Beware, the "kid" of "CRYPTO_SIG_ES256_PRIV_KEYS" and "CRYPTO_SIG_HSM_PUB_KEYS" must be the same !
+OidcProvider_CRYPTO_SIG_ES256_PRIV_KEYS=[{"alg": "ES256", "crv":"P-256","x":"uRxO96Oqn0BEJZYua3rkM9ntzLbt_nDbq4hwSgOUomQ","y":"o9BoK63TMCGmXjOcCZbtOTmw5HdGiy5ZzY4Qo5KG638","d":"sMJDu7_nEjB0SwTKuKR8XiZPHvoUkem3rdgxP39kkfQ","kty":"EC","kid":"pkcs11:ES256:hsm","use":"sig"}]
+OidcProvider_CRYPTO_SIG_RS256_PRIV_KEYS=[{"alg": "RS256", "kty": "RSA","n": "vmTVr5evEFVha25McCxJ8D_MV_52eA6j_0VUFE-bBUWjctqXK-Xf6W1lC2e_51RmL2owzl2w4Fw90cqeBzA1S2PJJdI_ptQcnwaCiXGRUMVqLXKxOsx1zqIj69F781_Ujp7bPYMkGNlsNmsY37roOzZLCFZLIJo6o90mrjT42nTkS-lgabyBMRZu783d_W1hs0CcjcOC4Hq2jEo_DVfy1RF5qj-Cr33LJ22Co6rkWb8zZnS9PFDZBJPz1tp53Gd2V6_BGbgETFMQI9-kss9HQCaH_1VXOFNr-zg7jw-XTHxvaQHEpCkhGrusirQB1o0tf2SheVhHXDUkG2q4aVgBqxurw4YONxBQvYY0xPK-OX1jQaWnaYPmB_v7_bt9wUrL4kYqGiVw5pXZZRIOPYloNhK_p7qLTTNjS4BKgveen_Vq32HZF8sLECQorAL7nSJABd0ReZEOBUyxWZ6KbIwnhykdADV2mBKyrFP0ZDKDQQprstb0V34hYaxuYDZx5obYo0rsPl1659u5KD-s5IAYEuTitdJNT3uWLHgGqLPsd17GHMggQhSuvFIyTH1-mMG3PWF19Oqq0zuZMLw29XDjSDyNRxWauoFzaCzGvWbV2cXsBOob4iik92PPWVJw5BAy6PlK3GxB0ZlSq_Wxp3p0I33BHFxbU8LmbWnAdB-iClk","e": "AQAB","d": "Indul5MGBhbuw9v7ynK6D9v8yhEusR01YwjR57thfNrWc_xOUYwTtNYw7JejjeUheoPmwfUECBmqt0fOw85eV3-A8m_VRgYwCDnNd8QvYkfaqM-Sdep9iSKhDhemMLCwcgEf_0q2RilWBaPtpNLZJ570hlXY09YXt4JZdj_wrNtsWLGu2nVdjd1Zx9-kyDP8885GiQNTtf-A_HSUZX3-X8QCGmfU6KAFHuYcODS_kd-jFnEbsMeSAdom0kZKuTOhoM4YTueZH5gJ2_SohBYx99MB258_Ytr3OUs8vPE9moMMSB4h0vX_IC_JVHKxwn1cNyuob6cjg_W6y5vONoPQCTF7p8_S6BpTzHfxHVIIebaGd2KBqWO_WirUFZNOFa85DoQmhEw-tpKp7Ra1ckZAeBTrV2r5YwIN4YdVqfjJiuKH151-GVrbMssQeNtvCzH-QuoV5nV92D6jSjGSVUndxCcHBbLMZHr-27JW9bSVJ3LmJGR0vU5-yGZH1ViqiLNsjxBwfxD4N5Ga5MRT2e8hlyyrat3SZ8ZZ-IkoW8c4RwnUr9onk3sXCZhQOq9XESWt7HF6iJODRiDYe-AZVc4AVLAF5DPRmFKf8f3J6Rhfnyrue2qBS00DyhFyZGNbw_UaMk5tz1WYpFfcXHanZdB7LP0NnzWjGIgS-qVRaDXxNeE","p": "8gp6yLQ07LqGllcDW2uDgkfYPUO9VCZRv2Zi4gSuJfXQHCcdE9qxMMhybzERUAItcDTY78AgrT8s02B8vWVyFX7bcHrycLFoqc_jCkrIRdY1UDjdZxc-5Js-FCNVG_189yjRuvCXl43JuO2chao2m8ae7efnLA8Ka4axtI98luqcWVL5hZSeeEz6jKOo0Hk2pfgIqJABaJGhkTifhCITrH63IkwYRg4ShVTBkBFQ7IwJG2viK809LnryPtH-WPTeeaYovbo86STZwWOLPBW7KsYqcT_tRebW42PQtqNG8hmAjgLLGUMZVT1Ymdflnf7vX8UjrmYj5vpjnhM9EM0C_w","q": "yV_VAdMEyb0UrUkv1E58sQxEGaaQ982RE11-YT-R6EXOjl6kR-XmTcBWkjzI4trvfQJXi8TUlahxxGiHYgYA56GRjR-CNBot_R_oTff7VWQDHwpQTyhd33cakpdHKgNqPiQ9zYKQom4bBwf8xENKIQQ1V9khtRGsl7q4rmx7lr4oJvLe9tCGSPVGvxs5NHbZLRSiQtQkoOBQ1S2QA68nD2o7CO0-oxJ-UDEzPoWcJJhtxRysE7aJtMPcQTWKApD3Tfs5aH8KtaWhoSlkLatqKOwPcjKpJAOKjUVCDedZbjx2j4ekJyY1aCV1eRz73XjiHcFcNnPuigXffx39wtjqpw","dp": "G9MUlmoRA33V5waNvj632YxE0ZYt97SIBUbR60W6d2awy-u7LgMgB4mjjiDH6ri1XIbWwYkGuKPglVQsQuGcodf5hg68PDRI4eyiHxbFuzGK43QGD8neUw19r3b4W8ViTk-E_MaXxrZoEDhQnBUbPgExWAwmySvZeM79MtKj8f16h9JAGRkitpWy3-QYjg7BN4cyB562ar0DI9ysidYZCOVwTCMPT05i1q0Nq3AyK19V1K8sSvjHJcbAfnRJlxRfVwDBAj6crfish8zXvsqIv7wUOPyuXDDTV0SsQ7K1fzNrUegETR0nlmL9AoKNRQJ_pjTVi0D2s6DpPszbYkkPJQ","dq": "gLiFTBk7Ikl_AhWaQTe6dOHGVi8m03_PkHVe54LfHX4hvte4Y00Nnf2oWOoJ7xjLpTjuBSXYTaHStx2qDHqR8X5Rr8fITs29P-Q5dj1hpv-7DwhktXS0LLfRgIq6rpxoOTipWMhw86M2G5R7emkY5WnvPyxIY5ncnVB55OTrSzxaJitxYouAivpeMqKQOn0N7ccWwWkh0MQSZ3IscG5xpWTeP6KHO24C1_fbLcfyO2JEKI9fX2p7M9VO4U_73BAWRP6lf6pVii9J1d7Dbn336hia9wBzJdYtpofy5ThQ7iowDydBQtUlpmDranOge71drG-BJj2M6SU_692b7AUEWQ","qi": "0-TUiGRoPBWatRlzSQIvwXs5zpGn20QfgmcGQD1LWnogWG-6QwfFsRWJ78FLEK69x35hBdcyzDNC5PzvBPXatr9_bL_Fv10qwMTkFwPOuDZHEzvb3-b_L3MD4JnQ6LbT8g36scv6aEgMNt9eeugRq0bR4xba1oj2pgjfVVKiENQWPlVYZ0HKYHAwdoss4d9x0dI1g-Gl426LreDz5RmDUgzdZ3nAfdnTrLUM69RTmAUjb_GfFWvmlBesFo-npv8qNToZRWmxEClXJZQCoxnzHx29bFe6WY5Jlt3zWCmI3o6LHQx6UiMrN-B_qE4T3plK0bS_w0x-Lbp9bhPbPE9AVA"}]
+OidcClient_CRYPTO_ENC_LOCALE_PRIV_KEYS=[{"e":"AQAB","n":"5OHMkVCg2xG2osiXbClpkW8YVxVeqPeQDrDZH1tiocf3S9kK1ErRP1oI1qwP3-MTZVp3O0NjO7eIkkqdogCl043vVty25KMk-lM-dAXfQFjSKBE5c2Y_mZbsvEyk885ZmEbb--S-lxZuBX1jWs574fOSsqKH5e5Mf_PjKgwZFOW0SFl6pGOp230Em5OfTbCN8AKMkw907b9DXoPocDcr3d3ZEa10f5OCI0aieTxvH5Jaq9ZMOQIj1-tTMpDecFYLO8REiQSsUp-4PLUbIBL2Iq-qwv6opkVetpiLR-wwz7e2Y_dDHCqnVHcCo_oWVFFRgKiL_dhmxFIpSkw4dc1ICQ","d":"vZepC6o9RJo8rkT44XjAYN8ky2YBPnerVe_6OrZJUnfBCowkI0xCXnbnIWPv1mZT973jTCz680mJkJzMTJi6xC4rVsmHmoblp5HzBsqibrvkgZoa-9Nz1XcmbKgUb3y7zJ7NtK97jM3gnx2JgnvONJG-L8jgR3-I0OimgHr6_8nh8Qv66at8fighlefmIp-2UVYPydKp2pi9drQAWFAYW5hgNCcmuMi8814O4hdm3zsJU6w8cwOLf2p_L3No9YonO2GcSO_ZRHqPqdj5lDwtBR2DbYAUpzOYj0FMPoG6MMM6ITK9DgHDtwVuoo6ZxI6aoAMCYZ8zehn9QuACtZZQPQ","p":"8l1JmRGOfMMxlqFaAB9sWFe29P4xIVl5Tez95Hf9qIIlcdNvrm6bep5889sMAfN3LB2NA09rwBdCPdjVT_80XgrxTsxPPOvzmxuHmHaozlkBAAgfNgIASgKaznSf8nbBkp-p6NRIc3JOCJDFopm6C43ZCexBu8or_CK554O8AMM","q":"8cJUELj52DDYoxcGsm6wIyk9QYCIRry3gxJwaHWQt4xTeX65_W27x0WVY4ZXNCIYYMxKQXN5Ud70OsdzExNHk9dn96w2cOT2tKlIixoSyDpbLsYKuQ4KlEz0S2GZJyiAT0C2N_1VlRy_OFAFmauj9SIMm3Wr3UhWa7fWRWThR0M","dp":"Rs_SzRJAG1u8hVInRZnowfb-0Z3jJOdLdeUkWThluHIuFo-8Na7DZpQf1e_OFlPYId-Qb8MorDsfc4qC6Jib6E4yKt-u1xHpXwwwFe-1anS-wg-dbt4uz3DrYh7ZDLJ95CUaM5iygmiHPCFwXQ2lOfL70tZgbkmniEdtIaNvrpk","dq":"vkXv2-l52kk3d8SbpLuxLTs71t3OY74LwME2b0B4Ub3DxQ-UWn2PGNsPJHGLGKDtBuJCXxj_Fwyes9ReIVk_MICMd0W240uRT8ccLT6sIaKsOTftIJCIiwe2Dc4Wt9cMhVOtFovwW5dweGWiwrtwI3JU8dW_Gj3gpo7duWgYVfk","qi":"Cpf7tVogmGoFr-WTWSkctb0KqNtNCY3tU__2b2GI0uW_a9TafQhU8fon4SNBPlicdAYlgO1q23tklyhGpLbw7qYgHkr-zt-v_Vfg5YP8cZYGEqW52Qjl2HeMlCCI0-38RG3wFYwXjGDZk9YW6VAWlc6i1MSLrd7NGRrwH1ZkD7U","kty":"RSA","alg": "RSA-OAEP","kid":"oidc-provider:locale","use":"enc"}]
+OidcProvider_COOKIES_KEYS=["iet7jaetheezaingahThooSiem3Oothu", "aeChoomaeyi5Jeo7Viezoh8aew8ieH3m", "JaeDahngohc3athooy1Eip2ahtei8Aep", "iu5vu5EeD4goow5eipeizequaetaxo0V"]
+OidcProvider_IS_LOCALHOST_ALLOWED=false
+OidcProvider_ERROR_URI_BASE=https://github.com/numerique-gouv/proconnect-documentation/blob/main/doc_fs/troubleshooting-fs.md
+# OidcClient
+OidcClient_SCOPE=openid uid given_name usual_name email siren siret organizational_unit belonging_population phone chorusdt
+OidcClient_HTTPS_CLIENT_CERT=/etc/ssl/docker_host/app.crt
+OidcClient_HTTPS_CLIENT_KEY=/etc/ssl/docker_host/app.key
+OidcClient_FAPI=false
+# Mongo
+FC_DB_TYPE=mongodb
+Mongoose_HOSTS=mongo-fca-low:27017
+Mongoose_DATABASE=core-fca-low
+Mongoose_USER=fc
+Mongoose_PASSWORD=pass
+Mongoose_TLS=true
+Mongoose_TLS_INSECURE=false
+Mongoose_TLS_ALLOW_INVALID_HOST_NAME=false
+Mongoose_TLS_CA_FILE=/etc/ssl/docker_host/docker-stack-ca.crt
+FC_DB_SYNCHRONIZE=false
+FC_DB_CONNECT_OPTIONS=?replicaSet=rs0
+# Crypto
+AdapterMongo_CLIENT_SECRET_CIPHER_PASS=JZBlwxfKnbn/RV025aw+dQxk+xoQT+Yr
+AdapterMongo_DECRYPT_CLIENT_SECRET_FEATURE=true
+AdapterMongo_DISABLE_IDP_VALIDATION_ON_LEGACY=false
+Session_USERINFO_CRYPT_KEY=raePh3i+a4eiwieb-H5iePh6o/gheequ
+## Redis
+Redis_DB=4
+Redis_HOST=redis-pwd
+Redis_PORT=6379
+Redis_PASSWORD=Ivae1feiThoogahquohDei7iwie0ceeM
+Redis_CACERT=/etc/ssl/docker_host/docker-stack-ca.crt
+Redis_ENABLE_TLS_FOR_SENTINEL_MODE=false
+# Arbitrary DB number, default is 0 and is used by legacy core.
+Session_COOKIE_SECRETS=["yahvaeJ0eiNua6te", "lidubozieKadee7w", "Eigoh6ev8xaiNoox", "veed7Oow7er5Saim"]
+# Mailer
+MAILER=logs
+MAILER_FROM_EMAIL=ne-pas-repondre@franceconnect.gouv.fr
+MAILER_FROM_NAME=NE PAS RÉPONDRE
+## Bluebird potential memory leak safe guard
+## @see https://gitlab.dev-franceconnect.fr/france-connect/fc/-/issues/131
+## @see http://bluebirdjs.com/docs/api/promise.config.html#promise.config
+BLUEBIRD_LONG_STACK_TRACES=0
+BLUEBIRD_DEBUG=0
+IDP_DEFAULT_RESPONSE_TYPES=["code"]
+IDP_DEFAULT_REVOCATION_ENDPOINT_AUTH_METHOD=client_secret_post

--- a/docker/compose/fca-low/core-prod.yml
+++ b/docker/compose/fca-low/core-prod.yml
@@ -1,0 +1,27 @@
+####################
+####################
+services:
+  core-prod:
+    hostname: core-prod
+    image: ghcr.io/proconnect-gouv/federation/core-fca-low:test-build-docker-2
+    working_dir: /var/www/app
+    depends_on:
+      mongo-fca-low:
+        condition: service_healthy
+      redis-pwd:
+        condition: service_healthy
+    volumes:
+      - '${VOLUMES_DIR}/app:/opt/scripts'
+      - '${VOLUMES_DIR}/log:/var/log/app'
+      - '${VOLUMES_DIR}/.home:/home'
+      - '${VOLUMES_DIR}/ssl:/etc/ssl/docker_host:ro'
+    env_file:
+      - '${COMPOSE_DIR}/shared/.env/base-app.env'
+      - '${COMPOSE_DIR}/fca-low/.env/core-prod.env'
+    tty: true
+    networks:
+      - fc
+      - public
+      - data
+    init: true
+    command: 'pm2 logs'

--- a/docker/compose/fca-low/stack.yml
+++ b/docker/compose/fca-low/stack.yml
@@ -7,6 +7,7 @@ include:
   - exploitation-fca-low.yml
   - hybridge.yml
   - core-rie.yml
+  - core-prod.yml
 
 services:
   small:
@@ -70,3 +71,10 @@ services:
       - 'csmr-rie'
       - 'fia-rie-low'
       - 'rp-bridge-proxy'
+
+  prod:
+    image: alpine
+    depends_on:
+      - 'core-prod'
+      - 'fsa1-low'
+      - 'fia1-low'


### PR DESCRIPTION
For now, this is still an initial proof of concept (POC) that allows launching a minimal development stack using the same Docker package as in production.
The version is currently hardcoded, and only the core uses a GitHub package.

After launching the stack with the `dks switch prod command`, the application still needs to be started manually.

To start the app:

`dks compose exec core-prod pm2-runtime /etc/pm2/app.json`