### PR TITLE
Add root compose.yaml file

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -1,0 +1,4 @@
+name: pc
+
+include:
+    - docker/compose/fca-low/stack.yml

--- a/docker/bash/config.sh
+++ b/docker/bash/config.sh
@@ -4,13 +4,8 @@
 [ $CI ] && NO_TTY=" -T" || NO_TTY=""
 
 #### Global Variables:
-COMPOSE_PROJECT_NAME=pc
-COMPOSE_FILE="${DOCKER_DIR}/compose/fca-low/stack.yml"
-
 WORKING_DIR="${DOCKER_DIR}"
 
-export COMPOSE_FILE
-export COMPOSE_PROJECT_NAME
 export WORKING_DIR
 
 # Get current uid/gid to use it within docker-compose:


### PR DESCRIPTION
This removes the need to set `COMPOSE_PROJECT_NAME` and `COMPOSE_FILE` in `docker-stack`, but also lets plain `docker compose` work (as long as the `CURRENT_UID` variable is set, currently).