### PR TITLE
🚚 Replace environment variables with relative paths in Compose files

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -123,12 +123,12 @@ services:
     depends_on:
       - <...any_required_service...>
     volumes:
-      - '${VOLUMES_DIR}/src/fc/back:/var/www/app'
-      - '${VOLUMES_DIR}/app:/opt/scripts'
-      - '${VOLUMES_DIR}/.home:/home'
+      - '../../volumes/src/fc/back:/var/www/app'
+      - '../../volumes/app:/opt/scripts'
+      - '../../volumes/.home:/home'
       - <...others_required_volumes...>
     env_file:
-      - '${COMPOSE_DIR}/shared/.env/base-app.env'
+      - '../shared/.env/base-app.env'
     networks:
       - public
     init: true

--- a/docker/bash/commands/docker.sh
+++ b/docker/bash/commands/docker.sh
@@ -77,15 +77,6 @@ _prune_ci() {
   $DOCKER_COMPOSE down --volumes --remove-orphans
 }
 
-_get_env() {
-  local app=${1}
-  local varName=${2}
-  local containerName="${COMPOSE_PROJECT_NAME}-${app}-1"
-  local expression='${'${varName}'}'
-
-  docker exec ${containerName} bash -c "echo ${expression}"
-}
-
 _switch() {
   _prune
   _logs "--bg"

--- a/docker/bash/commands/node.sh
+++ b/docker/bash/commands/node.sh
@@ -6,29 +6,6 @@ _log() {
   $DOCKER_COMPOSE exec ${NO_TTY} ${app} pm2 logs
 }
 
-_detect_instances() {
-  local apps="${@:-no-container}"
-  local instances=$(
-    for app in ${apps}; do
-      _get_env "${app}" "NESTJS_INSTANCE"
-    done
-  )
-
-  echo "${instances}" | sort | uniq | grep -oE "[a-zA-Z0-9-]+"
-}
-
-_clean_pc_dist() {
-  local apps="${@:-no-container}"
-  local instances=$(_detect_instances "${apps}")
-
-  cd ${VOLUMES_DIR}
-
-  for instance in ${instances}; do
-    echo "    * Purging build dir for ${instance}"
-    rm -rf "src/fc/back/dist/instances/${instance}"
-  done
-}
-
 _stop() {
   apps=${@:-no-container}
   for app in $apps; do

--- a/docker/bash/config.sh
+++ b/docker/bash/config.sh
@@ -5,15 +5,11 @@
 
 #### Global Variables:
 COMPOSE_PROJECT_NAME=pc
-COMPOSE_DIR="${DOCKER_DIR}/compose"
-COMPOSE_FILE="${COMPOSE_DIR}/fca-low/stack.yml"
+COMPOSE_FILE="${DOCKER_DIR}/compose/fca-low/stack.yml"
 
-VOLUMES_DIR="${DOCKER_DIR}/volumes"
 WORKING_DIR="${DOCKER_DIR}"
 
 export COMPOSE_FILE
-export COMPOSE_DIR
-export VOLUMES_DIR
 export COMPOSE_PROJECT_NAME
 export WORKING_DIR
 

--- a/docker/compose/fca-low/admin.yml
+++ b/docker/compose/fca-low/admin.yml
@@ -2,7 +2,7 @@ services:
   admin:
     hostname: admin
     build:
-      context: '${FEDERATION_DIR}/admin'
+      context: '../../../admin'
       target: dev
     user: ${CURRENT_UID}
     working_dir: /var/www/app
@@ -18,17 +18,17 @@ services:
       redis-pwd:
         condition: service_healthy
     volumes:
-      - '${FEDERATION_DIR}/admin:/var/www/app'
+      - '../../../admin:/var/www/app'
       - '/var/www/app/node_modules'
-      - '${VOLUMES_DIR}/app:/opt/scripts'
-      - '${VOLUMES_DIR}/.home:/home'
-      - '${VOLUMES_DIR}/ssl:/etc/ssl/docker_host:ro'
-      - '${VOLUMES_DIR}/log:/var/log/app'
+      - '../../volumes/app:/opt/scripts'
+      - '../../volumes/.home:/home'
+      - '../../volumes/ssl:/etc/ssl/docker_host:ro'
+      - '../../volumes/log:/var/log/app'
     env_file:
-      - '${COMPOSE_DIR}/shared/.env/base-app.env'
-      - '${COMPOSE_DIR}/shared/.env/postgres.env'
-      - '${COMPOSE_DIR}/shared/.env/pc-mongo.env'
-      - '${COMPOSE_DIR}/fca-low/.env/exploitation-fca-low.env'
+      - '../shared/.env/base-app.env'
+      - '../shared/.env/postgres.env'
+      - '../shared/.env/pc-mongo.env'
+      - '../fca-low/.env/exploitation-fca-low.env'
     networks:
       - exploitation
       - data

--- a/docker/compose/fca-low/core.yml
+++ b/docker/compose/fca-low/core.yml
@@ -7,8 +7,8 @@ services:
     ports:
       - 9229:9229
     env_file:
-      - '${COMPOSE_DIR}/shared/.env/base-app.env'
-      - '${COMPOSE_DIR}/fca-low/.env/core-fca-low.env'
+      - '../shared/.env/base-app.env'
+      - '../fca-low/.env/core-fca-low.env'
 
   core-squid:
     extends: core
@@ -25,5 +25,5 @@ services:
     extends: core
     hostname: core-rie
     env_file:
-      - '${COMPOSE_DIR}/shared/.env/base-app.env'
-      - '${COMPOSE_DIR}/fca-low/.env/core-fca-rie.env'
+      - '../shared/.env/base-app.env'
+      - '../fca-low/.env/core-fca-rie.env'

--- a/docker/compose/fca-low/hybridge.yml
+++ b/docker/compose/fca-low/hybridge.yml
@@ -8,10 +8,10 @@ services:
   rp-hybridge:
     image: nginx:1.14.2
     volumes:
-      - ${VOLUMES_DIR}/nginx-proxy/nginx.conf:/etc/nginx/nginx.conf:ro
-      - ${VOLUMES_DIR}/nginx-proxy/includes:/etc/nginx/includes:ro
-      - ${VOLUMES_DIR}/rp-bridge-proxy/:/etc/nginx/conf.d:ro
-      - ${VOLUMES_DIR}/ssl:/etc/nginx/docker_host:ro
+      - ../../volumes/nginx-proxy/nginx.conf:/etc/nginx/nginx.conf:ro
+      - ../../volumes/nginx-proxy/includes:/etc/nginx/includes:ro
+      - ../../volumes/rp-bridge-proxy/:/etc/nginx/conf.d:ro
+      - ../../volumes/ssl:/etc/nginx/docker_host:ro
     networks:
       public:
         ipv4_address: 172.16.1.254
@@ -21,7 +21,7 @@ services:
   hybridge-internet:
     hostname: hybridge-internet
     build:
-      context: '${FEDERATION_DIR}/back'
+      context: '../../../back'
       target: dev
     user: ${CURRENT_UID}
     working_dir: /var/www/app
@@ -29,15 +29,15 @@ services:
       rp-all:
         condition: service_started
     volumes:
-      - '${FEDERATION_DIR}/back:/var/www/app'
+      - '../../../back:/var/www/app'
       - '/var/www/app/node_modules'
-      - '${VOLUMES_DIR}/app:/opt/scripts'
-      - '${VOLUMES_DIR}/log:/var/log/app'
-      - '${VOLUMES_DIR}/.home:/home'
-      - '${VOLUMES_DIR}/ssl:/etc/ssl/docker_host:ro'
+      - '../../volumes/app:/opt/scripts'
+      - '../../volumes/log:/var/log/app'
+      - '../../volumes/.home:/home'
+      - '../../volumes/ssl:/etc/ssl/docker_host:ro'
     env_file:
-      - '${COMPOSE_DIR}/shared/.env/base-app.env'
-      - '${COMPOSE_DIR}/fca-low/.env/bridge-proxy-rie.env'
+      - '../shared/.env/base-app.env'
+      - '../fca-low/.env/bridge-proxy-rie.env'
     tty: true
     networks:
       - public
@@ -52,22 +52,22 @@ services:
   hybridge-rie:
     hostname: hybridge-rie
     build:
-      context: '${FEDERATION_DIR}/back'
+      context: '../../../back'
       target: dev
     user: ${CURRENT_UID}
     working_dir: /var/www/app
     depends_on:
       - broker
     volumes:
-      - '${FEDERATION_DIR}/back:/var/www/app'
+      - '../../../back:/var/www/app'
       - '/var/www/app/node_modules'
-      - '${VOLUMES_DIR}/app:/opt/scripts'
-      - '${VOLUMES_DIR}/log/:/var/log/app'
-      - '${VOLUMES_DIR}/.home:/home'
-      - ${VOLUMES_DIR}/ssl:/etc/ssl/docker_host:ro
+      - '../../volumes/app:/opt/scripts'
+      - '../../volumes/log/:/var/log/app'
+      - '../../volumes/.home:/home'
+      - ../../volumes/ssl:/etc/ssl/docker_host:ro
     env_file:
-      - '${COMPOSE_DIR}/shared/.env/base-app.env'
-      - '${COMPOSE_DIR}/fca-low/.env/csmr-rie.env'
+      - '../shared/.env/base-app.env'
+      - '../fca-low/.env/csmr-rie.env'
     tty: true
     networks:
       - rie

--- a/docker/compose/fca-low/mocks.yml
+++ b/docker/compose/fca-low/mocks.yml
@@ -9,8 +9,8 @@ services:
       file: ../shared/shared.yml
       service: base-sp-mock
     env_file:
-      - '${COMPOSE_DIR}/shared/.env/base-app.env'
-      - '${COMPOSE_DIR}/fca-low/.env/fsa1-low.env'
+      - '../shared/.env/base-app.env'
+      - '../fca-low/.env/fsa1-low.env'
 
   service-provider-2:
     hostname: service-provider-2
@@ -18,8 +18,8 @@ services:
       file: ../shared/shared.yml
       service: base-sp-mock
     env_file:
-      - '${COMPOSE_DIR}/shared/.env/base-app.env'
-      - '${COMPOSE_DIR}/fca-low/.env/fsa2-low.env'
+      - '../shared/.env/base-app.env'
+      - '../fca-low/.env/fsa2-low.env'
 
   service-provider-3:
     hostname: service-provider-3
@@ -27,8 +27,8 @@ services:
       file: ../shared/shared.yml
       service: base-sp-mock
     env_file:
-      - '${COMPOSE_DIR}/shared/.env/base-app.env'
-      - '${COMPOSE_DIR}/fca-low/.env/fsa3-low.env'
+      - '../shared/.env/base-app.env'
+      - '../fca-low/.env/fsa3-low.env'
 
   service-provider-4:
     hostname: service-provider-4
@@ -36,8 +36,8 @@ services:
       file: ../shared/shared.yml
       service: base-sp-mock
     env_file:
-      - '${COMPOSE_DIR}/shared/.env/base-app.env'
-      - '${COMPOSE_DIR}/fca-low/.env/fsa4-low.env'
+      - '../shared/.env/base-app.env'
+      - '../fca-low/.env/fsa4-low.env'
 
   ####################
   # IDP Mocks
@@ -49,8 +49,8 @@ services:
       file: ../shared/shared.yml
       service: base-idp-mock
     env_file:
-      - '${COMPOSE_DIR}/shared/.env/base-app.env'
-      - '${COMPOSE_DIR}/fca-low/.env/fia1-low.env'
+      - '../shared/.env/base-app.env'
+      - '../fca-low/.env/fia1-low.env'
 
   identity-provider-2:
     hostname: identity-provider-2
@@ -58,8 +58,8 @@ services:
       file: ../shared/shared.yml
       service: base-idp-mock
     env_file:
-      - '${COMPOSE_DIR}/shared/.env/base-app.env'
-      - '${COMPOSE_DIR}/fca-low/.env/fia2-low.env'
+      - '../shared/.env/base-app.env'
+      - '../fca-low/.env/fia2-low.env'
 
   proconnect-identite:
     hostname: proconnect-identite
@@ -67,8 +67,8 @@ services:
       file: ../shared/shared.yml
       service: base-idp-mock
     env_file:
-      - '${COMPOSE_DIR}/shared/.env/base-app.env'
-      - '${COMPOSE_DIR}/fca-low/.env/moncomptepro.env'
+      - '../shared/.env/base-app.env'
+      - '../fca-low/.env/moncomptepro.env'
 
   identity-provider-rie:
     hostname: identity-provider-rie
@@ -76,20 +76,20 @@ services:
       file: ../shared/shared.yml
       service: base-idp-mock
     env_file:
-      - '${COMPOSE_DIR}/shared/.env/base-app.env'
-      - '${COMPOSE_DIR}/fca-low/.env/fia-rie-low.env'
+      - '../shared/.env/base-app.env'
+      - '../fca-low/.env/fia-rie-low.env'
     networks:
       - rie
 
   identity-provider-llng:
     build:
-      context: '${WORKING_DIR}'
-      dockerfile: '${WORKING_DIR}/builds/lemonldap/Dockerfile'
+      context: '../..'
+      dockerfile: 'builds/lemonldap/Dockerfile'
     volumes:
-      - '${VOLUMES_DIR}/llng/scripts/:/scripts:ro'
-      - '${VOLUMES_DIR}/llng/llng-conf.json:/llng-conf.json:ro'
+      - '../../volumes/llng/scripts/:/scripts:ro'
+      - '../../volumes/llng/llng-conf.json:/llng-conf.json:ro'
     env_file:
-      - '${COMPOSE_DIR}/fca-low/.env/fia-llng-low.env'
+      - '../fca-low/.env/fia-llng-low.env'
     networks:
       - rie
 
@@ -103,8 +103,8 @@ services:
       file: ../shared/shared.yml
       service: base-dp-mock
     env_file:
-      - '${COMPOSE_DIR}/shared/.env/base-app.env'
-      - '${COMPOSE_DIR}/fca-low/.env/dpa1-low.env'
+      - '../shared/.env/base-app.env'
+      - '../fca-low/.env/dpa1-low.env'
 
   resource-server-2:
     hostname: resource-server-2
@@ -112,5 +112,5 @@ services:
       file: ../shared/shared.yml
       service: base-dp-mock
     env_file:
-      - '${COMPOSE_DIR}/shared/.env/base-app.env'
-      - '${COMPOSE_DIR}/fca-low/.env/dpa2-low.env'
+      - '../shared/.env/base-app.env'
+      - '../fca-low/.env/dpa2-low.env'

--- a/docker/compose/fca-low/mongo.yml
+++ b/docker/compose/fca-low/mongo.yml
@@ -2,14 +2,14 @@ services:
   mongo-fca-low:
     hostname: mongo-fca-low
     build:
-      context: '${WORKING_DIR}'
-      dockerfile: '${WORKING_DIR}/builds/mongodb/Dockerfile'
+      context: '../..'
+      dockerfile: 'builds/mongodb/Dockerfile'
       args:
         MONGO_VERSION: '5.0.23'
     volumes:
-      - '${VOLUMES_DIR}/mongo-fca-low/scripts:/opt/scripts'
-      - '${VOLUMES_DIR}/mongo-fca-low/initdb.d:/docker-entrypoint-initdb.d'
+      - '../../volumes/mongo-fca-low/scripts:/opt/scripts'
+      - '../../volumes/mongo-fca-low/initdb.d:/docker-entrypoint-initdb.d'
     env_file:
-      - '${COMPOSE_DIR}/fca-low/.env/mongo-fca-low.env'
+      - '../fca-low/.env/mongo-fca-low.env'
     networks:
       - data

--- a/docker/compose/shared/shared.yml
+++ b/docker/compose/shared/shared.yml
@@ -12,7 +12,7 @@ services:
 
   base-nodejs:
     build:
-      context: '${FEDERATION_DIR}/back'
+      context: '../../../back'
       target: dev
     user: ${CURRENT_UID}
     working_dir: /var/www/app
@@ -33,12 +33,12 @@ services:
       redis-pwd:
         condition: service_healthy
     volumes:
-      - '${FEDERATION_DIR}/back:/var/www/app'
+      - '../../../back:/var/www/app'
       - '/var/www/app/node_modules'
-      - '${VOLUMES_DIR}/app:/opt/scripts'
-      - '${VOLUMES_DIR}/log:/var/log/app'
-      - '${VOLUMES_DIR}/.home:/home'
-      - '${VOLUMES_DIR}/ssl:/etc/ssl/docker_host:ro'
+      - '../../volumes/app:/opt/scripts'
+      - '../../volumes/log:/var/log/app'
+      - '../../volumes/.home:/home'
+      - '../../volumes/ssl:/etc/ssl/docker_host:ro'
     networks:
       - fc
       - public
@@ -46,7 +46,7 @@ services:
 
   base-mock:
     build:
-      context: '${FEDERATION_DIR}/back'
+      context: '../../../back'
       target: dev
     user: ${CURRENT_UID}
     working_dir: /var/www/app
@@ -59,12 +59,12 @@ services:
   base-sp-mock:
     extends: base-mock
     volumes:
-      - '${FEDERATION_DIR}/back:/var/www/app'
+      - '../../../back:/var/www/app'
       - '/var/www/app/node_modules'
-      - '${VOLUMES_DIR}/app:/opt/scripts'
-      - '${VOLUMES_DIR}/log/:/var/log/app'
-      - '${VOLUMES_DIR}/.home:/home'
-      - '${VOLUMES_DIR}/ssl:/etc/ssl/docker_host:ro'
+      - '../../volumes/app:/opt/scripts'
+      - '../../volumes/log/:/var/log/app'
+      - '../../volumes/.home:/home'
+      - '../../volumes/ssl:/etc/ssl/docker_host:ro'
     depends_on:
       rp-all:
         condition: service_started
@@ -78,13 +78,13 @@ services:
   base-idp-mock:
     extends: base-mock
     volumes:
-      - '${FEDERATION_DIR}/back:/var/www/app'
+      - '../../../back:/var/www/app'
       - '/var/www/app/node_modules'
-      - '${VOLUMES_DIR}/app:/opt/scripts'
-      - '${VOLUMES_DIR}/fca-low/mocks/idp/databases:/var/databases'
-      - '${VOLUMES_DIR}/log/:/var/log/app'
-      - '${VOLUMES_DIR}/.home:/home'
-      - '${VOLUMES_DIR}/ssl:/etc/ssl/docker_host:ro'
+      - '../../volumes/app:/opt/scripts'
+      - '../../volumes/fca-low/mocks/idp/databases:/var/databases'
+      - '../../volumes/log/:/var/log/app'
+      - '../../volumes/.home:/home'
+      - '../../volumes/ssl:/etc/ssl/docker_host:ro'
     depends_on:
       rp-all:
         condition: service_started
@@ -98,12 +98,12 @@ services:
   base-dp-mock:
     extends: base-mock
     volumes:
-      - '${FEDERATION_DIR}/back:/var/www/app'
+      - '../../../back:/var/www/app'
       - '/var/www/app/node_modules'
-      - '${VOLUMES_DIR}/app:/opt/scripts'
-      - '${VOLUMES_DIR}/log:/var/log/app'
-      - '${VOLUMES_DIR}/.home:/home'
-      - '${VOLUMES_DIR}/ssl:/etc/ssl/docker_host:ro'
+      - '../../volumes/app:/opt/scripts'
+      - '../../volumes/log:/var/log/app'
+      - '../../volumes/.home:/home'
+      - '../../volumes/ssl:/etc/ssl/docker_host:ro'
     depends_on:
       rp-all:
         condition: service_started
@@ -114,9 +114,9 @@ services:
   base-redis:
     image: 'bitnami/redis:6.2.16'
     env_file:
-      - ${COMPOSE_DIR}/shared/.env/redis.env
+      - ../shared/.env/redis.env
     volumes:
-      - '${VOLUMES_DIR}/ssl:/bitnami/redis/data/ssl'
+      - '../../volumes/ssl:/bitnami/redis/data/ssl'
     healthcheck:
       interval: 2s
       start_period: 5s
@@ -138,14 +138,14 @@ services:
       - '80:80'
       - '443:443'
     volumes:
-      - ${VOLUMES_DIR}/nginx-proxy/nginx.conf:/etc/nginx/nginx.conf:ro
-      - ${VOLUMES_DIR}/nginx-proxy/etc:/etc/nginx/conf.d:ro
-      - ${VOLUMES_DIR}/nginx-proxy/includes:/etc/nginx/includes:ro
-      - ${VOLUMES_DIR}/nginx-proxy/public:/var/www:ro
-      - ${VOLUMES_DIR}/nginx-proxy/default-vhost:/etc/nginx/html:ro
-      - ${VOLUMES_DIR}/ssl:/etc/nginx/docker_host:ro
-      - ${VOLUMES_DIR}/ssl:/etc/nginx/client_certs:ro
-      - ${VOLUMES_DIR}/log/nginx:/var/log/nginx
+      - ../../volumes/nginx-proxy/nginx.conf:/etc/nginx/nginx.conf:ro
+      - ../../volumes/nginx-proxy/etc:/etc/nginx/conf.d:ro
+      - ../../volumes/nginx-proxy/includes:/etc/nginx/includes:ro
+      - ../../volumes/nginx-proxy/public:/var/www:ro
+      - ../../volumes/nginx-proxy/default-vhost:/etc/nginx/html:ro
+      - ../../volumes/ssl:/etc/nginx/docker_host:ro
+      - ../../volumes/ssl:/etc/nginx/client_certs:ro
+      - ../../volumes/log/nginx:/var/log/nginx
     networks:
       public:
         aliases:
@@ -181,10 +181,10 @@ services:
     image: jwilder/docker-gen
     volumes:
       - /var/run/docker.sock:/tmp/docker.sock:ro
-      - ${VOLUMES_DIR}/nginx-proxy/default-vhost:/etc/nginx/html
-      - ${VOLUMES_DIR}/nginx-proxy/etc:/etc/nginx/conf.d
-      - ${VOLUMES_DIR}/docker-gen/config:/etc/docker-gen/config:ro
-      - ${VOLUMES_DIR}/nginx-proxy/templates:/etc/docker-gen/templates:ro
+      - ../../volumes/nginx-proxy/default-vhost:/etc/nginx/html
+      - ../../volumes/nginx-proxy/etc:/etc/nginx/conf.d
+      - ../../volumes/docker-gen/config:/etc/docker-gen/config:ro
+      - ../../volumes/nginx-proxy/templates:/etc/docker-gen/templates:ro
     networks:
       - public
       - fc
@@ -216,20 +216,20 @@ services:
   log-hub:
     hostname: log-hub
     build:
-      context: '${FEDERATION_DIR}/back'
+      context: '../../../back'
       target: dev
     user: ${CURRENT_UID}
     working_dir: /var/www/app
     volumes:
-      - '${FEDERATION_DIR}/docker/log-hub:/var/www/app'
-      - '${VOLUMES_DIR}/app:/opt/scripts'
-      - '${VOLUMES_DIR}/log:/var/log/app'
-      - '${VOLUMES_DIR}/.home:/home'
-      - '${VOLUMES_DIR}/ssl:/etc/ssl/docker_host:ro'
+      - '../../../docker/log-hub:/var/www/app'
+      - '../../volumes/app:/opt/scripts'
+      - '../../volumes/log:/var/log/app'
+      - '../../volumes/.home:/home'
+      - '../../volumes/ssl:/etc/ssl/docker_host:ro'
     environment:
       - 'DEFAULT_MODE=dev'
     env_file:
-      - '${COMPOSE_DIR}/shared/.env/base-app.env'
+      - '../shared/.env/base-app.env'
     ports:
       - 6666:6666
     tty: true
@@ -237,8 +237,8 @@ services:
 
   broker:
     build:
-      context: '${WORKING_DIR}'
-      dockerfile: '${WORKING_DIR}/builds/broker/Dockerfile'
+      context: '../..'
+      dockerfile: 'builds/broker/Dockerfile'
     # Specify hostname to fix cluster name
     hostname: broker
     networks:
@@ -291,7 +291,7 @@ services:
     image: 'bitnami/redis-sentinel:6.2.16'
     scale: 3
     env_file:
-      - ${COMPOSE_DIR}/shared/.env/redis.env
+      - ../shared/.env/redis.env
     environment:
       - REDIS_SENTINEL_QUORUM=2
       - REDIS_MASTER_SET=fc_core_v2
@@ -305,7 +305,7 @@ services:
       - REDIS_SENTINEL_TLS_CA_FILE=/bitnami/redis/data/ssl/docker-stack-ca.crt
       - REDIS_SENTINEL_TLS_AUTH_CLIENTS=no
     volumes:
-      - '${VOLUMES_DIR}/ssl:/bitnami/redis/data/ssl'
+      - '../../volumes/ssl:/bitnami/redis/data/ssl'
     healthcheck:
       test: redis-cli -p 26379 --tls --cacert $${REDIS_SENTINEL_TLS_CA_FILE} ping
       interval: 2s
@@ -319,14 +319,14 @@ services:
   postgres:
     image: postgres:13-bullseye
     volumes:
-      - '${VOLUMES_DIR}/postgres/init-multiple-postgresql-databases.sh:/docker-entrypoint-initdb.d/init-multiple-postgresql-databases.sh:ro'
-      - '${VOLUMES_DIR}/postgres/start.sh:/usr/bin/start.sh:ro'
-      - '${VOLUMES_DIR}/postgres/postgresql.conf:/etc/postgresql/postgresql.conf'
-      - '${VOLUMES_DIR}/postgres/pg_hba.conf:/etc/postgresql/pg_hba.conf'
-      - ${VOLUMES_DIR}/ssl:/etc/ssl/docker_host:ro
+      - '../../volumes/postgres/init-multiple-postgresql-databases.sh:/docker-entrypoint-initdb.d/init-multiple-postgresql-databases.sh:ro'
+      - '../../volumes/postgres/start.sh:/usr/bin/start.sh:ro'
+      - '../../volumes/postgres/postgresql.conf:/etc/postgresql/postgresql.conf'
+      - '../../volumes/postgres/pg_hba.conf:/etc/postgresql/pg_hba.conf'
+      - ../../volumes/ssl:/etc/ssl/docker_host:ro
     env_file:
-      - '${COMPOSE_DIR}/shared/.env/postgres/base.env'
-      - '${COMPOSE_DIR}/shared/.env/postgres/databases.env'
+      - '../shared/.env/postgres/base.env'
+      - '../shared/.env/postgres/databases.env'
     command: ['start.sh']
     ports:
       - '5432:5432'


### PR DESCRIPTION
From https://github.com/proconnect-gouv/federation/commits?author=jonathanperret

Replace environment variables with relative paths in Compose files This makes the Compose stack more self-contained, less dependent on the `docker-stack` wrapper.

Note that `_clean_pc_dist` in `node.sh` was the last user of `VOLUMES_DIR` but was itself unused so I removed it, along with its `_detect_instances` and `_get_env` dependencies.