### PR TITLE
🚑 Build admin container with correct path

### DIFF
--- a/admin/deploy/pm2/app.json
+++ b/admin/deploy/pm2/app.json
@@ -1,6 +1,6 @@
 {
   "name": "exploitation",
-  "script": "./dist/src/main.js",
+  "script": "./dist/main.js",
   "error_file": "/data/log/fc-apps/federation-admin-err.log",
   "out_file": "/data/log/fc-apps/federation-admin-out.log",
   "watch": false,


### PR DESCRIPTION
The admin container no longer starts in production.

```
2025-08-21T11:17:29: PM2 log: Launching in no daemon mode
2025-08-21T11:17:29: PM2 error: Error: Script not found: /var/www/app/dist/src/main.js
```
