### PR TITLE
♻️ Remove command override from Compose services

### DIFF
--- a/admin/Dockerfile
+++ b/admin/Dockerfile
@@ -11,6 +11,8 @@ WORKDIR /var/www/app
 COPY package.json yarn.lock ./
 RUN yarn install --ignore-engines
 
+CMD yarn start:dev
+
 
 FROM ${NODE_IMAGE} AS builder
 

--- a/back/Dockerfile
+++ b/back/Dockerfile
@@ -11,6 +11,8 @@ WORKDIR /var/www/app
 COPY package.json yarn.lock ./
 RUN yarn install --ignore-engines
 
+CMD yarn start:dev ${NESTJS_INSTANCE}
+
 
 FROM ${NODE_IMAGE} AS builder
 

--- a/docker/compose/fca-low/admin.yml
+++ b/docker/compose/fca-low/admin.yml
@@ -33,4 +33,3 @@ services:
       - exploitation
       - data
     init: true
-    command: 'yarn start:dev'

--- a/docker/compose/fca-low/hybridge.yml
+++ b/docker/compose/fca-low/hybridge.yml
@@ -43,7 +43,6 @@ services:
       - public
       - data
     init: true
-    command: 'yarn start:dev bridge-http-proxy-rie'
 
   ####################
   ##

--- a/docker/compose/shared/shared.yml
+++ b/docker/compose/shared/shared.yml
@@ -43,7 +43,6 @@ services:
       - fc
       - public
       - data
-    command: 'yarn start:dev core-fca-low'
 
   base-mock:
     build:


### PR DESCRIPTION
Using the existing NESTJS_INSTANCE environment
variable lets all those containers share a command defined in the common Dockerfile.