### PR TITLE
Experimental upgrade openid-client

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -53,9 +53,7 @@
       "protocol": "inspector",
       "localRoot": "${workspaceFolder}/back",
       "remoteRoot": "/var/www/app",
-      "outFiles": ["${workspaceFolder}/back/dist/apps/core-fca/**/*.js"],
       "skipFiles": [
-        "${workspaceFolder}/back/node_modules/**/*.js",
         "<node_internals>/**/*.js"
       ],
       "cwd": "${workspaceFolder}/back",

--- a/back/apps/core-fca/src/services/core-fca-middleware.service.ts
+++ b/back/apps/core-fca/src/services/core-fca-middleware.service.ts
@@ -1,6 +1,5 @@
 import { plainToInstance } from 'class-transformer';
 import { validate } from 'class-validator';
-import { AuthorizationParameters } from 'openid-client';
 
 import { Injectable } from '@nestjs/common';
 
@@ -87,7 +86,7 @@ export class CoreFcaMiddlewareService {
   protected getAuthorizationParameters({
     method,
     req,
-  }: OidcCtx): AuthorizationParameters {
+  }: OidcCtx): Record<string, any> {
     const isPostMethod = method === 'POST';
     return isPostMethod ? req.body : req.query;
   }

--- a/back/apps/core-fca/src/services/core-fca.service.ts
+++ b/back/apps/core-fca/src/services/core-fca.service.ts
@@ -1,6 +1,5 @@
 import { Request, Response } from 'express';
 import { isEmpty } from 'lodash';
-import { AuthorizationParameters } from 'openid-client';
 
 import { Injectable } from '@nestjs/common';
 
