### PR TITLE
Make services depend on rp-all

### DIFF
--- a/docker/bash/commands/up.sh
+++ b/docker/bash/commands/up.sh
@@ -19,7 +19,7 @@ _up() {
   echo " * Get required services"
   # get asked services
   local apps=${@:-none}
-  local services=rp-all
+  local services=""
 
   for app in $apps; do
     services="$services $app"

--- a/docker/bash/commands/up.sh
+++ b/docker/bash/commands/up.sh
@@ -16,30 +16,18 @@ function _hook_admin() {
 }
 
 _up() {
-  echo " * Get required services"
   # get asked services
-  local apps=${@:-none}
-  local services=""
-
-  for app in $apps; do
-    services="$services $app"
-  done
-  echo " * Required services are: ${services}"
+  local services=${@}
 
   # docker compose up services
   echo " * Docker compose up services: ${services}"
   cd ${WORKING_DIR}
   $DOCKER_COMPOSE up --build -d $services
 
-  # Find which nodejs containers are running and store it into $NODEJS_CONTAINERS
-  echo " * Populate global variables"
-  local raw_all_containers=$(docker ps --format '{{.Names}}')
-  
-  # Find all containers and store it into $PC_CONTAINERS
-  PC_CONTAINERS=$(_container_to_compose_name "${raw_all_containers}")
-
-  echo " * Automatically run init scripts for started containers"
-  for app in ${PC_CONTAINERS}; do
+  # Find which containers are running and run their hooks
+  echo " * Running hooks for started containers"
+  local started_services=$($DOCKER_COMPOSE ps --format '{{.Service}}')
+  for app in ${started_services}; do
     # Container initialization hooks
     #
     # This runs arbitrary code if a container is started

--- a/docker/compose/fca-low/core-rie.yml
+++ b/docker/compose/fca-low/core-rie.yml
@@ -9,6 +9,8 @@ services:
     user: ${CURRENT_UID}
     working_dir: /var/www/app
     depends_on:
+      rp-all:
+        condition: service_started
       mongo-fca-low:
         condition: service_healthy
       redis-pwd:

--- a/docker/compose/fca-low/core.yml
+++ b/docker/compose/fca-low/core.yml
@@ -9,6 +9,8 @@ services:
     user: ${CURRENT_UID}
     working_dir: /var/www/app
     depends_on:
+      rp-all:
+        condition: service_started
       mongo-fca-low:
         condition: service_healthy
       redis-pwd:
@@ -35,6 +37,8 @@ services:
     extends: core-fca-low
     hostname: core-fca-low-squid
     depends_on:
+      rp-all:
+        condition: service_started
       mongo-fca-low:
         condition: service_healthy
       redis-pwd:

--- a/docker/compose/fca-low/exploitation-fca-low.yml
+++ b/docker/compose/fca-low/exploitation-fca-low.yml
@@ -9,6 +9,8 @@ services:
     user: ${CURRENT_UID}
     working_dir: /var/www/app
     depends_on:
+      rp-all:
+        condition: service_started
       pg-exploitation-fca-low:
         condition: service_started
       mongo-fca-low:

--- a/docker/compose/fca-low/hybridge.yml
+++ b/docker/compose/fca-low/hybridge.yml
@@ -27,6 +27,9 @@ services:
         INSTANCE: bridge-http-proxy-rie
     user: ${CURRENT_UID}
     working_dir: /var/www/app
+    depends_on:
+      rp-all:
+        condition: service_started
     volumes:
       - '${FEDERATION_DIR}/back:/var/www/app'
       - '/var/www/app/node_modules'
@@ -98,6 +101,8 @@ services:
     user: ${CURRENT_UID}
     working_dir: /var/www/app
     depends_on:
+      rp-all:
+        condition: service_started
       redis-pwd:
         condition: service_healthy
     volumes:

--- a/docker/compose/fca-low/mocks.yml
+++ b/docker/compose/fca-low/mocks.yml
@@ -13,6 +13,8 @@ services:
     user: ${CURRENT_UID}
     working_dir: /var/www/app
     depends_on:
+      rp-all:
+        condition: service_started
       redis-pwd:
         condition: service_healthy
     volumes:
@@ -42,6 +44,8 @@ services:
     user: ${CURRENT_UID}
     working_dir: /var/www/app
     depends_on:
+      rp-all:
+        condition: service_started
       redis-pwd:
         condition: service_healthy
     volumes:
@@ -71,6 +75,8 @@ services:
     user: ${CURRENT_UID}
     working_dir: /var/www/app
     depends_on:
+      rp-all:
+        condition: service_started
       redis-pwd:
         condition: service_healthy
     volumes:
@@ -99,6 +105,8 @@ services:
         INSTANCE: mock-service-provider-fca-low
     working_dir: /var/www/app
     depends_on:
+      rp-all:
+        condition: service_started
       redis-pwd:
         condition: service_healthy
     volumes:
@@ -132,6 +140,8 @@ services:
     user: ${CURRENT_UID}
     working_dir: /var/www/app
     depends_on:
+      rp-all:
+        condition: service_started
       redis-pwd:
         condition: service_healthy
     volumes:
@@ -162,6 +172,8 @@ services:
     user: ${CURRENT_UID}
     working_dir: /var/www/app
     depends_on:
+      rp-all:
+        condition: service_started
       redis-pwd:
         condition: service_healthy
     volumes:
@@ -192,6 +204,8 @@ services:
     user: ${CURRENT_UID}
     working_dir: /var/www/app
     depends_on:
+      rp-all:
+        condition: service_started
       redis-pwd:
         condition: service_healthy
     volumes:


### PR DESCRIPTION
This should avoid the need for explicit startup of rp-all in docker-stack.