### PR TITLE
🐛(bootstrap) fix visual regressions by completing Bootstrap migration

### DIFF
--- a/admin/cypress/integration/identity-provider/identity-provider-create.spec.js
+++ b/admin/cypress/integration/identity-provider/identity-provider-create.spec.js
@@ -66,7 +66,7 @@ describe('Identity provider creation', () => {
       cy.contains(
         `Le fournisseur d'identité MonSuperFI a été créé avec succès !`,
       ).should('exist');
-      cy.get('.alert-success > .close').click();
+      cy.closeBanner('.alert-success');
 
       cy.hasBusinessLog({
         entity: 'identity-provider',
@@ -98,7 +98,7 @@ describe('Identity provider creation', () => {
       cy.contains(
         `Le fournisseur d'identité MonSuperFI-2 a été créé avec succès !`,
       ).should('exist');
-      cy.get('.alert-success > .close').click();
+      cy.closeBanner('.alert-success');
     });
 
     it('if there is a valid supportEmail', () => {
@@ -124,7 +124,7 @@ describe('Identity provider creation', () => {
       cy.contains(
         `Le fournisseur d'identité MonSuperFI-2 a été créé avec succès !`,
       ).should('exist');
-      cy.get('.alert-success > .close').click();
+      cy.closeBanner('.alert-success');
     });
 
     it('if title contains authorized special chars', () => {
@@ -151,7 +151,7 @@ describe('Identity provider creation', () => {
       cy.contains(
         `Le fournisseur d'identité MonSuperFI-3 a été créé avec succès !`,
       ).should('exist');
-      cy.get('.alert-success > .close').click();
+      cy.closeBanner('.alert-success');
     });
 
     it('if all fields are provided with algo fields ', () => {
@@ -192,7 +192,7 @@ describe('Identity provider creation', () => {
       cy.contains(
         `Le fournisseur d'identité MonFIWithAlgoFields a été créé avec succès !`,
       ).should('exist');
-      cy.get('.alert-success > .close').click();
+      cy.closeBanner('.alert-success');
     });
 
     it('if discovery is set to true', () => {
@@ -216,7 +216,7 @@ describe('Identity provider creation', () => {
       cy.contains(
         `Le fournisseur d'identité MonSuperFI-Discovery-True a été créé avec succès !`,
       ).should('exist');
-      cy.get('.alert-success > .close').click();
+      cy.closeBanner('.alert-success');
     });
   });
 

--- a/admin/cypress/integration/identity-provider/identity-provider-delete.spec.js
+++ b/admin/cypress/integration/identity-provider/identity-provider-delete.spec.js
@@ -79,7 +79,7 @@ describe('Delete identity provider normal', () => {
     cy.contains(
       `Le fournisseur d'identité ${fi.name} a été supprimé avec succès !`,
     ).should('exist');
-    cy.get('.alert-success > .close').click();
+    cy.closeBanner('.alert-success');
     cy.get('#list-table').should('not.contain', `${fi.name}`);
     cy.hasBusinessLog({
       entity: 'identity-provider',
@@ -136,7 +136,7 @@ describe('Delete identity provider non latin', () => {
     cy.contains(
       `Le fournisseur d'identité ${fiNonLatinChar.name} a été supprimé avec succès !`,
     ).should('exist');
-    cy.get('.alert-success > .close').click();
+    cy.closeBanner('.alert-success');
     cy.get('#list-table').should('not.contain', `${fiNonLatinChar.name}`);
   });
 });

--- a/admin/cypress/integration/identity-provider/identity-provider-update.spec.js
+++ b/admin/cypress/integration/identity-provider/identity-provider-update.spec.js
@@ -60,7 +60,7 @@ describe('Identity provider update', () => {
       cy.contains(
         `Le fournisseur d'identité ${fiToUpdateName} a été créé avec succès !`,
       ).should('exist');
-      cy.get('.alert-success > .close').click();
+      cy.closeBanner('.alert-success');
     });
   });
 
@@ -99,7 +99,7 @@ describe('Identity provider update', () => {
       cy.get('#fi-subtitle')
         .contains(`Modifier le fournisseur d'identité: ${idp.title}`)
         .should('exist');
-      cy.get('.alert-success > .close').click();
+      cy.closeBanner('.alert-success');
 
       cy.hasBusinessLog({
         entity: 'identity-provider',
@@ -145,7 +145,7 @@ describe('Identity provider update', () => {
       cy.get('#fi-subtitle')
         .contains(`Modifier le fournisseur d'identité: ${idp.title}`)
         .should('exist');
-      cy.get('.alert-success > .close').click();
+      cy.closeBanner('.alert-success');
 
       assertFormValues(idp);
     });
@@ -180,7 +180,7 @@ describe('Identity provider update', () => {
       cy.contains(`Modifier le fournisseur d'identité: ${idp.title}`).should(
         'exist',
       );
-      cy.get('.alert-success > .close').click();
+      cy.closeBanner('.alert-success');
 
       assertFormValues(idp);
     });
@@ -216,7 +216,7 @@ describe('Identity provider update', () => {
       cy.contains(`Modifier le fournisseur d'identité: ${idp.title}`).should(
         'exist',
       );
-      cy.get('.alert-success > .close').click();
+      cy.closeBanner('.alert-success');
 
       assertFormValues(idp);
     });
@@ -262,7 +262,7 @@ describe('Identity provider update', () => {
       cy.get('#fi-subtitle')
         .contains(`Modifier le fournisseur d'identité: ${idp.title}`)
         .should('exist');
-      cy.get('.alert-success > .close').click();
+      cy.closeBanner('.alert-success');
 
       assertFormValues(idp);
     });
@@ -301,7 +301,7 @@ describe('Identity provider update', () => {
       cy.contains(`Modifier le fournisseur d'identité: ${idp.title}`).should(
         'exist',
       );
-      cy.get('.alert-success > .close').click();
+      cy.closeBanner('.alert-success');
 
       assertFormValues(idp);
     });

--- a/admin/cypress/integration/scopes/scopes-delete.spec.js
+++ b/admin/cypress/integration/scopes/scopes-delete.spec.js
@@ -41,7 +41,7 @@ describe('Delete a scope label', () => {
     cy.contains(
       `Le label ${scopeLabelsInfo.label} pour le scope ${scopeLabelsInfo.scope} a été créé avec succès !`,
     );
-    cy.get('.alert-success > .close').click();
+    cy.closeBanner('.alert-success');
 
     cy.contains(scopeLabelsInfo.scope).scrollIntoView().should('be.visible');
     cy.contains(scopeLabelsInfo.scope)
@@ -72,7 +72,7 @@ describe('Delete a scope label', () => {
       cy.contains(
         `Le label ${scopeLabelsInfo.label} pour le scope ${scopeLabelsInfo.scope} a été créé avec succès !`,
       );
-      cy.get('.alert-success > .close').click();
+      cy.closeBanner('.alert-success');
 
       deleteScopeLabel(scopeLabelsInfo.scope, configuration);
       cy.get('button[class="btn btn-success btn-yes"]').click();
@@ -103,7 +103,7 @@ describe('Delete a scope label', () => {
       cy.contains(
         `Le label ${scopeLabelsInfo.label} pour le scope ${scopeLabelsInfo.scope} a été créé avec succès !`,
       );
-      cy.get('.alert-success > .close').click();
+      cy.closeBanner('.alert-success');
 
       deleteScopeLabel(scopeLabelsInfo.scope, configuration);
       cy.wait(800);
@@ -141,7 +141,7 @@ describe('Delete a scope label', () => {
       cy.contains(
         `Le label ${scopeLabelsInfo.label} pour le scope ${scopeLabelsInfo.scope} a été créé avec succès !`,
       );
-      cy.get('.alert-success > .close').click();
+      cy.closeBanner('.alert-success');
 
       deleteScopeLabel(scopeLabelsInfo.scope, {
         ...configuration,

--- a/admin/cypress/integration/scopes/scopes-update.spec.js
+++ b/admin/cypress/integration/scopes/scopes-update.spec.js
@@ -42,7 +42,7 @@ describe('Update a scope label', () => {
       cy.contains(
         `Le label ${scopeLabelsInfo.label} pour le scope ${scopeLabelsInfo.scope} a été créé avec succès !`,
       ).scrollIntoView();
-      cy.get('.alert-success > .close').click();
+      cy.closeBanner('.alert-success');
 
       updateScopeLabel(
         scopeLabelsInfo.scope,
@@ -81,7 +81,7 @@ describe('Update a scope label', () => {
 
       createScopeLabels(scopeLabelsInfo, configuration);
       cy.get('button[type="submit"]').click();
-      cy.get('.alert-success > .close').click();
+      cy.closeBanner('.alert-success');
 
       updateScopeLabel(scopeLabelsInfo.scope, scopeLabelsUpdatedInfo, {
         ...configuration,

--- a/admin/cypress/integration/service-provider/service-provider-create.spec.js
+++ b/admin/cypress/integration/service-provider/service-provider-create.spec.js
@@ -58,7 +58,7 @@ describe('Service provider creation', () => {
       cy.contains(
         `Le fournisseur de service MyFirstSP a été créé avec succès !`,
       );
-      cy.get('.alert-success > .close').click();
+      cy.closeBanner('.alert-success');
 
       cy.hasBusinessLog({
         entity: 'service-provider',
@@ -83,7 +83,7 @@ describe('Service provider creation', () => {
       cy.contains(
         `Le fournisseur de service MyFirstSP localhost a été créé avec succès !`,
       );
-      cy.get('.alert-success > .close').click();
+      cy.closeBanner('.alert-success');
     });
 
     it('if we add a service provider even with localhost as redirectUriLogout ( integration ) ', () => {
@@ -102,7 +102,7 @@ describe('Service provider creation', () => {
       cy.contains(
         `Le fournisseur de service MyFirstSP localhost logout a été créé avec succès !`,
       );
-      cy.get('.alert-success > .close').click();
+      cy.closeBanner('.alert-success');
     });
 
     it('if we add a service provider with two logout redirections', () => {
@@ -121,7 +121,7 @@ describe('Service provider creation', () => {
       cy.contains(
         `Le fournisseur de service 2 logout uris a été créé avec succès !`,
       );
-      cy.get('.alert-success > .close').click();
+      cy.closeBanner('.alert-success');
     });
 
     it('if we add a service provider with two redirect uris', () => {
@@ -140,7 +140,7 @@ describe('Service provider creation', () => {
       cy.contains(
         `Le fournisseur de service 2 redirect uris a été créé avec succès !`,
       );
-      cy.get('.alert-success > .close').click();
+      cy.closeBanner('.alert-success');
     });
 
     it('if we add a service provider even with a mobile URI scheme as redirectUri ( integration ) ', () => {
@@ -160,7 +160,7 @@ describe('Service provider creation', () => {
       cy.contains(
         `Le fournisseur de service MyFirstSP mobile URI scheme a été créé avec succès !`,
       );
-      cy.get('.alert-success > .close').click();
+      cy.closeBanner('.alert-success');
     });
 
     it('if we add a service provider even with a mobile URI scheme as redirectUriLogout ( integration ) ', () => {
@@ -180,7 +180,7 @@ describe('Service provider creation', () => {
       cy.contains(
         `Le fournisseur de service MyFirstSP mobile URI scheme logout a été créé avec succès !`,
       );
-      cy.get('.alert-success > .close').click();
+      cy.closeBanner('.alert-success');
     });
 
     it('if we add a service provider with two emails', () => {
@@ -199,7 +199,7 @@ describe('Service provider creation', () => {
       cy.contains(
         `Le fournisseur de service 2 emails a été créé avec succès !`,
       );
-      cy.get('.alert-success > .close').click();
+      cy.closeBanner('.alert-success');
     });
 
     it('if we add a service provider with two ipAddresses', () => {
@@ -218,7 +218,7 @@ describe('Service provider creation', () => {
       cy.contains(
         `Le fournisseur de service 2 ipAddresses a été créé avec succès !`,
       );
-      cy.get('.alert-success > .close').click();
+      cy.closeBanner('.alert-success');
     });
 
     it('if we add a service provider with two websites', () => {
@@ -237,7 +237,7 @@ describe('Service provider creation', () => {
       cy.contains(
         `Le fournisseur de service 2 websites a été créé avec succès !`,
       );
-      cy.get('.alert-success > .close').click();
+      cy.closeBanner('.alert-success');
     });
 
     it('if we add a service provider with no email', () => {
@@ -252,7 +252,7 @@ describe('Service provider creation', () => {
       cy.contains(
         `Le fournisseur de service no email a été créé avec succès !`,
       );
-      cy.get('.alert-success > .close').click();
+      cy.closeBanner('.alert-success');
     });
 
     it('should have client secret in hexadecimal form', () => {
@@ -270,7 +270,7 @@ describe('Service provider creation', () => {
       cy.contains(
         `Le fournisseur de service check hexa a été créé avec succès !`,
       );
-      cy.get('.alert-success > .close').click();
+      cy.closeBanner('.alert-success');
       cy.contains('check hexa');
       cy.get('#list-table > tbody > tr > td').eq(0).click();
       cy.get('#client_secret')
@@ -512,7 +512,7 @@ describe('Service provider creation', () => {
       cy.contains(
         `Le fournisseur de service MyFirstSP URIScheme a été créé avec succès !`,
       );
-      cy.get('.alert-success > .close').click();
+      cy.closeBanner('.alert-success');
     });
 
     it('if we add a URIScheme in redirectUriLogout field', () => {
@@ -552,7 +552,7 @@ describe('Service provider creation', () => {
       cy.contains(
         `Le fournisseur de service champs optionnels a été créé avec succès !`,
       );
-      cy.get('.alert-success > .close').click();
+      cy.closeBanner('.alert-success');
     });
 
     it('if we add a name containing all kind of authorized chars', () => {

--- a/admin/cypress/integration/service-provider/service-provider-delete.spec.js
+++ b/admin/cypress/integration/service-provider/service-provider-delete.spec.js
@@ -102,7 +102,7 @@ describe('Delete service provider', () => {
       cy.contains(
         `Le fournisseur de service ${fs.name} a été supprimé avec succès !`,
       ).should('be.visible');
-      cy.get('.alert-success > .close').click();
+      cy.closeBanner('.alert-success');
       cy.get('table').contains(fs.name).should('not.exist');
 
       cy.hasBusinessLog({
@@ -127,7 +127,7 @@ describe('Delete service provider', () => {
       );
       cy.contains('Confirmer').click();
 
-      cy.get('.alert-success > .close').click();
+      cy.closeBanner('.alert-success');
       cy.contains(fs.name).should('not.exist');
     });
 
@@ -143,7 +143,7 @@ describe('Delete service provider', () => {
       );
       cy.contains('Confirmer').click();
 
-      cy.get('.alert-success > .close').click();
+      cy.closeBanner('.alert-success');
       cy.contains(fs.name).should('not.exist');
     });
   });

--- a/admin/cypress/integration/service-provider/service-provider-generate-new-client-secret.spec.js
+++ b/admin/cypress/integration/service-provider/service-provider-generate-new-client-secret.spec.js
@@ -92,7 +92,7 @@ describe('update a service-provider', () => {
       cy.contains(
         `Le nouveau client secret du fournisseur de service GenerateClientSecretFS a été généré avec succés !`,
       ).should('be.visible');
-      cy.get('.alert-success > .close').click();
+      cy.closeBanner('.alert-success');
     });
 
     it('Should not be able to update a fs with a false totp', () => {

--- a/admin/cypress/support/commands.js
+++ b/admin/cypress/support/commands.js
@@ -1,4 +1,4 @@
-import { formType, formFill, formControl, totp } from './forms';
+import { closeBanner, formType, formFill, formControl, totp } from './forms';
 import {
   resetMongo,
   resetPostgres,
@@ -34,6 +34,7 @@ Cypress.Commands.add('getUserActivationToken', getUserActivationToken);
 Cypress.Commands.add('formFill', formFill);
 Cypress.Commands.add('formControl', formControl);
 Cypress.Commands.add('formType', formType);
+Cypress.Commands.add('closeBanner', closeBanner);
 Cypress.Commands.add('totp', { prevSubject: 'optional' }, totp);
 Cypress.Commands.add('login', login);
 Cypress.Commands.add('firstLogin', firstLogin);

--- a/admin/cypress/support/forms.js
+++ b/admin/cypress/support/forms.js
@@ -152,3 +152,7 @@ export function totp(subject, arg1, arg2) {
     .then(() => cy.task('getTotp', { secret }))
     .then((token) => formType(input, token, configuration));
 }
+
+export function closeBanner(target) {
+  cy.get(target+' > .btn-close').click();
+}

--- a/admin/public/javascript/toggle-by-radio.js
+++ b/admin/public/javascript/toggle-by-radio.js
@@ -3,7 +3,7 @@ export function toggleByRadio(enableRadio) {
   const disableRadio = document.getElementById(disableRadioId);
 
   const target = document.getElementById(
-    enableRadio.getAttribute('data-target'),
+    enableRadio.getAttribute('data-bs-target'),
   );
 
   // Initial render

--- a/admin/views/account/creation.ejs
+++ b/admin/views/account/creation.ejs
@@ -17,7 +17,7 @@
               <input type="hidden" name="_csrf" value="<%= locals.csrfToken  %>">
               <input id="password" type="hidden" required name="password" value="<%= locals.tmpPassword%>">
               <input type="hidden" name="secret" id="secret" value="fakeSecret">
-              <section class="form-group row">
+              <section class="mb-3 row">
                 <label class="col-2 col-form-label" for="username">Nom d'utilisateur</label>
                 <div class="col-10">
                   <input id="username" type="text" required
@@ -35,7 +35,7 @@
                   </div>
                 </div>
               </section>
-              <section class="form-group row">
+              <section class="mb-3 row">
                 <label class="col-2 col-form-label" for="email">Email</label>
                 <div class="col-10">
                   <input id="email" type="text" required
@@ -54,7 +54,7 @@
                   </div>
                 </div>
               </section>
-              <section class="form-group row">
+              <section class="mb-3 row">
                 <label class="col-2 col-form-label" for="roles">Rôles</label>
                 <div class="col-10">
                   <% USER_ROLES_OPTIONS.filter(({value}) => !['new_account','blocked_user','inactive_'].some(role => value.startsWith(role))).forEach((roleOption, index) => { %>
@@ -80,10 +80,10 @@
 
               <div class="my-4 text-center">
                 <p>MOT DE PASSE TEMPORAIRE :</p>
-                <p class="font-weight-bold display-4 my-3" id="tmpPassword"><%= locals.tmpPassword%></p>
+                <p class="fw-bold display-4 my-3" id="tmpPassword"><%= locals.tmpPassword%></p>
               </div>
 
-              <section class="form-group row">
+              <section class="mb-3 row">
                 <label class="col-2 col-form-label" for="confirm-2FAuthentication">Code TOTP</label>
                 <div class="col-10">
                   <input id="_totp" type="text" required value="<%= locals.totp %>" placeholder="123456"

--- a/admin/views/account/enrollment.ejs
+++ b/admin/views/account/enrollment.ejs
@@ -20,7 +20,7 @@
           <form action="<%= locals.APP_ROOT %>/account/enrollment/<%= locals.id%>?_method=PATCH" method="POST"
             data-init="validateEnrollment" novalidate>
             <input type="hidden" name="_csrf" value="<%= locals.csrfToken  %>">
-            <div class="form-group row">
+            <div class="mb-3 row">
               <label class="col-lg-2 col-lg-form-label" for="password">Mot de passe</label>
               <div class="col-lg-10">
                 <input id="password" type="password" required
@@ -52,7 +52,7 @@
               </div>
             </div>
 
-            <div class="form-group row">
+            <div class="mb-3 row">
               <label class="col-lg-2 col-lg-form-label" for="confirm-password">Confirmation</label>
               <div class="col-lg-10">
                 <input id="confirm-password" type="password" required
@@ -74,7 +74,7 @@
             </div>
 
             <div class="my-5">
-              <p class="text-center text-info font-weight-bold">Scannez le QRCode ou saisissez les informations
+              <p class="text-center text-info fw-bold">Scannez le QRCode ou saisissez les informations
                 manuellement grâce à un outil adapté, puis saisissez le code obtenu ci-dessous pour valider.</p>
               <div class="text-center">
                 <div class="d-flex flex-wrap justify-content-center">
@@ -82,8 +82,8 @@
                     <img src="<%= locals.QRCode %>" alt="Si vous voyez ce message, le QRCode ne s'est pas chargé :'(" />
                   </div>
                   <div class="mx-4 d-flex justify-content-center flex-column">
-                    <p class="font-weight-bold">Saisie manuelle:</p>
-                    <table class="text-left table">
+                    <p class="fw-bold">Saisie manuelle:</p>
+                    <table class="text-start table">
                       <tr id="issuer">
                         <th scope="row">Issuer</th>
                         <td class="text-primary"><%= locals.issuer %></td>
@@ -110,7 +110,7 @@
               </div>
             </div>
 
-            <div class="form-group row">
+            <div class="mb-3 row">
               <label class="col-lg-2 col-lg-form-label" for="confirm-2FAuthentication">Code TOTP</label>
               <div class="col-lg-10">
                 <input id="_totp" type="text" required

--- a/admin/views/account/list.ejs
+++ b/admin/views/account/list.ejs
@@ -55,7 +55,7 @@
                         <input type="hidden" name="_csrf" value="<%= locals.csrfToken %>">
                         <input type="hidden" name="_totp">
                         <input type="hidden" name="username" value="<%= user.username %>">
-                        <button type="submit" class="btn-action-delete">
+                        <button type="submit" class="btn-action-delete btn btn-sm">
                           <i class="fa fa-trash" aria-hidden="true" title="Supprimer"></i>
                         </button>
                     </form>

--- a/admin/views/account/list.ejs
+++ b/admin/views/account/list.ejs
@@ -36,7 +36,7 @@
                 <td class="roles">
                   <% user.roles.forEach(function (role) { %>
                     <span
-                      class="badge badge-secondary p-1"><%= USER_ROLES_OPTIONS.find(({value}) => value === role).label %></span>
+                      class="badge text-bg-secondary p-1"><%= USER_ROLES_OPTIONS.find(({value}) => value === role).label %></span>
                   <% }) %>
                 </td>
                 <% if(CURRENT_USER.roles.find((role) => role === 'admin' && user.id !== CURRENT_USER.id)) { %>

--- a/admin/views/account/userAccount.ejs
+++ b/admin/views/account/userAccount.ejs
@@ -31,8 +31,8 @@
                 </div>
 
                 <div class="mx-4 d-flex justify-content-center flex-column">
-                  <p class="font-weight-bold">Saisie manuelle:</p>
-                  <table class="text-left table">
+                  <p class="fw-bold">Saisie manuelle:</p>
+                  <table class="text-start table">
                     <tr id="issuer">
                       <th scope="row">Issuer</th>
                       <td class="text-primary"><%= locals.issuer %></td>
@@ -73,7 +73,7 @@
             data-init="validateAccountUpdate" novalidate>
             <input type="hidden" name="_csrf" value="<%= locals.csrfToken  %>">
 
-            <div class="form-group row">
+            <div class="mb-3 row">
               <label class="col-lg-2 col-lg-form-label" for="password">Mot de passe actuel</label>
               <div class="col-lg-10">
                 <input id="currentPassword" type="password" required
@@ -91,7 +91,7 @@
                 <% } %>
               </div>
             </div>
-            <div class="form-group row">
+            <div class="mb-3 row">
               <label class="col-lg-2 col-lg-form-label" for="password">Votre nouveau mot de passe</label>
               <div class="col-lg-10">
                 <input id="password" type="password" required
@@ -123,7 +123,7 @@
               </div>
             </div>
 
-            <div class="form-group row">
+            <div class="mb-3 row">
               <label class="col-lg-2 col-lg-form-label" for="confirm-password">Confirmation de votre nouveau mot de passe</label>
               <div class="col-lg-10">
                 <input id="confirm-password" type="password" required
@@ -144,7 +144,7 @@
               </div>
             </div>
 
-            <div class="form-group row">
+            <div class="mb-3 row">
               <label class="col-lg-2 col-lg-form-label" for="confirm-2FAuthentication">Code TOTP</label>
               <div class="col-lg-10">
                 <input id="_totp" type="text" required

--- a/admin/views/configuration/indisponibilite.ejs
+++ b/admin/views/configuration/indisponibilite.ejs
@@ -11,7 +11,7 @@
       <h2 class="mb-4">Configuration indisponibilité FC</h2>
       <form method="post" id="indisponibilite" action="<%= APP_ROOT %>/configuration/indisponibilite" data-init="validForm" novalidate>
         <input type="hidden" name="_csrf" value="<%= locals.csrfToken %>">
-        <div class="form-group">
+        <div class="mb-3">
           <label for="message" class="mb-3">Message d'indisponibilité</label>
           <textarea class="form-control" 
             name="message" 
@@ -25,14 +25,14 @@
         <div class="row">
           <div class="col-sm my-1">
             <p class="mx-3">Début de l'indisponibilité</p>
-            <div class="form-inline">
+            <div class="d-flex align-items-center">
               <div class="row">
                   <div class="col-sm">
                       <div class="row">
                         <div class="col-sm">
                           <label for="dateDebut" class="m-1">Date</label>
                           <input type="date" 
-                            class="form-control mb-2 mr-sm-2" 
+                            class="form-control mb-2 me-sm-2"
                             id="dateDebut" 
                             placeholder="YYYY-MM-DD" 
                             name="dateDebut"
@@ -45,7 +45,7 @@
                   <div class="col-sm">
                     <label for="heureDebut" class="m-1"> Heure</label>
                     <input type="time" 
-                      class="form-control mb-2 mr-sm-2" 
+                      class="form-control mb-2 me-sm-2"
                       id="heureDebut" 
                       placeholder="HH:mm" 
                       name="heureDebut"
@@ -64,14 +64,14 @@
           </div>
           <div class="col-sm my-1">
             <p class="mx-3">Fin de l'indisponibilité</p>
-            <div class="form-inline">
+            <div class="d-flex align-items-center">
               <div class="row">
                 <div class="col-sm">
                   <div class="row">
                     <div class="col-sm">
                       <label for="dateFin" class="m-1">Date</label>
                       <input type="date" 
-                        class="form-control mb-2 mr-sm-2" 
+                        class="form-control mb-2 me-sm-2"
                         id="dateFin"
                         placeholder="YYYY-MM-DD"
                         name="dateFin"
@@ -84,7 +84,7 @@
                 <div class="col-sm">
                   <label for="heureFin" class="m-1"> Heure</label>
                   <input type="time" 
-                    class="form-control mb-2 mr-sm-2" 
+                    class="form-control mb-2 me-sm-2"
                     id="heureFin" 
                     placeholder="HH:mm" 
                     name="heureFin"
@@ -114,17 +114,17 @@
           </p>
           <p class="d-flex justify-content-center">Activer le message</p>
           <div class="d-flex justify-content-center">
-            <div class="custom-control custom-radio custom-control-inline">
-                <input type="radio" class="custom-control-input is-valid" id="activated" name="activateMessage" value="true"
+            <div class="form-check form-check-inline">
+                <input type="radio" class="form-check-input is-valid" id="activated" name="activateMessage" value="true"
                   <% if(locals.data && (locals.data.activateMessage === true || (locals.data.features && locals.data.features.displayMessageOnLogin === true))) { %> checked <% } %>
                   required>
-                <label class="custom-control-label" for="activated">oui</label>
+                <label class="form-check-label" for="activated">oui</label>
               </div>
-              <div class="custom-control custom-radio custom-control-inline">
-                <input type="radio" class="custom-control-input is-valid" id="unactivated" name="activateMessage" value="false"
+              <div class="form-check form-check-inline">
+                <input type="radio" class="form-check-input is-valid" id="unactivated" name="activateMessage" value="false"
                   <%if(locals.data && (locals.data.activateMessage === false || (locals.data.features && locals.data.features.displayMessageOnLogin === false))) { %> checked <% } %>
                     required>
-                <label class="custom-control-label" for="unactivated">non</label>
+                <label class="form-check-label" for="unactivated">non</label>
               </div>
           </div>   
         </div>

--- a/admin/views/identity-provider/creation.ejs
+++ b/admin/views/identity-provider/creation.ejs
@@ -666,7 +666,9 @@
                 <% } %>
               </div>
             </div>
-            <button type="submit" class="btn btn-primary">Créer le fournisseur d'identité</button>
+            <section class="row" style="margin: 2em 0em 1em 0.5em;">
+              <button type="submit" class="btn btn-primary">Créer le fournisseur d'identité</button>
+            </section>
           </form>
         </div>
       </div>

--- a/admin/views/identity-provider/creation.ejs
+++ b/admin/views/identity-provider/creation.ejs
@@ -17,7 +17,7 @@
         <div class="card-body">
           <form method="POST" data-init="initForm,validForm,changeDiscovery,changeSignature" id="fi-form" name="fi-form" action="?_csrf=<%= csrfToken %>" data-select="form" novalidate>
             <input type="hidden" name="_csrf" value="<%= locals.csrfToken  %>">
-            <div class="form-group row">
+            <div class="mb-3 row">
               <label class="col-2 col-form-label" for="name">Nom du FI * : </label>
               <div class="col-10">
                 <input id="name" type="text" required class="form-control <%= locals.messages.errors && messages.errors[0].name && 'is-invalid' %>" name="name" value="<%= locals.messages.values && messages.values[0].name %>" pattern="<%= VALID_INPUT_STRING_REGEX %>">
@@ -35,7 +35,7 @@
                 </div>
               </div>
             </div>
-            <div class="form-group row">
+            <div class="mb-3 row">
               <label class="col-2 col-form-label" for="title">Titre (tel qu'il apparaîtra aux utilisateurs FC) * : </label>
               <div class="col-10">
                 <input id="title" type="text" required class="form-control <%= locals.messages.errors && messages.errors[0].title && 'is-invalid' %>" name="title" value="<%= locals.messages.values && messages.values[0].title %>" pattern="<%= VALID_INPUT_STRING_REGEX %>">
@@ -54,7 +54,7 @@
               </div>
             </div>
 
-            <div class="form-group row">
+            <div class="mb-3 row">
               <label class="col-2 col-form-label" for="fqdns">Noms de domaines (un fqdn par ligne) :</label>
               <div class="col-10">
                 <textarea id="fqdns" rows="3" name="fqdns" class="form-control <%= locals.messages.errors && messages.errors[0].fqdns && 'is-invalid' %>" pattern="^([\da-z\.-]+)\.([a-z\.]{2,10})$"><%= locals.messages.values && messages.values[0].fqdns instanceof Array ? messages.values[0].fqdns.join('\n') : '' %></textarea>
@@ -73,7 +73,7 @@
               </div>
             </div>
 
-            <div class="form-group row">
+            <div class="mb-3 row">
               <label class="col-2 col-form-label" for="issuer"> Issuer URL * : </label>
               <div class="col-10">
                 <input id="issuer" type="text" required class="form-control <%= locals.messages.errors && messages.errors[0].issuer && 'is-invalid' %>" name="issuer" value="<%= locals.messages.values && messages.values[0].issuer %>" pattern="^((https?:\/\/)?((([^\s\/$.?#]{1,})(\.[^\s\/$?#]{2,})*\.[a-z]{2,})|(([0-9]{1,3}\.){3}[0-9]{1,3})|localhost)(:[0-9]{2,5})?(\/[^\s\/$]+)*\/?)$">
@@ -91,7 +91,7 @@
                 </div>
               </div>
             </div>
-            <div class="form-group row">
+            <div class="mb-3 row">
               <label class="col-2 col-form-label" for="jwksUrl"> JWKS URL <span class=<%= locals.messages.values && messages.values[0].discovery === true ? 'd-none' : '' %>>*</span> : </label>
               <div class="col-10">
                 <input id="jwksUrl" type="text" <%= locals.messages.values && messages.values[0].discovery ? 'disabled' : 'required' %> class="form-control <%= locals.messages.errors && messages.errors[0].jwksUrl && 'is-invalid' %>" name="jwksUrl" value="<%= locals.messages.values && messages.values[0].jwksUrl %>" pattern="^((https?:\/\/)?((([^\s\/$.?#]{1,})(\.[^\s\/$?#]{2,})*\.[a-z]{2,})|(([0-9]{1,3}\.){3}[0-9]{1,3})|localhost)(:[0-9]{2,5})?(\/[^\s\/$]+)*\/?)$">
@@ -109,7 +109,7 @@
                 </div>
               </div>
             </div>
-            <div class="form-group row">
+            <div class="mb-3 row">
               <label class="col-2 col-form-label" for="tokenUrl">Token URL <span class=<%= locals.messages.values && messages.values[0].discovery === true ? 'd-none' : '' %>>*</span> :</label>
               <div class="col-10">
                 <input id="tokenUrl" type="text" <%= locals.messages.values && messages.values[0].discovery ? 'disabled' : 'required' %> class="form-control <%= locals.messages.errors && messages.errors[0].tokenUrl && 'is-invalid' %>" name="tokenUrl" value="<%= locals.messages.values && messages.values[0].tokenUrl %>" pattern="^((https?:\/\/)?((([^\s\/$.?#]{1,})(\.[^\s\/$?#]{2,})*\.[a-z]{2,})|(([0-9]{1,3}\.){3}[0-9]{1,3})|localhost)(:[0-9]{2,5})?(\/[^\s\/$]+)*\/?)$">
@@ -127,7 +127,7 @@
                 </div>
               </div>
             </div>
-            <div class="form-group row">
+            <div class="mb-3 row">
               <label class="col-2 col-form-label" for="userInfoUrl">UserInfo URL <span class=<%= locals.messages.values && messages.values[0].discovery === true ? 'd-none' : '' %>>*</span> :</label>
               <div class="col-10">
                 <input id="userInfoUrl" <%= locals.messages.values && messages.values[0].discovery ? 'disabled' : 'required' %> type="text" class="form-control userInfoUrl <%= locals.messages.errors && messages.errors[0].userInfoUrl && 'is-invalid' %>" name="userInfoUrl" value="<%= locals.messages.values && messages.values[0].userInfoUrl %>" pattern="^((https?:\/\/)?((([^\s\/$.?#]{1,})(\.[^\s\/$?#]{2,})*\.[a-z]{2,})|(([0-9]{1,3}\.){3}[0-9]{1,3})|localhost)(:[0-9]{2,5})?(\/[^\s\/$]+)*\/?)$">
@@ -145,7 +145,7 @@
                 </div>
               </div>
             </div>
-            <div class="form-group row">
+            <div class="mb-3 row">
               <label class="col-2 col-form-label" for="authorizationUrl">Authorization URL <span class=<%= locals.messages.values && messages.values[0].discovery === true ? 'd-none' : '' %>>*</span> :</label>
               <div class="col-10">
                 <input id="authorizationUrl" <%= locals.messages.values && messages.values[0].discovery ? 'disabled' : 'required' %> type="text" class="form-control <%= locals.messages.errors && messages.errors[0].authorizationUrl && 'is-invalid' %>" name="authorizationUrl" value="<%= locals.messages.values && messages.values[0].authorizationUrl %>" pattern="^((https?:\/\/)?((([^\s\/$.?#]{1,})(\.[^\s\/$?#]{2,})*\.[a-z]{2,})|(([0-9]{1,3}\.){3}[0-9]{1,3})|localhost)(:[0-9]{2,5})?(\/[^\s\/$]+)*\/?)$">
@@ -163,7 +163,7 @@
                 </div>
               </div>
             </div>
-            <div class="form-group row">
+            <div class="mb-3 row">
               <label class="col-2 col-form-label" for="logoutUrl">Logout URL :</label>
               <div class="col-10">
                 <input id="logoutUrl" type="text" class="form-control <%= locals.messages.errors && messages.errors[0].logoutUrl && 'is-invalid' %>" name="logoutUrl" value="<%= locals.messages.values && messages.values[0].logoutUrl %>" pattern="^((https?:\/\/)?((([^\s\/$.?#]{1,})(\.[^\s\/$?#]{2,})*\.[a-z]{2,})|(([0-9]{1,3}\.){3}[0-9]{1,3})|localhost)(:[0-9]{2,5})?(\/[^\s\/$]+)*\/?)$">
@@ -181,7 +181,7 @@
                 </div>
               </div>
             </div>
-            <div class="form-group row">
+            <div class="mb-3 row">
               <label class="col-2 col-form-label" for="statusUrl">Status URL :</label>
               <div class="col-10">
                 <input id="statusUrl" type="text" class="form-control <%= locals.messages.errors && messages.errors[0].statusUrl && 'is-invalid' %>" name="statusUrl" value="<%= locals.messages.values && messages.values[0].statusUrl %>" pattern="^((https?:\/\/)?((([^\s\/$.?#]{1,})(\.[^\s\/$?#]{2,})*\.[a-z]{2,})|(([0-9]{1,3}\.){3}[0-9]{1,3})|localhost)(:[0-9]{2,5})?(\/[^\s\/$]+)*\/?)$">
@@ -199,20 +199,20 @@
                 </div>
               </div>
             </div>
-            <div class="form-group row">
+            <div class="mb-3 row">
               <label class="col-2 col-form-label">Utiliser la discovery URL : </label>
-              <div class="form-group col-4 d-flex align-items-end">
-                <div class="custom-control custom-radio custom-control-inline">
-                  <input type="radio" class="custom-control-input is-valid is-discovery discovery-radio" id="discovery" name="discovery" value="true" <%= locals.messages.values && messages.values[0].discovery ? 'checked' : '' %>>
-                  <label class="custom-control-label" for="discovery">oui</label>
+              <div class="mb-3 col-4 d-flex align-items-end">
+                <div class="form-check form-check-inline">
+                  <input type="radio" class="form-check-input is-valid is-discovery discovery-radio" id="discovery" name="discovery" value="true" <%= locals.messages.values && messages.values[0].discovery ? 'checked' : '' %>>
+                  <label class="form-check-label" for="discovery">oui</label>
                 </div>
-                <div class="custom-control custom-radio custom-control-inline">
-                  <input type="radio" class="custom-control-input is-valid is-discovery discovery-radio" id="no-discovery" name="discovery" value="false" <%= !locals.messages.values || !messages.values[0].discovery ? 'checked' :'' %>>
-                  <label class="custom-control-label" for="no-discovery">non</label>
+                <div class="form-check form-check-inline">
+                  <input type="radio" class="form-check-input is-valid is-discovery discovery-radio" id="no-discovery" name="discovery" value="false" <%= !locals.messages.values || !messages.values[0].discovery ? 'checked' :'' %>>
+                  <label class="form-check-label" for="no-discovery">non</label>
                 </div>
               </div>
             </div>
-            <div class="form-group row">
+            <div class="mb-3 row">
               <label class="col-2 col-form-label" for="discoveryUrl">Discovery URL <span class=<%= locals.messages.values && messages.values[0].discovery === false ? 'd-none' : '' %>>*</span> :</label>
               <div class="col-10">
                 <input id="discoveryUrl" <%= locals.messages.values && !messages.values[0].discovery ? 'required' :'disabled' %> type="text" class="form-control <%= locals.messages.errors && messages.errors[0].discoveryUrl && 'is-invalid' %>" name="discoveryUrl" value="<%= locals.messages.values && messages.values[0].discoveryUrl %>" pattern="^((https?:\/\/)?((([^\s\/$.?#]{1,})(\.[^\s\/$?#]{2,})*\.[a-z]{2,})|(([0-9]{1,3}\.){3}[0-9]{1,3})|localhost)(:[0-9]{2,5})?(\/[^\s\/$]+)*\/?)$">
@@ -230,7 +230,7 @@
                 </div>
               </div>
             </div>
-            <div class="form-group row">
+            <div class="mb-3 row">
               <label class="col-2 col-form-label" for="clientId">Client ID * :</label>
               <div class="col-10">
                 <input id="clientId" type="text" required class="form-control <%= locals.messages.errors && messages.errors[0].clientId && 'is-invalid' %>" name="clientId" value="<%= locals.messages.values && messages.values[0].clientId %>">
@@ -248,7 +248,7 @@
                 </div>
               </div>
             </div>
-            <div class="form-group row">
+            <div class="mb-3 row">
               <label class="col-2 col-form-label" for="client_secret">Client Secret * :</label>
               <div class="col-10">
                 <input id="client_secret" type="text" required class="form-control <%= locals.messages.errors && messages.errors[0].client_secret && 'is-invalid' %>" name="client_secret" value="<%= locals.messages.values && messages.values[0].client_secret %>">
@@ -267,7 +267,7 @@
               </div>
             </div>
 
-            <div class="form-group row">
+            <div class="mb-3 row">
               <label class="col-2 col-form-label" for="siret">Siret par défaut :</label>
               <div class="col-10">
                 <input id="siret" type="text" class="form-control <%= locals.messages.errors && messages.errors[0].siret && 'is-invalid' %>" name="siret" value="<%= locals.messages.values && messages.values[0].siret %>">
@@ -286,34 +286,34 @@
               </div>
             </div>
 
-            <div class="form-group row">
+            <div class="mb-3 row">
               <label class="col-2 col-form-label">Sélectionnable dans la mire : </label>
-              <div class="form-group col-4 d-flex align-items-end">
-                <div class="custom-control custom-radio custom-control-inline">
-                  <input type="radio" class="custom-control-input is-valid" id="activated" name="active" value="true" required <%= locals.messages.values && messages.values[0].active === true ? 'checked' : '' %>>
-                  <label class="custom-control-label" for="activated">oui</label>
+              <div class="mb-3 col-4 d-flex align-items-end">
+                <div class="form-check form-check-inline">
+                  <input type="radio" class="form-check-input is-valid" id="activated" name="active" value="true" required <%= locals.messages.values && messages.values[0].active === true ? 'checked' : '' %>>
+                  <label class="form-check-label" for="activated">oui</label>
                 </div>
-                <div class="custom-control custom-radio custom-control-inline">
-                  <input type="radio" class="custom-control-input is-valid" id="unactivated" name="active" value="false" required <%= !locals.messages.values || messages.values[0].active === false ? 'checked' : '' %>>
-                  <label class="custom-control-label" for="unactivated">non</label>
+                <div class="form-check form-check-inline">
+                  <input type="radio" class="form-check-input is-valid" id="unactivated" name="active" value="false" required <%= !locals.messages.values || messages.values[0].active === false ? 'checked' : '' %>>
+                  <label class="form-check-label" for="unactivated">non</label>
                 </div>
               </div>
               <label class="col-2 col-form-label">Visible dans la mire : </label>
-              <div class="form-group col-4 d-flex align-items-end">
-                <div class="custom-control custom-radio custom-control-inline">
-                  <input type="radio" class="custom-control-input is-valid" id="displayed" name="display" value="true" required <%= locals.messages.values && messages.values[0].display === true ? 'checked' : '' %>>
-                  <label class="custom-control-label" for="displayed">oui</label>
+              <div class="mb-3 col-4 d-flex align-items-end">
+                <div class="form-check form-check-inline">
+                  <input type="radio" class="form-check-input is-valid" id="displayed" name="display" value="true" required <%= locals.messages.values && messages.values[0].display === true ? 'checked' : '' %>>
+                  <label class="form-check-label" for="displayed">oui</label>
                 </div>
-                <div class="custom-control custom-radio custom-control-inline">
-                  <input type="radio" class="custom-control-input is-valid" id="notdisplayed" name="display" value="false" required <%= !locals.messages.values || messages.values[0].display === false ? 'checked' : '' %>>
-                  <label class="custom-control-label" for="notdisplayed">non</label>
+                <div class="form-check form-check-inline">
+                  <input type="radio" class="form-check-input is-valid" id="notdisplayed" name="display" value="false" required <%= !locals.messages.values || messages.values[0].display === false ? 'checked' : '' %>>
+                  <label class="form-check-label" for="notdisplayed">non</label>
                 </div>
               </div>
             </div>
 
             <input type="hidden" name="isBeta" value="false" />
 
-            <div class="form-group row">
+            <div class="mb-3 row">
               <label class="col-12 col-form-label" for="messageToDisplayWhenInactive">Message à afficher lorsque le FI est désactivé (Disponible prochainement par défaut si aucune saisie) :</label>
               <div class="col-12">
                 <input id="messageToDisplayWhenInactive" type="text" class="form-control" name="messageToDisplayWhenInactive" placeholder="Disponible prochainement" value="<%= locals.messages.values && messages.values[0].messageToDisplayWhenInactive %>">
@@ -331,7 +331,7 @@
                 </div>
               </div>
             </div>
-            <div class="form-group row">
+            <div class="mb-3 row">
               <label class="col-2 col-form-label" for="image">Lien vers lequel rediriger si le FI est désactivé :</label>
               <div class="col-10">
                 <input id="redirectionTargetWhenInactive" type="text" class="form-control <%= locals.messages.errors && messages.errors[0].redirectionTargetWhenInactive && 'is-invalid' %>" name="redirectionTargetWhenInactive" value="<%= locals.messages.values && messages.values[0].redirectionTargetWhenInactive %>">
@@ -349,7 +349,7 @@
                 </div>
               </div>
             </div>
-            <div class="form-group row">
+            <div class="mb-3 row">
               <label class="col-2 col-form-label" for="alt">Valeur de l'attribut HTML "alt" de l'image :</label>
               <div class="col-10">
                 <input id="alt" type="text" class="form-control <%= locals.messages.errors && messages.errors[0].alt && 'is-invalid' %>" name="alt" value="<%= locals.messages.values && messages.values[0].alt %>">
@@ -367,7 +367,7 @@
                 </div>
               </div>
             </div>
-            <div class="form-group row">
+            <div class="mb-3 row">
               <label class="col-2 col-form-label" for="image">Nom de l'image :</label>
               <div class="col-10">
                 <input id="image" type="text" class="form-control <%= locals.messages.errors && messages.errors[0].image && 'is-invalid' %>" name="image" value="<%= locals.messages.values && messages.values[0].image %>">
@@ -385,7 +385,7 @@
                 </div>
               </div>
             </div>
-            <div class="form-group row">
+            <div class="mb-3 row">
               <label class="col-2 col-form-label" for="imageFocus">Nom de l'image utilisée au survol/focus :</label>
               <div class="col-10">
                 <input id="imageFocus" type="text" class="form-control <%= locals.messages.errors && messages.errors[0].imageFocus && 'is-invalid' %>" name="imageFocus" value="<%= locals.messages.values && messages.values[0].imageFocus %>">
@@ -403,20 +403,20 @@
                 </div>
               </div>
             </div>
-            <div class="form-group row">
+            <div class="mb-3 row">
               <label class="col-2 col-form-label">Ignorer le niveau eidas : </label>
-              <div class="form-group col-4 d-flex align-items-end">
-                <div class="custom-control custom-radio custom-control-inline">
-                  <input type="radio" class="custom-control-input is-valid" id="trustedIdentity" name="trustedIdentity" value="true" required <%= locals.messages.values && messages.values[0].trustedIdentity === true ? 'checked' : '' %>>
-                  <label class="custom-control-label" for="trustedIdentity">oui</label>
+              <div class="mb-3 col-4 d-flex align-items-end">
+                <div class="form-check form-check-inline">
+                  <input type="radio" class="form-check-input is-valid" id="trustedIdentity" name="trustedIdentity" value="true" required <%= locals.messages.values && messages.values[0].trustedIdentity === true ? 'checked' : '' %>>
+                  <label class="form-check-label" for="trustedIdentity">oui</label>
                 </div>
-                <div class="custom-control custom-radio custom-control-inline">
-                  <input type="radio" class="custom-control-input is-valid" id="not-trustedIdentity" name="trustedIdentity" value="false" required <%= !locals.messages.values || messages.values[0].trustedIdentity ? 'checked' : '' %>>
-                  <label class="custom-control-label" for="not-trustedIdentity">non</label>
+                <div class="form-check form-check-inline">
+                  <input type="radio" class="form-check-input is-valid" id="not-trustedIdentity" name="trustedIdentity" value="false" required <%= !locals.messages.values || messages.values[0].trustedIdentity ? 'checked' : '' %>>
+                  <label class="form-check-label" for="not-trustedIdentity">non</label>
                 </div>
               </div>
             </div>
-            <div class="form-group row" id="eidas-level">
+            <div class="mb-3 row" id="eidas-level">
               <label class="col-2 col-form-label">Niveaux eidas (V2) : </label>
               <div class="col-10">
                 <% locals.acrList.forEach((acr) => { %>
@@ -428,20 +428,20 @@
               </div>
             </div>
 
-            <div class="form-group row">
+            <div class="mb-3 row">
               <label class="col-2 col-form-label" for="id_token_signed_response_alg">id_token_signed_response_alg * : </label>
               <div class="col-10">
-                <select class="custom-select" name="id_token_signed_response_alg" required>
+                <select class="form-select" name="id_token_signed_response_alg" required>
                   <option value="HS256" <%= messages.values && messages.values[0].id_token_signed_response_alg === "HS256" ? 'selected' : '' %>>HS256</option>
                   <option value="ES256" selected>ES256</option>
                   <option value="RS256" <%= messages.values && messages.values[0].id_token_signed_response_alg === "RS256" ? 'selected' : '' %>>RS256</option>
                 </select>
               </div>
             </div>
-            <div class="form-group row">
+            <div class="mb-3 row">
               <label class="col-2 col-form-label" for="userinfo_signed_response_alg">userinfo_signed_response_alg * : </label>
               <div class="col-10">
-                <select class="custom-select" name="userinfo_signed_response_alg">
+                <select class="form-select" name="userinfo_signed_response_alg">
                   <option value="" <%= messages.values && messages.values[0].userinfo_signed_response_alg === "" ? 'selected' : '' %>>Aucun</option>
                   <option value="HS256" <%= messages.values && messages.values[0].userinfo_signed_response_alg === "HS256" ? 'selected' : '' %>>HS256</option>
                   <option value="ES256" selected>ES256</option>
@@ -449,10 +449,10 @@
                 </select>
               </div>
             </div>
-            <div class="form-group row">
+            <div class="mb-3 row">
               <label class="col-2 col-form-label" for="id_token_encrypted_response_alg">id_token_encrypted_response_alg : </label>
               <div class="col-10">
-                <select class="custom-select" name="id_token_encrypted_response_alg">
+                <select class="form-select" name="id_token_encrypted_response_alg">
                   <option value="" <%= !messages.values || messages.values[0].id_token_encrypted_response_alg === "" ? 'selected' : '' %>></option>
                   <option value="ECDH-ES" <%= messages.values && messages.values[0].id_token_encrypted_response_alg === "ECDH-ES" ? 'selected' : '' %>>ECDH-ES</option>
                   <option value="RSA-OAEP" <%= messages.values && messages.values[0].id_token_encrypted_response_alg === "RSA-OAEP" ? 'selected' : '' %>>RSA-OAEP</option>
@@ -460,10 +460,10 @@
                 </select>
               </div>
             </div>
-            <div class="form-group row">
+            <div class="mb-3 row">
               <label class="col-2 col-form-label" for="userinfo_encrypted_response_alg">userinfo_encrypted_response_alg : </label>
               <div class="col-10">
-                <select class="custom-select" name="userinfo_encrypted_response_alg">
+                <select class="form-select" name="userinfo_encrypted_response_alg">
                   <option value="" <%= !messages.values || messages.values[0].userinfo_encrypted_response_alg === "" ? 'selected' : '' %>></option>
                   <option value="ECDH-ES" <%= messages.values && messages.values[0].userinfo_encrypted_response_alg === "ECDH-ES" ? 'selected' : '' %>>ECDH-ES</option>
                   <option value="RSA-OAEP" <%= messages.values && messages.values[0].userinfo_encrypted_response_alg === "RSA-OAEP" ? 'selected' : '' %>>RSA-OAEP</option>
@@ -471,35 +471,35 @@
                 </select>
               </div>
             </div>
-            <div class="form-group row">
+            <div class="mb-3 row">
               <label class="col-2 col-form-label" for="id_token_encrypted_response_enc">id_token_encrypted_response_enc : </label>
               <div class="col-10">
-                <select class="custom-select" name="id_token_encrypted_response_enc">
+                <select class="form-select" name="id_token_encrypted_response_enc">
                   <option value="" <%= !messages.values || messages.values[0].id_token_encrypted_response_enc === "" ? 'selected' : '' %>></option>
                   <option value="A256GCM" <%= messages.values && messages.values[0].id_token_encrypted_response_enc === "A256GCM" ? 'selected' : '' %>>A256GCM</option>
                 </select>
               </div>
             </div>
-            <div class="form-group row">
+            <div class="mb-3 row">
               <label class="col-2 col-form-label" for="userinfo_encrypted_response_enc">userinfo_encrypted_response_enc : </label>
               <div class="col-10">
-                <select class="custom-select" name="userinfo_encrypted_response_enc">
+                <select class="form-select" name="userinfo_encrypted_response_enc">
                   <option value="" <%= !messages.values || messages.values[0].userinfo_encrypted_response_enc === "" ? 'selected' : '' %>></option>
                   <option value="A256GCM" <%= messages.values && messages.values[0].userinfo_encrypted_response_enc === "A256GCM" ? 'selected' : '' %>>A256GCM</option>
                 </select>
               </div>
             </div>
-            <section class="form-group row" id="token_endpoint_auth_method">
+            <section class="mb-3 row" id="token_endpoint_auth_method">
               <label class="col-2 col-form-label">token_endpoint_auth_method : </label>
               <div class="col-10">
-                <select name="token_endpoint_auth_method" class="custom-select">
+                <select name="token_endpoint_auth_method" class="form-select">
                   <option value="client_secret_post" <%= !messages.values || messages.values[0].token_endpoint_auth_method === "client_secret_post" ? 'selected' : '' %>>
                     client_secret_post
                   </option>
                 </select>
               </div>
             </section>
-            <div class="form-group row">
+            <div class="mb-3 row">
               <label class="col-2 col-form-label" for="order">Ordre d'affichage dans la mire :</label>
               <div class="col-10">
                 <input id="order" type="number" class="form-control <%= locals.messages.errors && messages.errors[0].order && 'is-invalid' %>" name="order" value="<%= locals.messages.values && messages.values[0].order %>" placeholder="<%= locals.identityProvidersCount %> FI actuellement enregistrés">
@@ -518,7 +518,7 @@
               </div>
             </div>
 
-            <div class="form-group row">
+            <div class="mb-3 row">
               <label class="col-2 col-form-label" for="supportEmail">Email du support :</label>
               <div class="col-10">
                 <input id="supportEmail" type="email" class="form-control <%= locals.messages.errors && messages.errors[0].supportEmail && 'is-invalid' %>" name="supportEmail" value="<%= locals.messages.values && messages.values[0].supportEmail %>">
@@ -538,7 +538,7 @@
               </div>
             </div>
 
-            <div class="form-group row">
+            <div class="mb-3 row">
               <label class="col-2 col-form-label" for="emails">Email pour l'envoi des statistiques (une adresse mail par ligne) :</label>
               <div class="col-10">
                 <textarea id="emails" rows="3" name="emails" class="form-control <%= locals.messages.errors && messages.errors[0].emails && 'is-invalid' %>" pattern="^([a-zA-Z0-9_\.-]+)@([\da-z\.-]+)\.([a-z\.]{2,10})$"><%= locals.messages.values && messages.values[0].emails instanceof Array ? messages.values[0].emails.join('\n') : '' %></textarea>
@@ -556,31 +556,31 @@
                 </div>
               </div>
             </div>
-            <div class="form-group row">
+            <div class="mb-3 row">
               <label class="col-2 col-form-label" for="specificText">Texte pour les erreur E010004, E010006, E010008, E010009, E010015. :</label>
               <div class="col-10">
                 <input id="specificText" type="text" class="form-control <%= locals.messages.errors && messages.errors[0].specificText && 'is-invalid' %>" name="specificText" value="<%= locals.messages.values && messages.values[0].specificText %>">
               </div>
             </div>
 
-            <div class="form-group row">
+            <div class="mb-3 row">
 
               <label class="col-2 col-form-label" for="modalActive">Boîte de dialogue au clic :</label>
-              <div class="form-group col-4 d-flex align-items-end">
-                <div class="custom-control custom-radio custom-control-inline">
-                  <input type="radio" class="custom-control-input is-valid" id="modalActive" name="modalActive" value="true" required data-init="toggleByRadio" data-target="modal-settings" <%= locals.messages.values && messages.values[0].modalActive === true ? 'checked' : '' %>>
-                  <label class="custom-control-label" for="modalActive">Activée</label>
+              <div class="mb-3 col-4 d-flex align-items-end">
+                <div class="form-check form-check-inline">
+                  <input type="radio" class="form-check-input is-valid" id="modalActive" name="modalActive" value="true" required data-init="toggleByRadio" data-bs-target="modal-settings" <%= locals.messages.values && messages.values[0].modalActive === true ? 'checked' : '' %>>
+                  <label class="form-check-label" for="modalActive">Activée</label>
                 </div>
-                <div class="custom-control custom-radio custom-control-inline">
-                  <input type="radio" class="custom-control-input is-valid" id="not-modalActive" name="modalActive" value="false" required <%= !locals.messages.values || messages.values[0].modalActive === false ? 'checked' : '' %>>
-                  <label class="custom-control-label" for="not-modalActive">Désactivée</label>
+                <div class="form-check form-check-inline">
+                  <input type="radio" class="form-check-input is-valid" id="not-modalActive" name="modalActive" value="false" required <%= !locals.messages.values || messages.values[0].modalActive === false ? 'checked' : '' %>>
+                  <label class="form-check-label" for="not-modalActive">Désactivée</label>
                 </div>
               </div>
             </div>
 
 
             <div id="modal-settings">
-              <div class="form-group row">
+              <div class="mb-3 row">
                 <label class="col-lg-2 col-lg-form-label" for="modalTitle">Titre * : </label>
                 <div class="col-lg-10">
                   <input id="modalTitle" type="text" required class="form-control required <%= locals.messages.errors && messages.errors[0].modalTitle && 'is-invalid' %>" name="modalTitle" value="<%= locals.messages.values && messages.values[0].modalTitle %>" placeholder="Titre">
@@ -594,7 +594,7 @@
                 </div>
               </div>
 
-              <div class="form-group row">
+              <div class="mb-3 row">
                 <label class="col-lg-2 col-lg-form-label" for="modalBody">Texte * : </label>
                 <div class="col-lg-10">
                   <textarea id="modalBody" rows="3" name="modalBody" required pattern=".*" class="form-control required <%= locals.messages.errors && messages.errors[0].modalBody && 'is-invalid' %>"><%= locals.messages.values && messages.values[0].modalBody %></textarea>
@@ -608,7 +608,7 @@
                 </div>
               </div>
 
-              <div class="form-group row">
+              <div class="mb-3 row">
                 <label class="col-lg-2 col-lg-form-label" for="modalContinueText">Texte continuer * : </label>
                 <div class="col-lg-10">
                   <input id="modalContinueText" type="text" required class="form-control required <%= locals.messages.errors && messages.errors[0].modalContinueText && 'is-invalid' %>" name="modalContinueText" value="<%= locals.messages.values && messages.values[0].modalContinueText %>" placeholder="Texte continuer">
@@ -623,7 +623,7 @@
               </div>
 
 
-              <div class="form-group row">
+              <div class="mb-3 row">
                 <label class="col-lg-2 col-lg-form-label" for="modalMoreInfoLabel">Label lien d'information</label>
                 <div class="col-lg-10">
                   <input id="modalMoreInfoLabel" type="text" class="form-control <%= locals.messages.errors && messages.errors[0].modalMoreInfoLabel && 'is-invalid' %>" name="modalMoreInfoLabel" value="<%= locals.messages.values && messages.values[0].modalMoreInfoLabel %>" placeholder="Label lien d'information">
@@ -638,7 +638,7 @@
               </div>
 
 
-              <div class="form-group row">
+              <div class="mb-3 row">
                 <label class="col-lg-2 col-lg-form-label" for="modalMoreInfoUrl">URL lien d'information</label>
                 <div class="col-lg-10">
                   <input id="modalMoreInfoUrl" type="text" class="form-control <%= locals.messages.errors && messages.errors[0].modalMoreInfoUrl && 'is-invalid' %>" name="modalMoreInfoUrl" value="<%= locals.messages.values && messages.values[0].modalMoreInfoUrl %>" placeholder="https://" pattern="^((https?:\/\/)?((([^\s\/$.?#]{1,})(\.[^\s\/$?#]{2,})*\.[a-z]{2,})|(([0-9]{1,3}\.){3}[0-9]{1,3})|localhost)(:[0-9]{2,5})?(\/[^\s\/$]+)*\/?)$">
@@ -653,7 +653,7 @@
               </div>
             </div>
 
-            <div class="form-group row">
+            <div class="mb-3 row">
               <label class="col-lg-2 col-lg-form-label" for="_totp">Code TOTP</label>
               <div class="col-lg-10">
                 <input id="_totp" type="text" required class="form-control <%= locals.messages.errors && messages.errors[0]._totp && 'is-invalid' %>" name="_totp">

--- a/admin/views/identity-provider/list.ejs
+++ b/admin/views/identity-provider/list.ejs
@@ -77,25 +77,27 @@
             </td>
             <td class="border border-bottom-0 border-top-0 border-end-0 border-secondary"><%= identityProvider.eidas %></td>
             <td class="border border-bottom-0 border-top-0 border-secondary"><%= identityProvider.order %></td>
-            <td class=" d-flex">
+            <td class="border">
               <% if (CURRENT_USER.roles.includes('operator')) { %>
-                <a href="<%= APP_ROOT %>/identity-provider/<%= identityProvider._id %>"
-                  class="d-flex align-items-center mr-2 btn-action-update">
-                  <i class="fa fa-pencil-square-o text-dark" aria-hidden="true"
-                  title="Editer le fournisseur d'identité"></i>
-                </a>
-                <form name="deleteForm" method="POST" id="delete-<%= identityProvider._id %>"
-                  action="<%= APP_ROOT %>/identity-provider/<%= identityProvider._id %>?_method=DELETE"
-                  class="d-flex align-items-center mr-2" data-init="removeItem" data-element-type="le fournisseur d'identité"
-                  data-element-title="<%= identityProvider.title %>" data-element-id="<%= identityProvider._id %>"
-                  novalidate>
-                  <input type="hidden" name="_csrf" value="<%= locals.csrfToken%>">
-                  <input type="hidden" name="_totp">
-                  <input type="hidden" name="name" value="<%= identityProvider.name %>">
-                  <button type="submit" class="btn-action-delete">
-                    <i class="fa fa-trash" aria-hidden="true" title="Supprimer"></i>
-                  </button>
-                </form>
+                <div class="d-inline-flex">
+                  <a href="<%= APP_ROOT %>/identity-provider/<%= identityProvider._id %>"
+                    class="d-flex align-items-center mr-2 btn-action-update btn btn-sm">
+                    <i class="fa fa-pencil-square-o text-dark" aria-hidden="true"
+                    title="Editer le fournisseur d'identité"></i>
+                  </a>
+                  <form name="deleteForm" method="POST" id="delete-<%= identityProvider._id %>"
+                    action="<%= APP_ROOT %>/identity-provider/<%= identityProvider._id %>?_method=DELETE"
+                    class="d-flex align-items-center mr-2" data-init="removeItem" data-element-type="le fournisseur d'identité"
+                    data-element-title="<%= identityProvider.title %>" data-element-id="<%= identityProvider._id %>"
+                    novalidate>
+                    <input type="hidden" name="_csrf" value="<%= locals.csrfToken%>">
+                    <input type="hidden" name="_totp">
+                    <input type="hidden" name="name" value="<%= identityProvider.name %>">
+                    <button type="submit" class="btn-action-delete btn btn-sm">
+                      <i class="fa fa-trash" aria-hidden="true" title="Supprimer"></i>
+                    </button>
+                  </form>
+                </div>
             <% } %>
           </td>
           </tr>

--- a/admin/views/identity-provider/list.ejs
+++ b/admin/views/identity-provider/list.ejs
@@ -23,41 +23,41 @@
       <table class="table table-hover table-light shadow-sm" id="list-table">
         <thead class="thead-light">
         <tr class="align-top">
-          <th scope="col" class="col-3 border-bottom-0 border-top-0 border-right-0 border-secondary">
+          <th scope="col" class="col-3 border-bottom-0 border-top-0 border-end-0 border-secondary">
             <%- include('partials/sort-table', { uri: "/identity-provider", fieldToSortOn: "name", fieldName: "Nom du FI (mire)" }); %>
           </th>
-          <th scope="col" class="col-3 border border-bottom-0 border-top-0 border-right-0 border-secondary">Nom technique</th>
-          <th scope="col" class="col-3 border border-bottom-0 border-top-0 border-right-0 border-secondary">Fqdns</th>
-          <th scope="col" class="col-3 border border-bottom-0 border-top-0 border-right-0 border-secondary">Email de contact</th>
-          <th scope="col" class="col-4 border border-bottom-0 border-top-0 border-right-0 border-secondary">
+          <th scope="col" class="col-3 border border-bottom-0 border-top-0 border-end-0 border-secondary">Nom technique</th>
+          <th scope="col" class="col-3 border border-bottom-0 border-top-0 border-end-0 border-secondary">Fqdns</th>
+          <th scope="col" class="col-3 border border-bottom-0 border-top-0 border-end-0 border-secondary">Email de contact</th>
+          <th scope="col" class="col-4 border border-bottom-0 border-top-0 border-end-0 border-secondary">
             <%- include('partials/sort-table', { uri: "/identity-provider", fieldToSortOn: "active", fieldName: "Activé" }); %>
           </th>
-          <th scope="col" class="col-3 border border-bottom-0 border-top-0 border-right-0 border-secondary">Affiché</th>
-          <th scope="col" class="col-3 border border-bottom-0 border-top-0 border-right-0 border-secondary">Eidas</th>
-          <th scope="col" class="col-3 border border-bottom-0 border-top-0 border-right-0 border-secondary">
+          <th scope="col" class="col-3 border border-bottom-0 border-top-0 border-end-0 border-secondary">Affiché</th>
+          <th scope="col" class="col-3 border border-bottom-0 border-top-0 border-end-0 border-secondary">Eidas</th>
+          <th scope="col" class="col-3 border border-bottom-0 border-top-0 border-end-0 border-secondary">
             <%- include('partials/sort-table', { uri: "/identity-provider", fieldToSortOn: "order", fieldName: "Ordre d'affichage" }); %>
           </th>
-          <th scope="col" class="col-3 border border-bottom-0 border-top-0 border-right-0 border-secondary">Actions</th>
+          <th scope="col" class="col-3 border border-bottom-0 border-top-0 border-end-0 border-secondary">Actions</th>
         </tr>
         </thead>
         <tbody>
         <% identityProviders.forEach(function(identityProvider){ %>
           <tr data-idp-name="<%= identityProvider.name %>" id="<%= identityProvider.uid %>">
-            <th scope="row" class="border-bottom-0 border-top-0 border-right-0 border-secondary">
+            <th scope="row" class="border-bottom-0 border-top-0 border-end-0 border-secondary">
               <% if (CURRENT_USER.roles.includes('operator')) { %>
                 <a id='provider-<%= identityProvider._id %>' class="text-dark" href="<%= APP_ROOT %>/identity-provider/<%= identityProvider._id %>"><%= identityProvider.title %></a>
               <% } else { %>
                 <%= identityProvider.title %>
               <% } %>
             </th>
-            <td class="border border-bottom-0 border-top-0 border-right-0 border-secondary">
+            <td class="border border-bottom-0 border-top-0 border-end-0 border-secondary">
               <% if (CURRENT_USER.roles.includes('operator')) { %>
                 <a id='technic-<%= identityProvider._id %>' class="text-dark" href="<%= APP_ROOT %>/identity-provider/<%= identityProvider._id %>"><%= identityProvider.name %></a>
               <% } else { %>
                 <%= identityProvider.name %>
               <% } %>
             </td>
-            <td class="border border-bottom-0 border-top-0 border-right-0 border-secondary">
+            <td class="border border-bottom-0 border-top-0 border-end-0 border-secondary">
               <% if (identityProvider.fqdns) { %>
                 <a class="text-dark" href="<%= APP_ROOT %>/identity-provider/<%= identityProvider._id %>">
                   <% identityProvider.fqdns.forEach((fqdn) => { %>
@@ -68,14 +68,14 @@
                 </a>
               <% } %>
             </td>
-            <td class="border border-bottom-0 border-top-0 border-right-0 border-secondary"><%= identityProvider.mailto %></td>
-            <td class="text-center border border-bottom-0 border-top-0 border-right-0 border-secondary">
+            <td class="border border-bottom-0 border-top-0 border-end-0 border-secondary"><%= identityProvider.mailto %></td>
+            <td class="text-center border border-bottom-0 border-top-0 border-end-0 border-secondary">
               <i class="fa fa-toggle-<%= identityProvider.active ? "on" : "off" %>"></i>
             </td>
-            <td class="text-center border border-bottom-0 border-top-0 border-right-0 border-secondary">
+            <td class="text-center border border-bottom-0 border-top-0 border-end-0 border-secondary">
               <i class="fa fa-toggle-<%= identityProvider.display ? "on" : "off" %>"></i>
             </td>
-            <td class="border border-bottom-0 border-top-0 border-right-0 border-secondary"><%= identityProvider.eidas %></td>
+            <td class="border border-bottom-0 border-top-0 border-end-0 border-secondary"><%= identityProvider.eidas %></td>
             <td class="border border-bottom-0 border-top-0 border-secondary"><%= identityProvider.order %></td>
             <td class=" d-flex">
               <% if (CURRENT_USER.roles.includes('operator')) { %>

--- a/admin/views/identity-provider/update.ejs
+++ b/admin/views/identity-provider/update.ejs
@@ -17,7 +17,7 @@
         <div class="card-body">
           <form method="POST" action="<%= APP_ROOT %>/identity-provider/<%= id%>?_method=PATCH" data-init="initForm,changeDiscovery,validForm,changeSignature" id="fi-form" name="fi-form" data-select="form" novalidate>
             <input type="hidden" name="_csrf" value="<%= locals.csrfToken  %>">
-            <div class="form-group row">
+            <div class="mb-3 row">
               <label class="col-2 col-form-label" for="name">Nom du FI * : </label>
               <div class="col-10">
                 <input id="name" type="text" required disabled class="form-control <%= locals.messages.errors && messages.errors[0].name && 'is-invalid' %>" name="name_disabled" value="<%= locals.messages.values && messages.values[0].name %>" pattern="<%= VALID_INPUT_STRING_REGEX %>">
@@ -36,7 +36,7 @@
                 </div>
               </div>
             </div>
-            <div class="form-group row">
+            <div class="mb-3 row">
               <label class="col-2 col-form-label" for="title">Titre (tel qu'il apparaîtra aux utilisateurs FC) * : </label>
               <div class="col-10">
                 <input id="title" type="text" required class="form-control <%= locals.messages.errors && messages.errors[0].title && 'is-invalid' %>" name="title" value="<%= locals.messages.values && messages.values[0].title %>" pattern="<%= VALID_INPUT_STRING_REGEX %>">
@@ -55,7 +55,7 @@
               </div>
             </div>
 
-            <div class="form-group row">
+            <div class="mb-3 row">
               <label class="col-2 col-form-label" for="fqdns">Noms de domaines (un fqdn par ligne) :</label>
               <div class="col-10">
                 <textarea id="fqdns" rows="3" name="fqdns" class="form-control <%= locals.messages.errors && messages.errors[0].fqdns && 'is-invalid' %>" pattern="^([\da-z\.-]+)\.([a-z\.]{2,10})$"><%= locals.messages.values && messages.values[0].fqdns instanceof Array ? messages.values[0].fqdns.join('\n') : '' %></textarea>
@@ -74,7 +74,7 @@
               </div>
             </div>
 
-            <div class="form-group row">
+            <div class="mb-3 row">
               <label class="col-2 col-form-label" for="issuer"> Issuer URL * : </label>
               <div class="col-10">
                 <input id="issuer" type="text" required class="form-control <%= locals.messages.errors && messages.errors[0].issuer && 'is-invalid' %>" name="issuer" value="<%= locals.messages.values && messages.values[0].issuer %>" pattern="^((https?:\/\/)?((([^\s\/$.?#]{1,})(\.[^\s\/$?#]{2,})*\.[a-z]{2,})|(([0-9]{1,3}\.){3}[0-9]{1,3})|localhost)(:[0-9]{2,5})?(\/[^\s\/$]+)*\/?)$">
@@ -92,7 +92,7 @@
                 </div>
               </div>
             </div>
-            <div class="form-group row">
+            <div class="mb-3 row">
               <label class="col-2 col-form-label" for="jwksUrl"> JWKS URL <span class=<%= locals.messages.values && messages.values[0].discovery === true ? 'd-none' : '' %>>*</span> : </label>
               <div class="col-10">
                 <input id="jwksUrl" type="text" <%= locals.messages.values && messages.values[0].discovery ? 'disabled' : 'required'%> class="form-control <%= locals.messages.errors && messages.errors[0].jwksUrl && 'is-invalid' %>" name="jwksUrl" value="<%= locals.messages.values && messages.values[0].jwksUrl %>" pattern="^((https?:\/\/)?((([^\s\/$.?#]{1,})(\.[^\s\/$?#]{2,})*\.[a-z]{2,})|(([0-9]{1,3}\.){3}[0-9]{1,3})|localhost)(:[0-9]{2,5})?(\/[^\s\/$]+)*\/?)$">
@@ -111,7 +111,7 @@
               </div>
             </div>
 
-            <div class="form-group row">
+            <div class="mb-3 row">
               <label class="col-2 col-form-label" for="tokenUrl">Token URL <span class=<%= locals.messages.values && messages.values[0].discovery === true ? 'd-none' : '' %>>*</span> :</label>
               <div class="col-10">
                 <input id="tokenUrl" type="text" <%= locals.messages.values && messages.values[0].discovery ? 'disabled' : 'required'%> class="form-control <%= locals.messages.errors && messages.errors[0].tokenUrl && 'is-invalid' %>" name="tokenUrl" value="<%= locals.messages.values && messages.values[0].tokenUrl %>" pattern="^((https?:\/\/)?((([^\s\/$.?#]{1,})(\.[^\s\/$?#]{2,})*\.[a-z]{2,})|(([0-9]{1,3}\.){3}[0-9]{1,3})|localhost)(:[0-9]{2,5})?(\/[^\s\/$]+)*\/?)$">
@@ -129,7 +129,7 @@
                 </div>
               </div>
             </div>
-            <div class="form-group row">
+            <div class="mb-3 row">
               <label class="col-2 col-form-label" for="userInfoUrl">UserInfo URL <span class=<%= locals.messages.values && messages.values[0].discovery === true ? 'd-none' : '' %>>*</span>:</label>
               <div class="col-10">
                 <input id="userInfoUrl" <%= locals.messages.values && messages.values[0].discovery ? 'disabled' : 'required' %> type="text" class="form-control userInfoUrl <%= locals.messages.errors && messages.errors[0].userInfoUrl && 'is-invalid' %>" name="userInfoUrl" value="<%= locals.messages.values && messages.values[0].userInfoUrl %>" pattern="^((https?:\/\/)?((([^\s\/$.?#]{1,})(\.[^\s\/$?#]{2,})*\.[a-z]{2,})|(([0-9]{1,3}\.){3}[0-9]{1,3})|localhost)(:[0-9]{2,5})?(\/[^\s\/$]+)*\/?)$">
@@ -147,7 +147,7 @@
                 </div>
               </div>
             </div>
-            <div class="form-group row">
+            <div class="mb-3 row">
               <label class="col-2 col-form-label" for="authorizationUrl">Authorization URL <span class=<%= locals.messages.values && messages.values[0].discovery === true ? 'd-none' : '' %>>*</span> : </label>
               <div class="col-10">
                 <input id="authorizationUrl" <%= locals.messages.values && messages.values[0].discovery ? 'disabled' : 'required' %> type="text" class="form-control <%= locals.messages.errors && messages.errors[0].authorizationUrl && 'is-invalid' %>" name="authorizationUrl" value="<%= locals.messages.values && messages.values[0].authorizationUrl %>" pattern="^((https?:\/\/)?((([^\s\/$.?#]{1,})(\.[^\s\/$?#]{2,})*\.[a-z]{2,})|(([0-9]{1,3}\.){3}[0-9]{1,3})|localhost)(:[0-9]{2,5})?(\/[^\s\/$]+)*\/?)$">
@@ -165,7 +165,7 @@
                 </div>
               </div>
             </div>
-            <div class="form-group row">
+            <div class="mb-3 row">
               <label class="col-2 col-form-label" for="logoutUrl">Logout URL :</label>
               <div class="col-10">
                 <input id="logoutUrl" type="text" class="form-control <%= locals.messages.errors && messages.errors[0].logoutUrl && 'is-invalid' %>" name="logoutUrl" value="<%= locals.messages.values && messages.values[0].logoutUrl %>" pattern="^((https?:\/\/)?((([^\s\/$.?#]{1,})(\.[^\s\/$?#]{2,})*\.[a-z]{2,})|(([0-9]{1,3}\.){3}[0-9]{1,3})|localhost)(:[0-9]{2,5})?(\/[^\s\/$]+)*\/?)$">
@@ -183,7 +183,7 @@
                 </div>
               </div>
             </div>
-            <div class="form-group row">
+            <div class="mb-3 row">
               <label class="col-2 col-form-label" for="statusUrl">Status URL :</label>
               <div class="col-10">
                 <input id="statusUrl" type="text" class="form-control <%= locals.messages.errors && messages.errors[0].statusUrl && 'is-invalid' %>" name="statusUrl" value="<%= locals.messages.values && messages.values[0].statusUrl %>" pattern="^((https?:\/\/)?((([^\s\/$.?#]{1,})(\.[^\s\/$?#]{2,})*\.[a-z]{2,})|(([0-9]{1,3}\.){3}[0-9]{1,3})|localhost)(:[0-9]{2,5})?(\/[^\s\/$]+)*\/?)$">
@@ -201,20 +201,20 @@
                 </div>
               </div>
             </div>
-            <div class="form-group row">
+            <div class="mb-3 row">
               <label class="col-2 col-form-label">Utiliser la discovery URL : </label>
-              <div class="form-group col-4 d-flex align-items-end">
-                <div class="custom-control custom-radio custom-control-inline">
-                  <input type="radio" class="custom-control-input is-valid is-discovery discovery-radio" id="discovery" name="discovery" value="true" <%= locals.messages.values && messages.values[0].discovery ? 'checked' : '' %>>
-                  <label class="custom-control-label" for="discovery">oui</label>
+              <div class="mb-3 col-4 d-flex align-items-end">
+                <div class="form-check form-check-inline">
+                  <input type="radio" class="form-check-input is-valid is-discovery discovery-radio" id="discovery" name="discovery" value="true" <%= locals.messages.values && messages.values[0].discovery ? 'checked' : '' %>>
+                  <label class="form-check-label" for="discovery">oui</label>
                 </div>
-                <div class="custom-control custom-radio custom-control-inline">
-                  <input type="radio" class="custom-control-input is-valid is-discovery discovery-radio" id="no-discovery" name="discovery" value="false" <%= locals.messages.values && !messages.values[0].discovery ? 'checked' :'' %>>
-                  <label class="custom-control-label" for="no-discovery">non</label>
+                <div class="form-check form-check-inline">
+                  <input type="radio" class="form-check-input is-valid is-discovery discovery-radio" id="no-discovery" name="discovery" value="false" <%= locals.messages.values && !messages.values[0].discovery ? 'checked' :'' %>>
+                  <label class="form-check-label" for="no-discovery">non</label>
                 </div>
               </div>
             </div>
-            <div class="form-group row">
+            <div class="mb-3 row">
               <label class="col-2 col-form-label" for="discoveryUrl">Discovery URL <span class=<%= locals.messages.values && messages.values[0].discovery === false ? 'd-none' : '' %>>*</span> :</label>
               <div class="col-10">
                 <input id="discoveryUrl" <%= messages.values[0].discovery === false ? 'disabled' : 'required' %> type="text" class="form-control <%= locals.messages.errors && messages.errors[0].discoveryUrl && 'is-invalid' %>" name="discoveryUrl" value="<%= locals.messages.values && messages.values[0].discoveryUrl %>" pattern="^((https?:\/\/)?((([^\s\/$.?#]{1,})(\.[^\s\/$?#]{2,})*\.[a-z]{2,})|(([0-9]{1,3}\.){3}[0-9]{1,3})|localhost)(:[0-9]{2,5})?(\/[^\s\/$]+)*\/?)$">
@@ -232,7 +232,7 @@
                 </div>
               </div>
             </div>
-            <div class="form-group row">
+            <div class="mb-3 row">
               <label class="col-2 col-form-label" for="clientId">Client ID * :</label>
               <div class="col-10">
                 <input id="clientId" type="text" required class="form-control <%= locals.messages.errors && messages.errors[0].clientId && 'is-invalid' %>" name="clientId" value="<%= locals.messages.values && messages.values[0].clientId %>">
@@ -250,7 +250,7 @@
                 </div>
               </div>
             </div>
-            <div class="form-group row">
+            <div class="mb-3 row">
               <label class="col-2 col-form-label" for="client_secret">Client Secret * :</label>
               <div class="col-10">
                 <input id="client_secret" type="text" required class="form-control <%= locals.messages.errors && messages.errors[0].client_secret && 'is-invalid' %>" name="client_secret" value="<%= locals.messages.values && messages.values[0].client_secret %>">
@@ -269,7 +269,7 @@
               </div>
             </div>
 
-            <div class="form-group row">
+            <div class="mb-3 row">
               <label class="col-2 col-form-label" for="siret">Siret par défaut :</label>
               <div class="col-10">
                 <input id="siret" type="text" class="form-control <%= locals.messages.errors && messages.errors[0].siret && 'is-invalid' %>" name="siret" value="<%= locals.messages.values && messages.values[0].siret %>">
@@ -288,34 +288,34 @@
               </div>
             </div>
 
-            <div class="form-group row">
+            <div class="mb-3 row">
               <label class="col-2 col-form-label">Sélectionnable dans la mire : </label>
-              <div class="form-group col-4 d-flex align-items-end">
-                <div class="custom-control custom-radio custom-control-inline">
-                  <input type="radio" class="custom-control-input is-valid" id="activated" name="active" value="true" required <%= locals.messages.values && messages.values[0].active === true ? 'checked' : '' %>>
-                  <label class="custom-control-label" for="activated">oui</label>
+              <div class="mb-3 col-4 d-flex align-items-end">
+                <div class="form-check form-check-inline">
+                  <input type="radio" class="form-check-input is-valid" id="activated" name="active" value="true" required <%= locals.messages.values && messages.values[0].active === true ? 'checked' : '' %>>
+                  <label class="form-check-label" for="activated">oui</label>
                 </div>
-                <div class="custom-control custom-radio custom-control-inline">
-                  <input type="radio" class="custom-control-input is-valid" id="unactivated" name="active" value="false" required <%= locals.messages.values && messages.values[0].active === false ? 'checked' : '' %>>
-                  <label class="custom-control-label" for="unactivated">non</label>
+                <div class="form-check form-check-inline">
+                  <input type="radio" class="form-check-input is-valid" id="unactivated" name="active" value="false" required <%= locals.messages.values && messages.values[0].active === false ? 'checked' : '' %>>
+                  <label class="form-check-label" for="unactivated">non</label>
                 </div>
               </div>
               <label class="col-2 col-form-label">Visible dans la mire : </label>
-              <div class="form-group col-4 d-flex align-items-end">
-                <div class="custom-control custom-radio custom-control-inline">
-                  <input type="radio" class="custom-control-input is-valid" id="displayed" name="display" value="true" required <%= locals.messages.values && messages.values[0].display === true ? 'checked' : '' %>>
-                  <label class="custom-control-label" for="displayed">oui</label>
+              <div class="mb-3 col-4 d-flex align-items-end">
+                <div class="form-check form-check-inline">
+                  <input type="radio" class="form-check-input is-valid" id="displayed" name="display" value="true" required <%= locals.messages.values && messages.values[0].display === true ? 'checked' : '' %>>
+                  <label class="form-check-label" for="displayed">oui</label>
                 </div>
-                <div class="custom-control custom-radio custom-control-inline">
-                  <input type="radio" class="custom-control-input is-valid" id="notdisplayed" name="display" value="false" required <%= locals.messages.values && messages.values[0].display === false ? 'checked' : '' %>>
-                  <label class="custom-control-label" for="notdisplayed">non</label>
+                <div class="form-check form-check-inline">
+                  <input type="radio" class="form-check-input is-valid" id="notdisplayed" name="display" value="false" required <%= locals.messages.values && messages.values[0].display === false ? 'checked' : '' %>>
+                  <label class="form-check-label" for="notdisplayed">non</label>
                 </div>
               </div>
             </div>
        
             <input type="hidden" name="isBeta" value="false" />
             
-            <div class="form-group row">
+            <div class="mb-3 row">
               <label class="col-12 col-form-label" for="messageToDisplayWhenInactive">Message à afficher lorsque le FI est désactivé (Disponible prochainement par défaut si aucune saisie) :</label>
               <div class="col-12">
                 <input id="messageToDisplayWhenInactive" type="text" class="form-control" name="messageToDisplayWhenInactive" placeholder="Disponible prochainement" value="<%= locals.messages.values && messages.values[0].messageToDisplayWhenInactive %>">
@@ -333,7 +333,7 @@
                 </div>
               </div>
             </div>
-            <div class="form-group row">
+            <div class="mb-3 row">
               <label class="col-2 col-form-label" for="image">Lien vers lequel rediriger si le FI est désactivé :</label>
               <div class="col-10">
                 <input id="redirectionTargetWhenInactive" type="text" class="form-control <%= locals.messages.errors && messages.errors[0].redirectionTargetWhenInactive && 'is-invalid' %>" name="redirectionTargetWhenInactive" value="<%= locals.messages.values && messages.values[0].redirectionTargetWhenInactive %>">
@@ -351,7 +351,7 @@
                 </div>
               </div>
             </div>
-            <div class="form-group row">
+            <div class="mb-3 row">
               <label class="col-2 col-form-label" for="alt">Valeur de l'attribut HTML "alt" de l'image :</label>
               <div class="col-10">
                 <input id="alt" type="text" class="form-control <%= locals.messages.errors && messages.errors[0].alt && 'is-invalid' %>" name="alt" value="<%= locals.messages.values && messages.values[0].alt %>">
@@ -369,7 +369,7 @@
                 </div>
               </div>
             </div>
-            <div class="form-group row">
+            <div class="mb-3 row">
               <label class="col-2 col-form-label" for="image">Nom de l'image :</label>
               <div class="col-10">
                 <input id="image" type="text" class="form-control <%= locals.messages.errors && messages.errors[0].image && 'is-invalid' %>" name="image" value="<%= locals.messages.values && messages.values[0].image %>">
@@ -387,7 +387,7 @@
                 </div>
               </div>
             </div>
-            <div class="form-group row">
+            <div class="mb-3 row">
               <label class="col-2 col-form-label" for="imageFocus">Nom de l'image utilisée au survol/focus :</label>
               <div class="col-10">
                 <input id="imageFocus" type="text" class="form-control <%= locals.messages.errors && messages.errors[0].imageFocus && 'is-invalid' %>" name="imageFocus" value="<%= locals.messages.values && messages.values[0].imageFocus %>">
@@ -406,21 +406,21 @@
               </div>
             </div>
 
-            <div class="form-group row">
+            <div class="mb-3 row">
               <label class="col-2 col-form-label">Ignorer le niveau eidas : </label>
-              <div class="form-group col-4 d-flex align-items-end">
-                <div class="custom-control custom-radio custom-control-inline">
-                  <input type="radio" class="custom-control-input is-valid" id="trustedIdentity" name="trustedIdentity" value="true" required <%= locals.messages.values && messages.values[0].trustedIdentity === true ? 'checked' : '' %>>
-                  <label class="custom-control-label" for="trustedIdentity">oui</label>
+              <div class="mb-3 col-4 d-flex align-items-end">
+                <div class="form-check form-check-inline">
+                  <input type="radio" class="form-check-input is-valid" id="trustedIdentity" name="trustedIdentity" value="true" required <%= locals.messages.values && messages.values[0].trustedIdentity === true ? 'checked' : '' %>>
+                  <label class="form-check-label" for="trustedIdentity">oui</label>
                 </div>
-                <div class="custom-control custom-radio custom-control-inline">
-                  <input type="radio" class="custom-control-input is-valid" id="not-trustedIdentity" name="trustedIdentity" value="false" required <%= locals.messages.values && messages.values[0].trustedIdentity === false ? 'checked' : '' %>>
-                  <label class="custom-control-label" for="not-trustedIdentity">non</label>
+                <div class="form-check form-check-inline">
+                  <input type="radio" class="form-check-input is-valid" id="not-trustedIdentity" name="trustedIdentity" value="false" required <%= locals.messages.values && messages.values[0].trustedIdentity === false ? 'checked' : '' %>>
+                  <label class="form-check-label" for="not-trustedIdentity">non</label>
                 </div>
               </div>
             </div>
 
-            <div class="form-group row" id="eidas-level">
+            <div class="mb-3 row" id="eidas-level">
               <label class="col-2 col-form-label">Niveaux eidas (v2) : </label>
               <div class="col-10">
                 <% locals.acrList.forEach((acr) => { %>
@@ -433,20 +433,20 @@
             </div>
 
 
-            <div class="form-group row">
+            <div class="mb-3 row">
               <label class="col-2 col-form-label" for="id_token_signed_response_alg">id_token_signed_response_alg * : </label>
               <div class="col-10">
-                <select class="custom-select" name="id_token_signed_response_alg" required>
+                <select class="form-select" name="id_token_signed_response_alg" required>
                   <option value="HS256" <%= (messages.values && messages.values[0].id_token_signed_response_alg === "HS256") ? 'selected' : '' %>>HS256</option>
                   <option value="ES256" <%= messages.values && messages.values[0].id_token_signed_response_alg === "ES256" ? 'selected' : '' %>>ES256</option>
                   <option value="RS256" <%= messages.values && messages.values[0].id_token_signed_response_alg === "RS256" ? 'selected' : '' %>>RS256</option>
                 </select>
               </div>
             </div>
-            <div class="form-group row">
+            <div class="mb-3 row">
               <label class="col-2 col-form-label" for="userinfo_signed_response_alg">userinfo_signed_response_alg * : </label>
               <div class="col-10">
-                <select class="custom-select" name="userinfo_signed_response_alg">
+                <select class="form-select" name="userinfo_signed_response_alg">
                   <option value="" <%= messages.values && messages.values[0].userinfo_signed_response_alg === "" ? 'selected' : '' %>>Aucun</option>
                   <option value="HS256" <%= messages.values && messages.values[0].userinfo_signed_response_alg === "HS256" ? 'selected' : '' %>>HS256</option>
                   <option value="ES256" <%= messages.values && messages.values[0].userinfo_signed_response_alg === "ES256" ? 'selected' : '' %>>ES256</option>
@@ -454,10 +454,10 @@
                 </select>
               </div>
             </div>
-            <div class="form-group row">
+            <div class="mb-3 row">
               <label class="col-2 col-form-label" for="id_token_encrypted_response_alg">id_token_encrypted_response_alg : </label>
               <div class="col-10">
-                <select class="custom-select" name="id_token_encrypted_response_alg">
+                <select class="form-select" name="id_token_encrypted_response_alg">
                   <option value="" <%= !messages.values || messages.values[0].id_token_encrypted_response_alg === "" ? 'selected' : '' %>></option>
                   <option value="ECDH-ES" <%= messages.values && messages.values[0].id_token_encrypted_response_alg === "ECDH-ES" ? 'selected' : '' %>>ECDH-ES</option>
                   <option value="RSA-OAEP" <%= messages.values && messages.values[0].id_token_encrypted_response_alg === "RSA-OAEP" ? 'selected' : '' %>>RSA-OAEP</option>
@@ -465,10 +465,10 @@
                 </select>
               </div>
             </div>
-            <div class="form-group row">
+            <div class="mb-3 row">
               <label class="col-2 col-form-label" for="userinfo_encrypted_response_alg">userinfo_encrypted_response_alg : </label>
               <div class="col-10">
-                <select class="custom-select" name="userinfo_encrypted_response_alg">
+                <select class="form-select" name="userinfo_encrypted_response_alg">
                   <option value="" <%= !messages.values || messages.values[0].userinfo_encrypted_response_alg === "" ? 'selected' : '' %>></option>
                   <option value="ECDH-ES" <%= messages.values && messages.values[0].userinfo_encrypted_response_alg === "ECDH-ES" ? 'selected' : '' %>>ECDH-ES</option>
                   <option value="RSA-OAEP" <%= messages.values && messages.values[0].userinfo_encrypted_response_alg === "RSA-OAEP" ? 'selected' : '' %>>RSA-OAEP</option>
@@ -476,35 +476,35 @@
                 </select>
               </div>
             </div>
-            <div class="form-group row">
+            <div class="mb-3 row">
               <label class="col-2 col-form-label" for="id_token_encrypted_response_enc">id_token_encrypted_response_enc : </label>
               <div class="col-10">
-                <select class="custom-select" name="id_token_encrypted_response_enc">
+                <select class="form-select" name="id_token_encrypted_response_enc">
                   <option value="" <%= !messages.values || messages.values[0].id_token_encrypted_response_enc === "" ? 'selected' : '' %>></option>
                   <option value="A256GCM" <%= messages.values && messages.values[0].id_token_encrypted_response_enc === "A256GCM" ? 'selected' : '' %>>A256GCM</option>
                 </select>
               </div>
             </div>
-            <div class="form-group row">
+            <div class="mb-3 row">
               <label class="col-2 col-form-label" for="userinfo_encrypted_response_enc">userinfo_encrypted_response_enc : </label>
               <div class="col-10">
-                <select class="custom-select" name="userinfo_encrypted_response_enc">
+                <select class="form-select" name="userinfo_encrypted_response_enc">
                   <option value="" <%= !messages.values || messages.values[0].userinfo_encrypted_response_enc === "" ? 'selected' : '' %>></option>
                   <option value="A256GCM" <%= messages.values && messages.values[0].userinfo_encrypted_response_enc === "A256GCM" ? 'selected' : '' %>>A256GCM</option>
                 </select>
               </div>
             </div>
-            <section class="form-group row" id="token_endpoint_auth_method">
+            <section class="mb-3 row" id="token_endpoint_auth_method">
               <label class="col-2 col-form-label">token_endpoint_auth_method : </label>
               <div class="col-10">
-                <select name="token_endpoint_auth_method" class="custom-select">
+                <select name="token_endpoint_auth_method" class="form-select">
                   <option value="client_secret_post" <%= messages.values && messages.values[0].token_endpoint_auth_method === 'client_secret_post' ? 'selected' : '' %>>
                     client_secret_post
                   </option>
                 </select>
               </div>
             </section>
-            <div class="form-group row">
+            <div class="mb-3 row">
               <label class="col-2 col-form-label" for="order">Ordre d'affichage dans la mire :</label>
               <div class="col-10">
                 <input id="order" type="number" class="form-control <%= locals.messages.errors && messages.errors[0].order && 'is-invalid' %>" name="order" value="<%= locals.messages.values && messages.values[0].order %>" placeholder="<%= locals.identityProvidersCount %> FI actuellement enregistrés">
@@ -523,7 +523,7 @@
               </div>
             </div>
 
-            <div class="form-group row">
+            <div class="mb-3 row">
               <label class="col-2 col-form-label" for="supportEmail">Email du support :</label>
               <div class="col-10">
                 <input id="supportEmail" type="email" class="form-control <%= locals.messages.errors && messages.errors[0].supportEmail && 'is-invalid' %>" name="supportEmail" value="<%= locals.messages.values && messages.values[0].supportEmail %>">
@@ -542,7 +542,7 @@
               </div>
             </div>
 
-            <div class="form-group row">
+            <div class="mb-3 row">
               <label class="col-2 col-form-label" for="emails">Email pour l'envoi des statistiques (une adresse mail par ligne) :</label>
               <div class="col-10">
                 <textarea id="emails" rows="3" name="emails" class="form-control <%= locals.messages.errors && messages.errors[0].emails && 'is-invalid' %>" pattern="^([a-zA-Z0-9_\.-]+)@([\da-z\.-]+)\.([a-z\.]{2,10})$"><%= locals.messages.values && messages.values[0].emails instanceof Array ? messages.values[0].emails.join('\n') : '' %></textarea>
@@ -561,14 +561,14 @@
               </div>
             </div>
 
-            <div class="form-group row">
+            <div class="mb-3 row">
               <label class="col-2 col-form-label" for="specificText">Texte pour les erreur E010004, E010006, E010008, E010009, E010015. :</label>
               <div class="col-10">
                 <input id="specificText" type="text" class="form-control <%= locals.messages.errors && messages.errors[0].specificText && 'is-invalid' %>" name="specificText" value="<%= locals.messages.values && messages.values[0].specificText %>">
               </div>
             </div>
 
-            <div class="form-group row">
+            <div class="mb-3 row">
               <label class="col-lg-2 col-lg-form-label" for="_totp">Code TOTP</label>
               <div class="col-lg-10">
                 <input id="_totp" type="text" required class="form-control <%= locals.messages.errors && messages.errors[0]._totp && 'is-invalid' %>" name="_totp">

--- a/admin/views/login.ejs
+++ b/admin/views/login.ejs
@@ -16,9 +16,9 @@
     <% } %>
     <%- include('partials/global-errors-handler.ejs') -%>
     <input type="hidden" name="_csrf" value="<%= locals.csrfToken  %>">
-    <label for="username" class="sr-only">Username</label>
+    <label for="username" class="visually-hidden">Username</label>
     <input type="text" name="username" class="form-control" placeholder="Username" required autofocus="">
-    <label for="password" class="sr-only">Password</label>
+    <label for="password" class="visually-hidden">Password</label>
     <input type="password" name="password" class="form-control" placeholder="Password" required>
     <% if (showTotpField) {%>
     <label class="form-label" for="_totp">Code TOTP</label>

--- a/admin/views/notification/create.ejs
+++ b/admin/views/notification/create.ejs
@@ -11,7 +11,7 @@
       <h2 class="mb-4">Configuration d'une notification FC</h2>
       <form method="post" name="notification" action="<%= APP_ROOT %>/notification/create" data-init="validForm" novalidate>
         <input type="hidden" name="_csrf" value="<%= locals.csrfToken %>">
-        <div class="form-group">
+        <div class="mb-3">
           <label for="message" class="mb-3">Contenu de la notification (200 caractères maximum)</label>
           <textarea class="form-control" 
             name="message" 
@@ -26,14 +26,14 @@
         <div class="row">
           <div class="col-sm my-1">
             <p class="mx-3">Début de la notification</p>
-            <div class="form-inline">
+            <div class="d-flex align-items-center">
               <div class="row">
                   <div class="col-sm">
                       <div class="row">
                         <div class="col-sm">
                           <label for="startDate" class="m-1">Date</label>
                           <input type="date" 
-                            class="form-control mb-2 mr-sm-2" 
+                            class="form-control mb-2 me-sm-2"
                             id="dateDebut" 
                             placeholder="YYYY-MM-DD" 
                             name="startDate"
@@ -44,7 +44,7 @@
                         <div class="col-sm">
                           <label for="startHour" class="m-1"> Heure</label>
                           <input type="time" 
-                            class="form-control mb-2 mr-sm-2" 
+                            class="form-control mb-2 me-sm-2"
                             id="startHour" 
                             placeholder="HH:mm" 
                             name="startHour"
@@ -60,14 +60,14 @@
           </div>
           <div class="col-sm my-1">
             <p class="mx-3">Fin de la notification</p>
-            <div class="form-inline">
+            <div class="d-flex align-items-center">
               <div class="row">
                 <div class="col-sm">
                   <div class="row">
                     <div class="col-sm">
                       <label for="stopDate" class="m-1">Date</label>
                       <input type="date" 
-                        class="form-control mb-2 mr-sm-2" 
+                        class="form-control mb-2 me-sm-2"
                         id="dateFin"
                         placeholder="YYYY-MM-DD"
                         name="stopDate"
@@ -78,7 +78,7 @@
                     <div class="col-sm">
                       <label for="stopHour" class="m-1"> Heure</label>
                       <input type="time" 
-                        class="form-control mb-2 mr-sm-2" 
+                        class="form-control mb-2 me-sm-2"
                         id="stopHour" 
                         placeholder="HH:mm" 
                         name="stopHour"
@@ -97,24 +97,24 @@
         <div class="col-xs-6 my-4">
           <p class="d-flex justify-content-center">Activer la notification</p>
           <div class="d-flex justify-content-center">
-            <div class="custom-control custom-radio custom-control-inline">
+            <div class="form-check form-check-inline">
                 <input type="radio" 
-                  class="custom-control-input is-valid" 
+                  class="form-check-input is-valid" 
                   id="activated" 
                   name="isActive" 
                   value="true"
                   checked 
                   required>
-                <label class="custom-control-label" for="activated">oui</label>
+                <label class="form-check-label" for="activated">oui</label>
               </div>
-              <div class="custom-control custom-radio custom-control-inline">
+              <div class="form-check form-check-inline">
                 <input type="radio" 
-                  class="custom-control-input is-valid" 
+                  class="form-check-input is-valid" 
                   id="unactivated" 
                   name="isActive" 
                   value="false" 
                   required>
-                <label class="custom-control-label" for="unactivated">non</label>
+                <label class="form-check-label" for="unactivated">non</label>
               </div>
           </div>   
         </div>

--- a/admin/views/notification/information.ejs
+++ b/admin/views/notification/information.ejs
@@ -22,18 +22,18 @@
       <table class="table table-hover table-light shadow-sm" id="list-table">
         <thead class="thead-light">
           <tr class="d-flex">
-            <th scope="col" class="col-4 border-bottom-0 border-top-0 border-right-0 border-secondary">Message d'information</th>
-            <th scope="col" class="col-2 border border-bottom-0 border-top-0 border-right-0 border-secondary">Début</th>
-            <th scope="col" class="col-2 border border-bottom-0 border-top-0 border-right-0 border-secondary">Fin</th>
-            <th scope="col" class="col-2 border border-bottom-0 border-top-0 border-right-0 border-secondary">Date de création</th>
-            <th scope="col" class="col-1 border border-bottom-0 border-top-0 border-right-0 border-secondary">Actif</th>
-            <th scope="col" class="col-1 border border-bottom-0 border-top-0 border-right-0 border-secondary">Actions</th>
+            <th scope="col" class="col-4 border-bottom-0 border-top-0 border-end-0 border-secondary">Message d'information</th>
+            <th scope="col" class="col-2 border border-bottom-0 border-top-0 border-end-0 border-secondary">Début</th>
+            <th scope="col" class="col-2 border border-bottom-0 border-top-0 border-end-0 border-secondary">Fin</th>
+            <th scope="col" class="col-2 border border-bottom-0 border-top-0 border-end-0 border-secondary">Date de création</th>
+            <th scope="col" class="col-1 border border-bottom-0 border-top-0 border-end-0 border-secondary">Actif</th>
+            <th scope="col" class="col-1 border border-bottom-0 border-top-0 border-end-0 border-secondary">Actions</th>
           </tr>
         </thead>
         <tbody id="messages">
           <% notifications.forEach(function(notification, index){ %>
             <tr id="line<%= index %>" class="fs d-flex">
-              <td class="col-4 text-truncate border-bottom-0 border-top-0 border-right-0 border-secondary">
+              <td class="col-4 text-truncate border-bottom-0 border-top-0 border-end-0 border-secondary">
                 <% if (CURRENT_USER.roles.includes('operator')) { %>
                   <a href="<%= APP_ROOT %>/notification/<%= notification._id %>"
                     class="text-dark">
@@ -41,7 +41,7 @@
                   </a>
                 <% } %>
               </td>
-              <td class="col-2 text-truncate border border-bottom-0 border-top-0 border-right-0 border-secondary time-client-id">
+              <td class="col-2 text-truncate border border-bottom-0 border-top-0 border-end-0 border-secondary time-client-id">
                 <% if (CURRENT_USER.roles.includes('operator')) { %>
                   <%= notification.startDate && moment(notification.startDate)
                     .locale('fr')
@@ -50,7 +50,7 @@
                   %>
                 <% } %>
               </td>
-              <td class="col-2 text-truncate border border-bottom-0 border-top-0 border-right-0 border-secondary">
+              <td class="col-2 text-truncate border border-bottom-0 border-top-0 border-end-0 border-secondary">
                 <% if (CURRENT_USER.roles.includes('operator')) { %>
                   <%= notification.stopDate && moment(notification.stopDate)
                     .locale('fr')
@@ -68,12 +68,12 @@
                   %>
                 <% } %>
               </td>
-              <td class="col-1 text-truncate border border-bottom-0 border-top-0 border-right-0 border-secondary">
+              <td class="col-1 text-truncate border border-bottom-0 border-top-0 border-end-0 border-secondary">
                 <% if (CURRENT_USER.roles.includes('operator')) { %>
                   <%= notification.isActive ? 'Oui' : 'Non' %>
                 <% } %>
               </td>
-              <td class="col-1 text-truncate border border-bottom-0 border-top-0 border-right-0 border-secondary">
+              <td class="col-1 text-truncate border border-bottom-0 border-top-0 border-end-0 border-secondary">
                 <% if (CURRENT_USER.roles.includes('operator')) { %>
                   <a href="<%= APP_ROOT %>/notification/<%= notification._id %>"
                     class="d-flex align-items-center mr-2 btn-action-update">

--- a/admin/views/notification/update.ejs
+++ b/admin/views/notification/update.ejs
@@ -11,7 +11,7 @@
       <h2 class="mb-4">Modification d'une notification FC</h2>
       <form method="post"name="notification" id="notification" action="<%= APP_ROOT %>/notification/<%= locals.notification.id %>?_method=PATCH" data-init="validForm" novalidate>
         <input type="hidden" name="_csrf" value="<%= locals.csrfToken %>">
-        <div class="form-group">
+        <div class="mb-3">
           <label for="message" class="mb-3">Contenu de la notification (200 caractères maximum)</label>
           <textarea class="form-control" 
             name="message" 
@@ -26,14 +26,14 @@
         <div class="row">
           <div class="col-sm my-1">
             <p class="mx-3">Début de la notification</p>
-            <div class="form-inline">
+            <div class="d-flex align-items-center">
               <div class="row">
                   <div class="col-sm">
                       <div class="row">
                         <div class="col-sm">
                           <label for="dateDebut" class="m-1">Date</label>
                           <input type="date" 
-                            class="form-control mb-2 mr-sm-2" 
+                            class="form-control mb-2 me-sm-2"
                             id="dateDebut" 
                             placeholder="YYYY-MM-DD" 
                             name="startDate"
@@ -44,7 +44,7 @@
                         <div class="col-sm">
                           <label for="startHour" class="m-1"> Heure</label>
                           <input type="time" 
-                            class="form-control mb-2 mr-sm-2" 
+                            class="form-control mb-2 me-sm-2"
                             id="heureDebut" 
                             placeholder="HH:mm" 
                             name="startHour"
@@ -61,14 +61,14 @@
           </div>
           <div class="col-sm my-1">
             <p class="mx-3">Fin de la notification</p>
-            <div class="form-inline">
+            <div class="d-flex align-items-center">
               <div class="row">
                 <div class="col-sm">
                   <div class="row">
                     <div class="col-sm">
                       <label for="dateFin" class="m-1">Date</label>
                       <input type="date" 
-                        class="form-control mb-2 mr-sm-2" 
+                        class="form-control mb-2 me-sm-2"
                         id="dateFin"
                         placeholder="YYYY-MM-DD"
                         name="stopDate"
@@ -79,7 +79,7 @@
                     <div class="col-sm">
                       <label for="stopHour" class="m-1"> Heure</label>
                       <input type="time" 
-                        class="form-control mb-2 mr-sm-2" 
+                        class="form-control mb-2 me-sm-2"
                         id="heureFin" 
                         placeholder="HH:mm" 
                         name="stopHour"
@@ -113,17 +113,17 @@
                 isActive = false;
               }
             %>
-            <div class="custom-control custom-radio custom-control-inline">
-                <input type="radio" class="custom-control-input is-valid" id="activated" name="isActive" value="true"
+            <div class="form-check form-check-inline">
+                <input type="radio" class="form-check-input is-valid" id="activated" name="isActive" value="true"
                   <% if(isActive){ %> checked <% } %>
                   required>
-                <label class="custom-control-label" for="activated">oui</label>
+                <label class="form-check-label" for="activated">oui</label>
               </div>
-              <div class="custom-control custom-radio custom-control-inline">
-                <input type="radio" class="custom-control-input is-valid" id="unactivated" name="isActive" value="false"
+              <div class="form-check form-check-inline">
+                <input type="radio" class="form-check-input is-valid" id="unactivated" name="isActive" value="false"
                   <%if(!isActive){ %> checked <% } %>
                   required>
-                <label class="custom-control-label" for="unactivated">non</label>
+                <label class="form-check-label" for="unactivated">non</label>
               </div>
           </div>   
         </div>

--- a/admin/views/partials/choose-items-number-to-show.ejs
+++ b/admin/views/partials/choose-items-number-to-show.ejs
@@ -1,4 +1,4 @@
-<select id="itemNumberList" class="custom-select-sm custom-select item-number" name="limit">
+<select id="itemNumberList" class="form-select-sm form-select item-number" name="limit">
   <option value="10" <%= limit == '10' ? 'selected' : ''%> ><i>10</i></option>
   <option value="30" <%= limit == '30' ? 'selected' : ''%> ><i>30</i></option>
   <option value="50" <%= limit == '50' ? 'selected' : ''%> ><i>50</i></option>

--- a/admin/views/partials/claims.ejs
+++ b/admin/views/partials/claims.ejs
@@ -1,6 +1,6 @@
-<div class="form-group row">
+<div class="mb-3 row">
   <label class="col-2 col-form-label mt-2">Claims : </label>
-  <div class="form-group m-3 col-md-9">
+  <div class="mb-3 m-3 col-md-9">
     <input type="hidden" name="claims" value="amr" />
     <% locals.claims && locals.claims.forEach(({ name }) => { %>
     <div class="form-check form-check-inline">

--- a/admin/views/partials/dropdownAccount.ejs
+++ b/admin/views/partials/dropdownAccount.ejs
@@ -1,7 +1,7 @@
 <div class="dropdown">
   <a class="dropdown-toggle" data-bs-toggle="dropdown" href="#" role="button" aria-haspopup="true"
      aria-expanded="false"><%= CURRENT_USER.username %></a>
-  <div class="dropdown-menu dropdown-menu-right">
+  <div class="dropdown-menu dropdown-menu-end">
     <a class="dropdown-item" href="<%= APP_ROOT %>/account/me">Mon compte</a>
     <a id="logout-link" class="dropdown-item" href="<%= APP_ROOT %>/logout">Déconnexion</a>
   </div>

--- a/admin/views/partials/header.ejs
+++ b/admin/views/partials/header.ejs
@@ -7,7 +7,7 @@
       Exploitation
     </a>
     <div class="collapse navbar-collapse">
-      <ul class="navbar-nav mr-auto">
+      <ul class="navbar-nav me-auto">
         <% if (locals.CURRENT_USER.roles.includes('operator') || locals.CURRENT_USER.roles.includes('security')) { %>
         <li class="nav-item">
           <a class="nav-link" data-prefix="<%= locals.APP_ROOT %>/service-provider"
@@ -30,9 +30,9 @@
         </li>
       </ul>
       <div class="dropdown">
-        <a class="dropdown-toggle mr-2" data-bs-toggle="dropdown" href="#" role="button" aria-haspopup="true"
+        <a class="dropdown-toggle me-2" data-bs-toggle="dropdown" href="#" role="button" aria-haspopup="true"
           aria-expanded="false"><i class="fa fa-git-square"></i></a>
-        <div class="dropdown-menu dropdown-menu-right p-3 text-muted meta-information-container">
+        <div class="dropdown-menu dropdown-menu-end p-3 text-muted meta-information-container">
           <div class="meta-information">
             <i>Environnement : <%= locals.APP_ENVIRONMENT %></i>
           </div>
@@ -53,9 +53,9 @@
 <% if (messages.success) { %>
 <div class="row">
   <div class="col-10 offset-1 alert alert-success" id="successBanner" role="alert">
-    <button type="button" class="close" data-bs-dismiss="alert" aria-label="Close">
+    <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close">
       <span aria-hidden="true">x<span>
-          <span class="sr-only">Fermer</span>
+          <span class="visually-hidden">Fermer</span>
     </button>
     <%= messages.success[0] %>
   </div>
@@ -65,9 +65,9 @@
 <% if (locals.messages.errors && messages.errors[0]._totp) { %>
 <div class="row">
   <div class="col-10 offset-1 alert alert-danger" role="alert">
-    <button type="button" class="close" data-bs-dismiss="alert" aria-label="Close">
+    <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close">
       <span aria-hidden="true">x<span>
-          <span class="sr-only">Fermer</span>
+          <span class="visually-hidden">Fermer</span>
     </button>
     <% messages.errors[0]._totp.forEach((error) => { %>
       <p> <%= error %></p>

--- a/admin/views/partials/resource-server.ejs
+++ b/admin/views/partials/resource-server.ejs
@@ -1,11 +1,11 @@
-<div class="form-group">
+<div class="mb-3">
     <details>
         <summary id="open-custom-configuration">Section Fournisseur de données</summary>
 
-        <div class="form-group row">
+        <div class="mb-3 row">
             <label class="col-2 col-form-label" for="introspection_signed_response_alg">introspection_signed_response_alg : </label>
             <div class="col-10">
-                <select class="custom-select" name="introspection_signed_response_alg">
+                <select class="form-select" name="introspection_signed_response_alg">
                     <option value="" <%= !messages.values || messages.values[0].introspection_signed_response_alg === null ? 'selected' : '' %>>[VIDE] - config FS par défaut</option>
                     <option value="HS256" <%= messages.values && messages.values[0].introspection_signed_response_alg === "HS256" ? 'selected' : '' %>>HS256 - config FD par défaut</option>
                     <option value="ES256" <%= messages.values && messages.values[0].introspection_signed_response_alg === "ES256" ? 'selected' : '' %>>ES256 - config FD</option>
@@ -14,10 +14,10 @@
             </div>
         </div>
 
-        <div class="form-group row">
+        <div class="mb-3 row">
             <label class="col-2 col-form-label" for="introspection_encrypted_response_alg">introspection_encrypted_response_alg :</label>
             <div class="col-10">
-                <select class="custom-select" name="introspection_encrypted_response_alg">
+                <select class="form-select" name="introspection_encrypted_response_alg">
                     <option value="" <%= !messages.values || messages.values[0].introspection_encrypted_response_alg === null ? 'selected' : '' %>>[VIDE] - config FS par défaut</option>
                     <option value="ECDH-ES" <%= messages.values && messages.values[0].introspection_encrypted_response_alg === "ECDH-ES" ? 'selected' : '' %>>ECDH-ES - config FD par défaut</option>
                     <option value="RSA-OAEP" <%= messages.values && messages.values[0].introspection_encrypted_response_alg === "RSA-OAEP" ? 'selected' : '' %>>RSA-OAEP - config FD</option>
@@ -25,17 +25,17 @@
             </div>
         </div>
 
-        <div class="form-group row">
+        <div class="mb-3 row">
             <label class="col-2 col-form-label" for="introspection_encrypted_response_enc">introspection_encrypted_response_enc : </label>
             <div class="col-10">
-                <select class="custom-select" name="introspection_encrypted_response_enc">
+                <select class="form-select" name="introspection_encrypted_response_enc">
                     <option value="" <%= !messages.values || messages.values[0].introspection_encrypted_response_enc === null ? 'selected' : '' %>>[VIDE] - config FS par défaut</option>
                     <option value="A256GCM" <%= messages.values && messages.values[0].introspection_encrypted_response_enc === "A256GCM" ? 'selected' : '' %>>A256GCM - config FD par défaut</option>
                 </select>
             </div>
         </div>
 
-        <div class="form-group row">
+        <div class="mb-3 row">
             <label class="col-2 col-form-label" for="response_types">response_types :</label>
             <div class="col-10">
                 <textarea id="response_types" class="form-control" name="response_types" pattern=".*"><%= locals.messages.values && messages.values[0].response_types %></textarea>
@@ -49,7 +49,7 @@
             </div>
         </div>
 
-        <div class="form-group row">
+        <div class="mb-3 row">
             <label class="col-2 col-form-label" for="grant_types">grant_types :</label>
             <div class="col-10">
                 <textarea id="grant_types" class="form-control" name="grant_types" pattern=".*"><%= locals.messages.values && messages.values[0].grant_types %></textarea>
@@ -63,7 +63,7 @@
             </div>
         </div>
 
-        <div class="form-group row">
+        <div class="mb-3 row">
             <label class="col-2 col-form-label" for="jwks_uri">jwks_uri :</label>
             <div class="col-10">
                 <input id="jwks_uri" type="text" class="form-control <%= locals.messages.errors && messages.errors[0].jwks_uri && 'is-invalid' %>" name="jwks_uri" value="<%= locals.messages.values && messages.values[0].jwks_uri %>">

--- a/admin/views/partials/scopes.ejs
+++ b/admin/views/partials/scopes.ejs
@@ -1,6 +1,6 @@
-<div class="form-group row">
+<div class="mb-3 row">
   <label class="col-2 col-form-label mt-2">Scopes : </label>
-  <div class="form-group m-3 col-md-9">
+  <div class="mb-3 m-3 col-md-9">
     <% if (!locals.messages.values[0].scopes ||
     locals.messages.values[0].scopes.length === 0) { %>
     <p class="text-danger">

--- a/admin/views/partials/search.ejs
+++ b/admin/views/partials/search.ejs
@@ -1,6 +1,6 @@
 <div class=" float-end">
   <form class="d-flex align-items-center" id="search-form" data-init="validForm" method="GET" novalidate>
-    <div class="mb-3 mx-sm-2 mb-2">
+    <div class="mb-3 mx-sm-2">
       <label for="search" class="visually-hidden">Search</label>
       <input type="text"
       value="<%= userSearch %>"
@@ -14,7 +14,7 @@
       autofocus
       required>
     </div>
-    <button type="submit" id="searchBtn" class="btn btn-primary mb-2 p-1">Rechercher</button>
+    <button type="submit" id="searchBtn" class="btn btn-primary mb-3 p-1">Rechercher</button>
   </form>
 </div>
  

--- a/admin/views/partials/search.ejs
+++ b/admin/views/partials/search.ejs
@@ -1,7 +1,7 @@
-<div class=" float-right">
-  <form class="form-inline" id="search-form" data-init="validForm" method="GET" novalidate>
-    <div class="form-group mx-sm-2 mb-2">
-      <label for="search" class="sr-only">Search</label>
+<div class=" float-end">
+  <form class="d-flex align-items-center" id="search-form" data-init="validForm" method="GET" novalidate>
+    <div class="mb-3 mx-sm-2 mb-2">
+      <label for="search" class="visually-hidden">Search</label>
       <input type="text"
       value="<%= userSearch %>"
       name="search"

--- a/admin/views/scopes/claim/form.ejs
+++ b/admin/views/scopes/claim/form.ejs
@@ -23,7 +23,7 @@
             action="<%= APP_ROOT %><%= (locals.action && locals.action === 'creation') ? '/scopes/claim/create' : `/scopes/claim/update/${id}?_method=PATCH` %>"
             novalidate
           >
-            <div class="form-group row mt-4">
+            <div class="mb-3 row mt-4">
               <label class="col-2 col-form-label" for="claim">Claim*</label>
               <div class="col-10">
                 <input
@@ -38,7 +38,7 @@
                 />
               </div>
             </div>
-            <div class="form-group row">
+            <div class="mb-3 row">
               <label class="col-2" for="confirm-2FAuthentication"
                 >Code TOTP</label
               >

--- a/admin/views/scopes/label/creation.ejs
+++ b/admin/views/scopes/label/creation.ejs
@@ -21,7 +21,7 @@
             action="<%= APP_ROOT %>/scopes/label/create"
             novalidate
           >
-            <div class="form-group row mt-4">
+            <div class="mb-3 row mt-4">
               <label class="col-2 col-form-label" for="scope">Scope*</label>
               <div class="col-10">
                 <input
@@ -35,7 +35,7 @@
                 />
               </div>
             </div>
-            <div class="form-group row">
+            <div class="mb-3 row">
               <label class="col-2 col-form-label" for="exampleInputEmail1"
                 >Label*</label
               >
@@ -51,14 +51,14 @@
                 />
               </div>
             </div>
-            <div class="form-group row">
+            <div class="mb-3 row">
               <label class="col-2 col-form-label" for="fd"
                 >Fournisseur de données*</label
               >
               <div class="col-10">
                 <select
                   id="fd"
-                  class="custom-select-sm custom-select item-number"
+                  class="form-select-sm form-select item-number"
                   name="fd"
                   required
                 >
@@ -69,7 +69,7 @@
                 </select>
               </div>
             </div>
-            <div class="form-group row">
+            <div class="mb-3 row">
               <label class="col-2" for="confirm-2FAuthentication"
                 >Code TOTP</label
               >

--- a/admin/views/scopes/label/update.ejs
+++ b/admin/views/scopes/label/update.ejs
@@ -19,7 +19,7 @@
           name="scope-labels-form" 
           action="<%= APP_ROOT %>/scopes/label/update/<%= id%>?_method=PATCH" 
           novalidate>
-            <div class="form-group row mt-4">
+            <div class="mb-3 row mt-4">
               <label class="col-2 col-form-label" for="scope">Scope*</label>
               <div class="col-10">
                 <input type="text" 
@@ -32,7 +32,7 @@
                 required readonly>
               </div>
             </div>
-            <div class="form-group row">
+            <div class="mb-3 row">
                 <label class="col-2 col-form-label" for="exampleInputEmail1">Label*</label>
                 <div class="col-10">
                   <input type="text" 
@@ -45,11 +45,11 @@
                     required>
                 </div>
             </div>
-            <div class="form-group row">
+            <div class="mb-3 row">
               <label class="col-2 col-form-label" for="fd">Fournisseur de données*</label>
               <div class="col-10">
                 <select id="fd" 
-                  class="custom-select-sm custom-select item-number" 
+                  class="form-select-sm form-select item-number" 
                   name="fd"
                   style="width:15%;"
                   required>
@@ -60,7 +60,7 @@
                 </select>
               </div>
             </div>
-            <div class="form-group row">
+            <div class="mb-3 row">
               <label class="my-2" for="confirm-2FAuthentication">Code TOTP</label>
               <div class="col-lg-10">
                 <input id="_totp" 

--- a/admin/views/service-provider/creation.ejs
+++ b/admin/views/service-provider/creation.ejs
@@ -16,7 +16,7 @@
         <label class="btn btn-primary">
           Importer un CSV <input type="file" data-init="csvParser" name="csv-input" accept="text/csv" hidden>
         </label>
-        <label id="file-name" class="font-weight-bold p-2"></label>
+        <label id="file-name" class="fw-bold p-2"></label>
       </div>
       <div class="card col-12" style="margin-bottom:4em;" id="form-card">
         <%- include('partials/global-errors-handler.ejs') -%>
@@ -24,7 +24,7 @@
 
           <form method="POST" data-init="validForm" id="fs-form" name="fs-form" data-select="form" novalidate>
 
-            <section class="form-group row">
+            <section class="mb-3 row">
               <label class="col-2 col-form-label" for="name">Nom du fournisseur de service (mire) : </label>
               <div class="col-10">
                 <input id="name" type="text" required class="form-control <%= locals.messages.errors && messages.errors[0].name && 'is-invalid' %>" placeholder="Nom du fournisseur de service" name="name" value="<%= locals.messages.values && messages.values[0].name %>" pattern="<%= VALID_INPUT_STRING_REGEX %>">
@@ -43,7 +43,7 @@
               </div>
             </section>
 
-            <section class="form-group row">
+            <section class="mb-3 row">
               <label class="col-2 col-form-label" for="redirectUri">URL de redirection de connexion : </label>
               <div class="col-10">
                 <textarea id="redirect_uris" class="form-control <%= locals.messages.errors && messages.errors[0].redirectUri && 'is-invalid' %>" placeholder="https://url-de-redirection.com" name="redirectUri" pattern="^(?:((https?:\/\/)?((([^\s\/$.?#]{1,})(\.[^\s\/$?#]{2,})*\.[a-z]{2,})|(([0-9]{1,3}\.){3}[0-9]{1,3})|(([A-Za-z0-9\.\+-]{6,}):(?:\/\/)?(?:[\-;:&=\+\$,\w]+@)?[A-Za-z0-9\.\-_]+)|localhost)(:[0-9]{2,5})?(\/[^\s\/$]+)*\/?)?)$"><%= locals.messages.values && messages.values[0].redirectUri %></textarea>
@@ -61,7 +61,7 @@
                 </div>
               </div>
             </section>
-            <section class="form-group row">
+            <section class="mb-3 row">
               <label class="col-2 col-form-label" for="redirectUriLogout">URL de redirection de déconnexion : </label>
               <div class="col-10">
                 <textarea id="post_logout_redirect_uris" class="form-control <%= locals.messages.errors && messages.errors[0].redirectUriLogout && 'is-invalid' %>" name="redirectUriLogout" placeholder="https://url-de-redirection.com/deconnexion" pattern="^(?:((https?:\/\/)?((([^\s\/$.?#]{1,})(\.[^\s\/$?#]{2,})*\.[a-z]{2,})|(([0-9]{1,3}\.){3}[0-9]{1,3})|(([A-Za-z0-9\.\+-]{6,}):(?:\/\/)?(?:[\-;:&=\+\$,\w]+@)?[A-Za-z0-9\.\-_]+)|localhost)(:[0-9]{2,5})?(\/[^\s\/$]+)*\/?)?)$"><%= locals.messages.values && messages.values[0].redirectUriLogout %></textarea>
@@ -79,7 +79,7 @@
                 </div>
               </div>
             </section>
-            <section class="form-group row">
+            <section class="mb-3 row">
               <label class="col-2 col-form-label" for="site">Site : </label>
               <div class="col-10">
                 <textarea id="site" required class="form-control <%= locals.messages.errors && messages.errors[0].site && 'is-invalid' %>" placeholder="https://monsite.com" name="site" pattern="^(?:((https?:\/\/)?((([^\s\/$.?#]{1,})(\.[^\s\/$?#]{2,})*\.[a-z]{2,})|(([0-9]{1,3}\.){3}[0-9]{1,3})|localhost)(:[0-9]{2,5})?(\/[^\s\/$]+)*\/?))?$"><%= locals.messages.values && messages.values[0].site %></textarea>
@@ -98,7 +98,7 @@
               </div>
             </section>
 
-            <section class="form-group row">
+            <section class="mb-3 row">
               <label class="col-2 col-form-label" for="emails">Email(s) de contact (un par ligne)</label>
               <div class="col-10">
                 <textarea id="emails" class="form-control <%= locals.messages.errors && messages.errors[0].emails && 'is-invalid' %>" placeholder="email@email.com" name="emails" pattern="^$|^([a-zA-Z0-9_\.-]+)@([\da-z\.-]+)\.([a-z\.]{2,10})$"><%= locals.messages.values && messages.values[0].emails instanceof Array ? messages.values[0].emails.join('\n') : '' %></textarea>
@@ -116,7 +116,7 @@
                 </div>
               </div>
             </section>
-            <section class="form-group row">
+            <section class="mb-3 row">
               <label class="col-2 col-form-label" for="ipAddresses">Plages d'adresses IP (une par ligne)</label>
               <div class="col-10">
                 <textarea id="IPServerAddressesAndRanges" class="form-control <%= locals.messages.errors && messages.errors[0].ipAddresses && 'is-invalid' %>" placeholder="1.1.1.1" name="ipAddresses" pattern="<%= IP_VALIDATOR_REGEX %>"><%= locals.messages.values && messages.values[0].ipAddresses %></textarea>
@@ -134,9 +134,9 @@
                 </div>
               </div>
             </section>
-            <section class="form-group row">
+            <section class="mb-3 row">
               <label class="col-2 col-form-label mt-2">Scopes : </label>
-              <div class="form-group m-3 col-md-9">
+              <div class="mb-3 m-3 col-md-9">
                 <div class="form-check form-check-inline">
                   <input type="hidden" name="scopes" value="openid" />
                   <input type="checkbox" class="form-check-input" id="scope-openid" name="scopes" checked disabled />
@@ -161,48 +161,48 @@
 
             <%- include('partials/claims.ejs') -%>
 
-            <section class="form-group row">
+            <section class="mb-3 row">
               <label class="col-2 col-form-label">Activé : </label>
-              <div class="form-group col-4 d-flex align-items-end">
-                <div class="custom-control custom-radio custom-control-inline">
-                  <input type="radio" class="custom-control-input is-valid" id="activated" name="active" value="true" checked required>
-                  <label class="custom-control-label" for="activated">oui</label>
+              <div class="mb-3 col-4 d-flex align-items-end">
+                <div class="form-check form-check-inline">
+                  <input type="radio" class="form-check-input is-valid" id="activated" name="active" value="true" checked required>
+                  <label class="form-check-label" for="activated">oui</label>
                 </div>
-                <div class="custom-control custom-radio custom-control-inline">
-                  <input type="radio" class="custom-control-input is-valid" id="unactivated" name="active" value="false" required>
-                  <label class="custom-control-label" for="unactivated">non</label>
+                <div class="form-check form-check-inline">
+                  <input type="radio" class="form-check-input is-valid" id="unactivated" name="active" value="false" required>
+                  <label class="form-check-label" for="unactivated">non</label>
                 </div>
               </div>
             </section>
 
-            <section class="form-group row">
+            <section class="mb-3 row">
               <label class="col-2 col-form-label">Accepte les employé.e.s d'organisme privé" : </label>
-              <div class="form-group col-4 d-flex align-items-end">
-                <div class="custom-control custom-radio custom-control-inline">
-                  <input type="radio" class="custom-control-input is-consent-required <%= locals.messages.errors && messages.errors[0].type && 'is-invalid' %>" id="public" name="type" value="public" checked required>
-                  <label class="custom-control-label" for="public">non</label>
+              <div class="mb-3 col-4 d-flex align-items-end">
+                <div class="form-check form-check-inline">
+                  <input type="radio" class="form-check-input is-consent-required <%= locals.messages.errors && messages.errors[0].type && 'is-invalid' %>" id="public" name="type" value="public" checked required>
+                  <label class="form-check-label" for="public">non</label>
                 </div>
-                <div class="custom-control custom-radio custom-control-inline">
-                  <input type="radio" class="custom-control-input is-consent-required <%= locals.messages.errors && messages.errors[0].type && 'is-invalid' %>" id="private" name="type" value="private" required>
-                  <label class="custom-control-label" for="private">oui</label>
+                <div class="form-check form-check-inline">
+                  <input type="radio" class="form-check-input is-consent-required <%= locals.messages.errors && messages.errors[0].type && 'is-invalid' %>" id="private" name="type" value="private" required>
+                  <label class="form-check-label" for="private">oui</label>
                 </div>
               </div>
             </section>
 
-            <div class="form-group row">
+            <div class="mb-3 row">
               <label class="col-2 col-form-label" for="id_token_signed_response_alg">id_token_signed_response_alg : </label>
               <div class="col-10">
-                <select class="custom-select" name="id_token_signed_response_alg" required>
+                <select class="form-select" name="id_token_signed_response_alg" required>
                   <option value="HS256" <%= messages.values && messages.values[0].id_token_signed_response_alg === "HS256" ? 'selected' : '' %>>HS256</option>
                   <option value="ES256" <%= messages.values && messages.values[0].id_token_signed_response_alg === "ES256" ? 'selected' : '' %>>ES256</option>
                   <option value="RS256" <%= messages.values && messages.values[0].id_token_signed_response_alg === "RS256" ? 'selected' : '' %>>RS256</option>
                 </select>
               </div>
             </div>
-            <div class="form-group row">
+            <div class="mb-3 row">
               <label class="col-2 col-form-label" for="userinfo_signed_response_alg">userinfo_signed_response_alg * : </label>
               <div class="col-10">
-                <select class="custom-select" name="userinfo_signed_response_alg">
+                <select class="form-select" name="userinfo_signed_response_alg">
                   <option value="" <%= messages.values && messages.values[0].userinfo_signed_response_alg === "" ? 'selected' : '' %>>Aucun</option>
                   <option value="HS256" <%= messages.values && messages.values[0].userinfo_signed_response_alg === "HS256" ? 'selected' : '' %>>HS256</option>
                   <option value="ES256" <%= messages.values && messages.values[0].userinfo_signed_response_alg === "ES256" ? 'selected' : '' %>>ES256</option>
@@ -214,7 +214,7 @@
               </div>
             </div>
 
-            <section class="form-group row">
+            <section class="mb-3 row">
               <label class="col-2 col-form-label" for="entityId">Id d'entité : </label>
               <div class="col-10">
                 <input id="entityId" name="entityId" type="text" class="form-control <%= locals.messages.errors && messages.errors[0].entityId && 'is-invalid' %>" value="<%= locals.messages.values && messages.values[0].entityId %>" pattern="^[a-zA-Z0-9]{1}[a-zA-Z0-9\-]{31,}$">
@@ -235,7 +235,7 @@
 
             <%- include('partials/resource-server.ejs') -%>
 
-            <section class="form-group row">
+            <section class="mb-3 row">
               <label class="col-2 col-form-label" for="confirm-2FAuthentication">Code TOTP</label>
               <div class="col-10">
                 <input id="_totp" type="text" required value="" placeholder="123456" class="form-control <%= locals.messages.errors && messages.errors[0]._totp && 'is-invalid' %>" name="_totp">

--- a/admin/views/service-provider/creation.ejs
+++ b/admin/views/service-provider/creation.ejs
@@ -176,7 +176,7 @@
             </section>
 
             <section class="mb-3 row">
-              <label class="col-2 col-form-label">Accepte les employé.e.s d'organisme privé" : </label>
+              <label class="col-2 col-form-label">Accepte les employé·e·s d'organisme privé" : </label>
               <div class="mb-3 col-4 d-flex align-items-end">
                 <div class="form-check form-check-inline">
                   <input type="radio" class="form-check-input is-consent-required <%= locals.messages.errors && messages.errors[0].type && 'is-invalid' %>" id="public" name="type" value="public" checked required>

--- a/admin/views/service-provider/generate-new-client-secret.ejs
+++ b/admin/views/service-provider/generate-new-client-secret.ejs
@@ -20,28 +20,28 @@
             data-element-title="<%=  messages.values && messages.values[0].name %>" id="fs-form" name="fs-form" novalidate>
 
             <% if (locals.messages.values && messages.values[0].secretUpdatedAt) { %>
-              <div class="form-group row">
-                  <label class="col-12 col-form-label mt-3 font-italic font-weight-bold " for="information">
+              <div class="mb-3 row">
+                  <label class="col-12 col-form-label mt-3 fst-italic fw-bold " for="information">
                       Le client secret a été généré  le <%= locals.messages.values && moment(messages.values[0].secretUpdatedAt).format('YYYY-MM-DD') %> 
                     à <%= locals.messages.values && moment(messages.values[0].secretUpdatedAt).format('HH:mm:ss') %>
                     par <%= locals.messages.values && messages.values[0].secretUpdatedBy %>
                   </label>
                 </div>
               <% } %>
-            <div class="form-group row">
+            <div class="mb-3 row">
               <label class="col-2 col-form-label" for="name">Nom du fournisseur de service (mire) : </label>
               <input type="text" readonly  name="name" class="form-control-plaintext col-10" id="name" value="<%= locals.messages.values && messages.values[0].name %>">
             </div>
-            <div class="form-group row">
+            <div class="mb-3 row">
               <label class="col-2 col-form-label" for="key">Client ID : </label>
               <input type="text" readonly name="key" class="form-control-plaintext col-10" id="key" value="<%= locals.messages.values && messages.values[0].key %>">
             </div>
-            <div class="form-group row">
+            <div class="mb-3 row">
               <label class="col-2 col-form-label" for="client_secret">Client secret actuel : </label>
               <input type="text" name="client_secret" readonly class="form-control-plaintext col-10 " id="client_secret" value="<%= locals.messages.values && messages.values[0].client_secret %>">
             </div>
            
-            <div class="form-group row">
+            <div class="mb-3 row">
               <label class="col-2 col-form-label" for="client_secret">TOTP : </label>
               <div class="col-10 mt-1">
                 <input class="form-control <%= locals.messages.errors && messages.errors[0]._totp && 'is-invalid' %>"

--- a/admin/views/service-provider/list.ejs
+++ b/admin/views/service-provider/list.ejs
@@ -25,7 +25,7 @@
         <% } %>
         <%- include('partials/search', {userSearch: querySearch}); %>
         <% if (CURRENT_USER.roles.includes('operator')) { %>
-        <div id="delete-button" class="ml-2">
+        <div id="delete-button" class="ms-2">
           <input id="csrf" type="hidden" name="_csrf" value="<%= locals.csrfToken  %>">
           <input id="app" type="hidden" name="_app" value="<%= APP_ROOT %>">
           <button id="submit-action" class="btn btn-danger" data-init="submitDeletion" type="button">Supprimer</button>
@@ -40,29 +40,29 @@
           <thead class="thead-light">
 
             <tr class="d-flex">
-              <th scope="col" class="col-3 border-bottom-0 border-top-0 border-right-0 border-secondary">
+              <th scope="col" class="col-3 border-bottom-0 border-top-0 border-end-0 border-secondary">
                 <%- include('partials/sort-table', { uri: "/service-provider", fieldToSortOn: "name", fieldName: "Nom du service (mire)" }); %>
               </th>
-              <th scope="col" class="col-3 border border-bottom-0 border-top-0 border-right-0 border-secondary">Client ID</th>
-              <th scope="col" class="col-2 border border-bottom-0 border-top-0 border-right-0 border-secondary">
+              <th scope="col" class="col-3 border border-bottom-0 border-top-0 border-end-0 border-secondary">Client ID</th>
+              <th scope="col" class="col-2 border border-bottom-0 border-top-0 border-end-0 border-secondary">
                 <%- include('partials/sort-table', { uri: "/service-provider", fieldToSortOn: "createdAt", fieldName: "Date de création de la clé de production" }); %>
               </th>
-              <th scope="col" class="col-2 border border-bottom-0 border-top-0 border-right-0 border-secondary">
+              <th scope="col" class="col-2 border border-bottom-0 border-top-0 border-end-0 border-secondary">
                 <%- include('partials/sort-table', { uri: "/service-provider", fieldToSortOn: "secretUpdatedAt", fieldName: "Date de génération du secret" }); %>
               </th>
-              <th scope="col" class="col-1 border border-bottom-0 border-top-0 border-right-0 border-secondary">
+              <th scope="col" class="col-1 border border-bottom-0 border-top-0 border-end-0 border-secondary">
                 <%- include('partials/sort-table', { uri: "/service-provider", fieldToSortOn: "active", fieldName: "Activé" }); %>
               </th>
-              <th scope="col" class="col-1 border border-bottom-0 border-top-0 border-right-0 border-secondary">Actions</th>
+              <th scope="col" class="col-1 border border-bottom-0 border-top-0 border-end-0 border-secondary">Actions</th>
             </tr>
           </thead>
           <tbody>
             <% serviceProviders.forEach(function(serviceProvider, index){ %>
             <tr class="fs d-flex">
               <th scope="row"
-                class="col-3 text-truncate d-inline-flex border-bottom-0 border-top-0 border-right-0 border-secondary">
+                class="col-3 text-truncate d-inline-flex border-bottom-0 border-top-0 border-end-0 border-secondary">
                 <% if (CURRENT_USER.roles.includes('operator')) { %>
-                <div id="multiple-delete-<%= serviceProvider.id %>" class="d-flex align-items-center mr-2">
+                <div id="multiple-delete-<%= serviceProvider.id %>" class="d-flex align-items-center mr-2 form-check-inline">
                   <input data-init="displayRemoveButtonEvent" data-element-title="<%= serviceProvider.name %>" class="delete-items"
                     type="checkbox" name="deleteItems" value="<%= serviceProvider._id %>" />
                 </div>
@@ -73,7 +73,7 @@
                   <%= serviceProvider.name %>
                 <% } %>
               </th>
-              <td class="col-3 text-truncate border border-bottom-0 border-top-0 border-right-0 border-secondary"
+              <td class="col-3 text-truncate border border-bottom-0 border-top-0 border-end-0 border-secondary"
                 title="<%= serviceProvider.key %>">
                 <% if (CURRENT_USER.roles.includes('operator')) { %>
                   <a id='key-<%= serviceProvider.key %>' class="key text-dark" href="<%= APP_ROOT %>/service-provider/update/<%= serviceProvider._id %>/secret"><%= serviceProvider.key %></a>
@@ -81,15 +81,15 @@
                   <%= serviceProvider.key %>
                 <% } %>
               </td>
-              <td class="col-2 d-inline-flex d-flex justify-content-center time-client-id border border-bottom-0 border-top-0 border-right-0 border-secondary"><%= serviceProvider.createdAt && moment(new Date(serviceProvider.createdAt)).format('DD/MM/YYYY') %></td>
-              <td class="col-2 d-inline-flex d-flex justify-content-center time-secret border border-bottom-0 border-top-0 border-right-0 border-secondary"><%= serviceProvider.secretUpdatedAt && moment(new Date(serviceProvider.secretUpdatedAt)).format('DD/MM/YYYY') %></td>
+              <td class="col-2 d-inline-flex d-flex justify-content-center time-client-id border border-bottom-0 border-top-0 border-end-0 border-secondary"><%= serviceProvider.createdAt && moment(new Date(serviceProvider.createdAt)).format('DD/MM/YYYY') %></td>
+              <td class="col-2 d-inline-flex d-flex justify-content-center time-secret border border-bottom-0 border-top-0 border-end-0 border-secondary"><%= serviceProvider.secretUpdatedAt && moment(new Date(serviceProvider.secretUpdatedAt)).format('DD/MM/YYYY') %></td>
 
-              <td class="text-center col-1 border border-bottom-0 border-top-0 border-right-0 border-secondary">
+              <td class="text-center col-1 border border-bottom-0 border-top-0 border-end-0 border-secondary">
                 <i class="fa fa-toggle-<%= serviceProvider.active ? 'on' : 'off' %>"></i>
               </td>
 
               <td
-                class="col-1 d-inline-flex d-flex justify-content-center quick-action border border-bottom-0 border-top-0 border-right-0 border-secondary">
+                class="col-1 d-inline-flex d-flex justify-content-center quick-action border border-bottom-0 border-top-0 border-end-0 border-secondary">
                 <% if (CURRENT_USER.roles.includes('operator')) { %>
                 <a href="<%= APP_ROOT %>/service-provider/<%= serviceProvider._id %>"
                   class="d-flex align-items-center mr-2 btn-action-update">

--- a/admin/views/service-provider/list.ejs
+++ b/admin/views/service-provider/list.ejs
@@ -92,12 +92,12 @@
                 class="col-1 d-inline-flex d-flex justify-content-center quick-action border border-bottom-0 border-top-0 border-end-0 border-secondary">
                 <% if (CURRENT_USER.roles.includes('operator')) { %>
                 <a href="<%= APP_ROOT %>/service-provider/<%= serviceProvider._id %>"
-                  class="d-flex align-items-center mr-2 btn-action-update">
+                  class="d-flex align-items-center mr-2 btn-action-update btn btn-sm">
                   <i class="fa fa-pencil-square-o text-dark" aria-hidden="true"
                     title="Editer le fournisseur de services"></i>
                 </a>
                 <a href="<%= APP_ROOT %>/service-provider/update/<%= serviceProvider._id %>/secret"
-                  class="d-flex align-items-center mr-2 btn-action-generate-client-secret">
+                  class="d-flex align-items-center mr-2 btn-action-generate-client-secret btn btn-sm">
                   <i class="fa fa-refresh text-dark" aria-hidden="true" title="Générer un nouveau secret"></i>
                 </a>
                 <form name="deleteForm" method="POST" id="delete-<%= serviceProvider._id %>"
@@ -108,7 +108,7 @@
                   <input type="hidden" name="_csrf" value="<%= locals.csrfToken%>">
                   <input type="hidden" name="_totp">
                   <input type="hidden" name="name" value="<%= serviceProvider.name %>">
-                  <button type="submit" class="btn-action-delete">
+                  <button type="submit" class="btn-action-delete btn btn-sm">
                     <i class="fa fa-trash" aria-hidden="true" title="Supprimer"></i>
                   </button>
                 </form>

--- a/admin/views/service-provider/update.ejs
+++ b/admin/views/service-provider/update.ejs
@@ -16,7 +16,7 @@
         <%- include('partials/global-errors-handler.ejs') -%>
         <div class="card-body">
           <form method="POST" action="<%= APP_ROOT %>/service-provider/<%= id%>?_method=PATCH" data-init="validForm" id="fs-form" name="fs-form" data-select="form" novalidate>
-            <section class="form-group row">
+            <section class="mb-3 row">
               <label class="col-2 col-form-label" for="name">Nom du fournisseur de service (mire) : </label>
               <div class="col-10">
                 <input id="name" type="text" required class="form-control <%= locals.messages.errors && messages.errors[0].name && 'is-invalid' %>" placeholder="<%= locals.messages.values && messages.values[0].name %>" name="name" value="<%= locals.messages.values && messages.values[0].name %>" pattern="<%= VALID_INPUT_STRING_REGEX %>">
@@ -35,7 +35,7 @@
               </div>
             </section>
 
-            <section class="form-group row">
+            <section class="mb-3 row">
               <label class="col-2 col-form-label" for="redirectUri">URL de redirection de connexion : </label>
               <div class="col-10">
                 <textarea id="redirectUri" class="form-control <%= locals.messages.errors && messages.errors[0].redirectUri && 'is-invalid' %>" placeholder="https://url-de-redirection.com" name="redirectUri" pattern="^(?:((https?:\/\/)?((([^\s\/$.?#]{1,})(\.[^\s\/$?#]{2,})*\.[a-z]{2,})|(([0-9]{1,3}\.){3}[0-9]{1,3})|(([A-Za-z0-9\.\+-]{6,}):(?:\/\/)?(?:[\-;:&=\+\$,\w]+@)?[A-Za-z0-9\.\-_]+)|localhost)(:[0-9]{2,5})?(\/[^\s\/$]+)*\/?)?)$"><%= locals.messages.values && messages.values[0].redirectUri %></textarea>
@@ -53,7 +53,7 @@
                 </div>
               </div>
             </section>
-            <section class="form-group row">
+            <section class="mb-3 row">
               <label class="col-2 col-form-label" for="redirectUriLogout">URL de redirection de déconnexion : </label>
               <div class="col-10">
                 <textarea id="redirectUriLogout" type="text" class="form-control <%= locals.messages.errors && messages.errors[0].redirectUriLogout && 'is-invalid' %>" name="redirectUriLogout" placeholder="https://url-de-redirection.com/deconnexion" pattern="^(?:((https?:\/\/)?((([^\s\/$.?#]{1,})(\.[^\s\/$?#]{2,})*\.[a-z]{2,})|(([0-9]{1,3}\.){3}[0-9]{1,3})|(([A-Za-z0-9\.\+-]{6,}):(?:\/\/)?(?:[\-;:&=\+\$,\w]+@)?[A-Za-z0-9\.\-_]+)|localhost)(:[0-9]{2,5})?(\/[^\s\/$]+)*\/?)?)$"><%= locals.messages.values && ( messages.values[0].postLogoutUri || messages.values[0].redirectUriLogout ) %></textarea>
@@ -71,7 +71,7 @@
                 </div>
               </div>
             </section>
-            <section class="form-group row">
+            <section class="mb-3 row">
               <label class="col-2 col-form-label" for="site">Site : </label>
               <div class="col-10">
                 <textarea id="site" class="form-control <%= locals.messages.errors && messages.errors[0].site && 'is-invalid' %>" placeholder="https://monsite.com" name="site" pattern="^(?:((https?:\/\/)?((([^\s\/$.?#]{1,})(\.[^\s\/$?#]{2,})*\.[a-z]{2,})|(([0-9]{1,3}\.){3}[0-9]{1,3})|localhost)(:[0-9]{2,5})?(\/[^\s\/$]+)*\/?))?$"><%= locals.messages.values && messages.values[0].site %></textarea>
@@ -90,7 +90,7 @@
               </div>
             </section>
 
-            <section class="form-group row">
+            <section class="mb-3 row">
               <label class="col-2 col-form-label" for="emails">Email(s) de contact (un par ligne)</label>
               <div class="col-10">
                 <textarea id="emails" class="form-control  <%= locals.messages.errors && messages.errors[0].emails && 'is-invalid' %>" placeholder="email@email.com" name="emails" pattern="^$|^([a-zA-Z0-9_\.-]+)@([\da-z\.-]+)\.([a-z\.]{2,10})$"><%= locals.messages.values && messages.values[0].emails %></textarea>
@@ -108,7 +108,7 @@
                 </div>
               </div>
             </section>
-            <section class="form-group row">
+            <section class="mb-3 row">
               <label class="col-2 col-form-label" for="ipAddresses">Plages d'adresses IP (une par ligne)</label>
               <div class="col-10">
                 <textarea id="ipAddresses" class="form-control  <%= locals.messages.errors && messages.errors[0].ipAddresses && 'is-invalid' %>" placeholder="1.1.1.1" name="ipAddresses" pattern="<%= IP_VALIDATOR_REGEX %>"><%= locals.messages.values && ( messages.values[0].ipAddresses || messages.values[0].ipsRanges ) %></textarea>
@@ -131,48 +131,48 @@
 
             <%- include('partials/claims.ejs') -%>
 
-            <section class="form-group row">
+            <section class="mb-3 row">
               <label class="col-2 col-form-label">Activé : </label>
-              <div class="form-group col-4 d-flex align-items-end">
-                <div class="custom-control custom-radio custom-control-inline">
-                  <input type="radio" class="custom-control-input
+              <div class="mb-3 col-4 d-flex align-items-end">
+                <div class="form-check form-check-inline">
+                  <input type="radio" class="form-check-input
                     <%= locals.messages.errors && messages.errors[0].active && 'is-invalid' %>" id="activated" name="active" value="true" <% if(locals.messages.values && `${messages.values[0].active}` === 'true'){ %> checked <% } %> required>
-                  <label class="custom-control-label" for="activated">oui</label>
+                  <label class="form-check-label" for="activated">oui</label>
                 </div>
-                <div class="custom-control custom-radio custom-control-inline">
-                  <input type="radio" class="custom-control-input
+                <div class="form-check form-check-inline">
+                  <input type="radio" class="form-check-input
                     <%= locals.messages.errors && messages.errors[0].active && 'is-invalid' %>" id="unactivated" name="active" value="false" <% if(locals.messages.values && `${messages.values[0].active}` === 'false'){ %> checked <% } %> required>
-                  <label class="custom-control-label" for="unactivated">non</label>
+                  <label class="form-check-label" for="unactivated">non</label>
                 </div>
               </div>
             </section>
-            <section class="form-group row">
+            <section class="mb-3 row">
               <label class="col-2 col-form-label">Accepte les employé.e.s d'organisme privé</label>
-              <div class="form-group col-4 d-flex align-items-end">
-                <div class="custom-control custom-radio custom-control-inline">
-                  <input type="radio" class=" custom-control-input is-consent-required <%= locals.messages.errors && messages.errors[0].type && 'is-invalid' %>" id="public" name="type" value="public" <% if(locals.messages.values && messages.values[0].type === 'public'){ %> checked <% } %> required>
-                  <label class="custom-control-label" for="public">non</label>
+              <div class="mb-3 col-4 d-flex align-items-end">
+                <div class="form-check form-check-inline">
+                  <input type="radio" class=" form-check-input is-consent-required <%= locals.messages.errors && messages.errors[0].type && 'is-invalid' %>" id="public" name="type" value="public" <% if(locals.messages.values && messages.values[0].type === 'public'){ %> checked <% } %> required>
+                  <label class="form-check-label" for="public">non</label>
                 </div>
-                <div class="custom-control custom-radio custom-control-inline">
-                  <input type="radio" class="custom-control-input is-consent-required <%= locals.messages.errors && messages.errors[0].type && 'is-invalid' %>" id="private" name="type" value="private" <% if(locals.messages.values && messages.values[0].type === 'private'){ %> checked <% } %> required>
-                  <label class="custom-control-label" for="private">oui</label>
+                <div class="form-check form-check-inline">
+                  <input type="radio" class="form-check-input is-consent-required <%= locals.messages.errors && messages.errors[0].type && 'is-invalid' %>" id="private" name="type" value="private" <% if(locals.messages.values && messages.values[0].type === 'private'){ %> checked <% } %> required>
+                  <label class="form-check-label" for="private">oui</label>
                 </div>
             </section>
 
-            <div class="form-group row">
+            <div class="mb-3 row">
               <label class="col-2 col-form-label" for="id_token_signed_response_alg">id_token_signed_response_alg : </label>
               <div class="col-10">
-                <select class="custom-select" name="id_token_signed_response_alg" required>
+                <select class="form-select" name="id_token_signed_response_alg" required>
                   <option value="HS256" <%= messages.values && messages.values[0].id_token_signed_response_alg === "HS256" ? 'selected' : '' %>>HS256</option>
                   <option value="ES256" <%= messages.values && messages.values[0].id_token_signed_response_alg === "ES256" ? 'selected' : '' %>>ES256</option>
                   <option value="RS256" <%= messages.values && messages.values[0].id_token_signed_response_alg === "RS256" ? 'selected' : '' %>>RS256</option>
                 </select>
               </div>
             </div>
-            <div class="form-group row">
+            <div class="mb-3 row">
               <label class="col-2 col-form-label" for="userinfo_signed_response_alg">userinfo_signed_response_alg : </label>
               <div class="col-10">
-                <select class="custom-select" name="userinfo_signed_response_alg">
+                <select class="form-select" name="userinfo_signed_response_alg">
                   <option value="" <%= messages.values && messages.values[0].userinfo_signed_response_alg === "" ? 'selected' : '' %>>Aucun</option>
                   <option value="HS256" <%= messages.values && messages.values[0].userinfo_signed_response_alg === "HS256" ? 'selected' : '' %>>HS256</option>
                   <option value="ES256" <%= messages.values && messages.values[0].userinfo_signed_response_alg === "ES256" ? 'selected' : '' %>>ES256</option>
@@ -181,7 +181,7 @@
               </div>
             </div>
 
-            <section class="form-group row">
+            <section class="mb-3 row">
               <label class="col-2 col-form-label" for="entityId">Id d'entité : </label>
               <div class="col-10 d-flex align-items-center">
                 <%= locals.messages.values && messages.values[0].entityId %>
@@ -190,7 +190,7 @@
 
             <%- include('partials/resource-server.ejs') -%>
 
-            <section class="form-group row">
+            <section class="mb-3 row">
               <label class="col-2 col-form-label" for="confirm-2FAuthentication">Code TOTP</label>
               <div class="col-10">
                 <input id="_totp" type="text" required class="form-control <%= locals.messages.errors && messages.errors[0]._totp && 'is-invalid' %>" name="_totp">

--- a/admin/views/service-provider/update.ejs
+++ b/admin/views/service-provider/update.ejs
@@ -147,7 +147,7 @@
               </div>
             </section>
             <section class="mb-3 row">
-              <label class="col-2 col-form-label">Accepte les employé.e.s d'organisme privé</label>
+              <label class="col-2 col-form-label">Accepte les employé·e·s d'organisme privé</label>
               <div class="mb-3 col-4 d-flex align-items-end">
                 <div class="form-check form-check-inline">
                   <input type="radio" class=" form-check-input is-consent-required <%= locals.messages.errors && messages.errors[0].type && 'is-invalid' %>" id="public" name="type" value="public" <% if(locals.messages.values && messages.values[0].type === 'public'){ %> checked <% } %> required>


### PR DESCRIPTION
Most of the changes were obtained by running [this handy tool](https://github.com/coliff/bootstrap-5-migrate-tool).

Additional manual changes with global search and replace
- `custom-control-inline` -> `form-check-inline`
- add `form-check-inline` on `multiple-delete-` rows