@@ -59,7 +58,7 @@ export class CoreFcaService {
     const { nonce, state } =
       await this.oidcClient.utils.buildAuthorizeParameters();
 
-    const authorizeParams: AuthorizationParameters = {
+    const authorizeParams: Record<string, any> = {
       state,
       nonce,
       scope,
@@ -94,6 +93,7 @@ export class CoreFcaService {
       authorizeParams['acr_values'] = 'eidas1';
     }
 
+    authorizeParams['claims'] = JSON.stringify(authorizeParams['claims']);
     const authorizationUrl = await this.oidcClient.utils.getAuthorizeUrl(
       idpId,
       authorizeParams,
@@ -113,7 +113,7 @@ export class CoreFcaService {
 
     this.session.set('User', sessionPayload);
 
-    res.redirect(authorizationUrl);
+    res.redirect(authorizationUrl.toString());
   }
 
   /**

--- a/back/libs/oidc-client/src/services/oidc-client-utils.service.spec.ts
+++ b/back/libs/oidc-client/src/services/oidc-client-utils.service.spec.ts
@@ -5,7 +5,7 @@
  */
 import { isURL } from 'class-validator';
 import { JWK } from 'jose-v2';
-import { CallbackParamsType, errors } from 'openid-client';
+import { ClientError } from 'openid-client-v6';
 
 import { Test, TestingModule } from '@nestjs/testing';
 
@@ -332,7 +332,7 @@ describe('OidcClientUtilsService', () => {
       state: 'callbackParamsState',
       nonce: 'callbackParamsNonce',
     };
-    const callbackParams: CallbackParamsType = {
+    const callbackParams: Record<string, string> = {
       state: 'callbackParamsState',
       code: 'callbackParamsCode',
     };
@@ -386,19 +386,7 @@ describe('OidcClientUtilsService', () => {
 
     it('should throw FcException if oidc-client throws OPError', async () => {
       // Given
-      const exception = new errors.OPError({ error: 'invalid_scope' });
-      callbackMock.mockRejectedValueOnce(exception);
-      // Then
-      await expect(
-        service.getTokenSet(req, providerId, params),
-      ).rejects.toThrow(FcException);
-    });
-
-    it('should throw FcException if oidc-client throws RPError', async () => {
-      // Given
-      const exception = new errors.RPError({
-        message: 'state missing from the response',
-      });
+      const exception = new ClientError('invalid_scope');
       callbackMock.mockRejectedValueOnce(exception);
       // Then
       await expect(
@@ -411,7 +399,7 @@ describe('OidcClientUtilsService', () => {
     const params = {
       state: Symbol('state'),
       code: Symbol('code'),
-    } as unknown as CallbackParamsType;
+    } as unknown as Record<string, string>;
     const state = params.state;
 
     it('should throw if state is not provided in url', () => {

--- a/back/libs/oidc-client/src/services/oidc-client.service.spec.ts
+++ b/back/libs/oidc-client/src/services/oidc-client.service.spec.ts
@@ -1,5 +1,8 @@
 import { ValidationError } from 'class-validator';
-import { TokenSet } from 'openid-client';
+import {
+  TokenEndpointResponse,
+  TokenEndpointResponseHelpers
+} from 'openid-client-v6';
 
 import { LoggerService } from '@fc/logger';
 
@@ -44,7 +47,7 @@ describe('OidcClientService', () => {
         claims: jest.fn().mockReturnValue({
           acr: 'acrMock',
         }),
-      } as unknown as TokenSet;
+      } as unknown as TokenEndpointResponse & TokenEndpointResponseHelpers;
       utilsMock.getTokenSet.mockResolvedValueOnce(tokenSetMock);
 
       const result = await service.getToken(
@@ -70,7 +73,7 @@ describe('OidcClientService', () => {
           acr: 'acrMock',
           amr: 'amrMock', // amr should be an array, this should trigger a validation error
         }),
-      } as unknown as TokenSet);
+      } as unknown as TokenEndpointResponse & TokenEndpointResponseHelpers);
 
       await expect(
         service.getToken(

--- a/back/libs/oidc-client/src/services/oidc-client.service.ts
+++ b/back/libs/oidc-client/src/services/oidc-client.service.ts
@@ -1,6 +1,6 @@
 import { plainToInstance } from 'class-transformer';
 import { validate } from 'class-validator';
-import { IdTokenClaims, TokenSet } from 'openid-client';
+import { TokenEndpointResponse, TokenEndpointResponseHelpers } from 'openid-client-v6';
 
 import { Injectable } from '@nestjs/common';
 
@@ -40,7 +40,7 @@ export class OidcClientService {
      * - voir commit original : 440d0a1734e0e1206b7e21781cbb0f186a93dd82
      */
     // OIDC: call idp's /token endpoint
-    const tokenSet: TokenSet = await this.utils.getTokenSet(
+    const tokenSet: (TokenEndpointResponseHelpers & TokenEndpointResponse) = await this.utils.getTokenSet(
       req,
       idpId,
       params,
@@ -52,7 +52,7 @@ export class OidcClientService {
       id_token: idToken,
       refresh_token: refreshToken,
     } = tokenSet;
-    const { acr, amr = [] }: IdTokenClaims = tokenSet.claims();
+    const { acr, amr = [] }: Record<string,any> = tokenSet.claims();
 
     const tokenResult = plainToInstance(TokenResultDto, {
       acr,
@@ -87,7 +87,7 @@ export class OidcClientService {
   async getEndSessionUrl(
     ipdId: string,
     stateFromSession: string,
-    idTokenHint?: TokenSet | string,
+    idTokenHint?: string,
     postLogoutRedirectUri?: string,
   ) {
     return await this.utils.getEndSessionUrl(

--- a/back/libs/oidc-provider/src/oidc-provider.service.ts
+++ b/back/libs/oidc-provider/src/oidc-provider.service.ts
@@ -4,7 +4,6 @@ import {
   KoaContextWithOIDC,
   Provider,
 } from 'oidc-provider';
-import { HttpOptions } from 'openid-client';
 
 import { Global, Injectable } from '@nestjs/common';
 import { HttpAdapterHost } from '@nestjs/core';
@@ -102,7 +101,7 @@ export class OidcProviderService {
    *
    * @param {HttpOptions} options
    */
-  private getHttpOptions(options: HttpOptions): HttpOptions {
+  private getHttpOptions(options: Record<string, any>): Record<string, any> {
     options.timeout = this.configuration.timeout;
     return options;
   }

--- a/back/libs/oidc/src/dto/client-metadata.dto.ts
+++ b/back/libs/oidc/src/dto/client-metadata.dto.ts
@@ -1,7 +1,16 @@
 import { IsArray, IsBoolean, IsIn, IsNumber, IsString } from 'class-validator';
-import { ClientAuthMethod, ResponseType } from 'openid-client';
 
 import { SUPPORTED_SIG_ALG } from '@fc/cryptography';
+
+export type ResponseType = 'code' | 'id_token' | 'code id_token' | 'none' | string;
+export type ClientAuthMethod =
+  | 'client_secret_basic'
+  | 'client_secret_post'
+  | 'client_secret_jwt'
+  | 'private_key_jwt'
+  | 'tls_client_auth'
+  | 'self_signed_tls_client_auth'
+  | 'none';
 
 export class ClientMetadata {
   @IsString()

--- a/back/package.json
+++ b/back/package.json
@@ -15,7 +15,7 @@
     "build:partners": "nest build partners-instance",
     "format": "prettier --write \"apps/**/*.ts\" \"libs/**/*.ts\" \"instances/**/*.ts\"",
     "start": "nest start",
-    "start:dev": "NODE_ENV=development nest start --watch --watchAssets",
+    "start:dev": "NODE_ENV=development nest start --watch --watchAssets --debug 0.0.0.0:9229",
     "start:ci": "NODE_ENV=development nest start",
     "start:prod:core-fca-low": "node dist/instances/core-fca-low/main.js > /tmp/.pm2/logs/fca-out-0.log 2> /tmp/.pm2/logs/fca-error-0.log",
     "start:prod:csmr-rie": "node dist/instances/csmr-rie/main.js > /tmp/.pm2/logs/csmr-rie-out-0.log 2> /tmp/.pm2/csmr-rie-error-0.log",

--- a/docker/compose/fca-low/core.yml
+++ b/docker/compose/fca-low/core.yml
@@ -15,6 +15,8 @@ services:
         condition: service_healthy
       redis-pwd:
         condition: service_healthy
+    ports:
+      - 9229:9229
     volumes:
       - '${FEDERATION_DIR}/back:/var/www/app'
       - '/var/www/app/node_modules'


### PR DESCRIPTION
This PR is definitely not mergeable as-is, I'm pushing only to share the curent state of my exploration of what it takes to migrate from openid-client v5 to v6 in Core (we are already using v6 in the mocks). It's promising but there is more work ahead.

In particular the unit tests are not updated to match the implementation changes. (There is a roadblock to doing this, namely Jest's support for the particular "flavor" of ESM modules seen v6 of openid-client.) Not all of the endpoints are migrated either, so the E2E tests are probably failing too.