### PR TITLE
🔒️(totp) use RFC-compliant OTP window and simplify testing

### DIFF
--- a/admin/cypress.config.js
+++ b/admin/cypress.config.js
@@ -28,7 +28,6 @@ module.exports = defineConfig({
     APP_NAME: 'exploitation-fca-low',
     FEDERATION_DIR: `${process.env.PC_ROOT}/federation`,
     LOG_FILE_PATH: `${process.env.PC_ROOT}/federation/docker/volumes/log/fcexploitation.log`,
-    TOTP_WINDOW: 'loose',
   },
   pageLoadTimeout: 30000,
   viewportHeight: 1800,

--- a/admin/cypress/plugins/otp-plugin.js
+++ b/admin/cypress/plugins/otp-plugin.js
@@ -1,25 +1,8 @@
 const { authenticator } = require('otplib');
 
-const MIN_REMAINING_TIME = 5;
-
-async function generateTotp(key) {
-  return new Promise((resolve) => {
-    const ttl = authenticator.timeRemaining();
-    // If TOTP expires in less than 5 seconds
-    // we'll wait for the next timeframe
-    // in order to be sure to have a valid TOTP
-    // at the time the form is submited
-    const wait = ttl < MIN_REMAINING_TIME ? ttl + 1 : 0;
-
-    setTimeout(() => {
-      resolve(authenticator.generate(key));
-    }, wait * 1000);
-  });
-}
-
 function getTotp(args) {
   const { secret } = args;
-  return generateTotp(secret);
+  return authenticator.generate(secret);
 }
 
 module.exports = { getTotp };

--- a/admin/src/config/totp.ts
+++ b/admin/src/config/totp.ts
@@ -1,4 +1,4 @@
 export default {
   algorithm: process.env.TOTP_ALGO || 'sha1',
-  window: process.env.TOTP_WINDOW === 'loose' ? 1 : 0,
+  window: 1,
 };

--- a/quality/fca/cypress/plugins/otp-plugin.ts
+++ b/quality/fca/cypress/plugins/otp-plugin.ts
@@ -1,27 +1,11 @@
 import * as otplib from 'otplib';
-
-const MIN_REMAINING_TIME = 5;
-
-async function generateTotp(key): Promise<string> {
-  return new Promise((resolve) => {
-    const ttl = otplib.authenticator.timeRemaining();
-    // If TOTP expires in less than 5 seconds
-    // we'll wait for the next timeframe
-    // in order to be sure to have a valid TOTP
-    // at the time the form is submited
-    const wait = ttl < MIN_REMAINING_TIME ? ttl + 1 : 0;
-
-    setTimeout(() => {
-      resolve(otplib.authenticator.generate(key));
-    }, wait * 1000);
-  });
-}
-
 interface TotpArgs {
   totpSecret: string;
 }
 
 export function getTotp(args: TotpArgs): Promise<string> {
   const { totpSecret } = args;
-  return generateTotp(totpSecret);
+  return new Promise((resolve) =>
+    resolve(otplib.authenticator.generate(totpSecret)),
+  );
 }


### PR DESCRIPTION
Relevant RFC: https://datatracker.ietf.org/doc/html/rfc6238#section-5.2

The TOTP RFC recommends using 'an acceptable OTP transmission delay window' of at most one. Zero is too tight for practical purposes and leads to wasted time waiting for the next TOTP token to appear when using an authenticator app.

In addition, we have two mitigations for this problem in Cypress: originally the environment variable TOTP_WINDOW was set to "loose" to allow this one-step delay. However, this could not possibly have worked, since this variable is only ever seen by the Cypress testing environment, which *generates* OTP codes, and could not have any effect on the admin application which *accepts* OTP codes - and the 'window' config only affects acceptance.

Because this was ineffective a second mitigation was added to the tests with a 5-second wait when the OTP code had less than 5 seconds' validity (increased from an initial value of 2). This seems to have worked but increases CI duration, which is not ideal.

Therefore, without compromising security, in this PR we set the delay window to one time step (30 seconds) in the admin application, and remove both mitigations from the tests.