### PR TITLE
Use node_modules from node image directly instead of copying to an anonymous volume

### DIFF
--- a/admin/Dockerfile
+++ b/admin/Dockerfile
@@ -12,6 +12,8 @@ RUN --mount=type=cache,target=/usr/local/share/.cache,id=admin-yarn-cache,sharin
     --mount=type=tmpfs,target=/tmp \
     yarn install --ignore-engines
 
+COPY . ./
+
 CMD yarn start:dev
 
 

--- a/back/.dockerignore
+++ b/back/.dockerignore
@@ -1,0 +1,1 @@
+node_modules

--- a/back/Dockerfile
+++ b/back/Dockerfile
@@ -12,6 +12,8 @@ RUN --mount=type=cache,target=/usr/local/share/.cache,id=back-yarn-cache,sharing
     --mount=type=tmpfs,target=/tmp \
     yarn install --ignore-engines
 
+COPY . ./
+
 CMD yarn start:dev ${NESTJS_INSTANCE}
 
 

--- a/docker/bash/commands/node.sh
+++ b/docker/bash/commands/node.sh
@@ -25,17 +25,3 @@ _stop_all() {
   local containers=$(_get_node_containers_to_start)
   _stop $containers
 }
-
-_clean() {
-  echo "Cleaning node_modules and dist directories"
-  cd ${FEDERATION_DIR}
-
-  rm -rf back/node_modules
-  rm -rf admin/node_modules
-  rm -rf admin/node_modules
-
-  rm -rf admin/dist
-  rm -rf back/dist
-
-  echo "Done cleaning"
-}

--- a/docker/compose/fca-low/admin.yml
+++ b/docker/compose/fca-low/admin.yml
@@ -17,12 +17,15 @@ services:
       redis-pwd:
         condition: service_healthy
     volumes:
-      - '../../../admin:/var/www/app'
-      - '/var/www/app/node_modules'
+      - '../../../admin/src:/var/www/app/src:ro'
+      - '../../../admin/views:/var/www/app/views:ro'
       - '../../volumes/app:/opt/scripts'
       - '../../volumes/.home:/home'
       - '../../volumes/ssl:/etc/ssl/docker_host:ro'
       - '../../volumes/log:/var/log/app'
+    tmpfs:
+      - /var/www/app/dist:mode=777
+      - /var/www/app/.cache:mode=777
     env_file:
       - '../shared/.env/base-app.env'
       - '../shared/.env/postgres.env'

--- a/docker/compose/fca-low/hybridge.yml
+++ b/docker/compose/fca-low/hybridge.yml
@@ -28,12 +28,14 @@ services:
       rp-all:
         condition: service_started
     volumes:
-      - '../../../back:/var/www/app'
-      - '/var/www/app/node_modules'
+      - '../../../back/apps:/var/www/app/apps:ro'
+      - '../../../back/libs:/var/www/app/libs:ro'
       - '../../volumes/app:/opt/scripts'
       - '../../volumes/log:/var/log/app'
       - '../../volumes/.home:/home'
       - '../../volumes/ssl:/etc/ssl/docker_host:ro'
+    tmpfs:
+      - /var/www/app/dist:mode=777
     env_file:
       - '../shared/.env/base-app.env'
       - '../fca-low/.env/bridge-proxy-rie.env'
@@ -57,12 +59,14 @@ services:
     depends_on:
       - broker
     volumes:
-      - '../../../back:/var/www/app'
-      - '/var/www/app/node_modules'
+      - '../../../back/apps:/var/www/app/apps:ro'
+      - '../../../back/libs:/var/www/app/libs:ro'
       - '../../volumes/app:/opt/scripts'
       - '../../volumes/log/:/var/log/app'
       - '../../volumes/.home:/home'
       - ../../volumes/ssl:/etc/ssl/docker_host:ro
+    tmpfs:
+      - /var/www/app/dist:mode=777
     env_file:
       - '../shared/.env/base-app.env'
       - '../fca-low/.env/csmr-rie.env'

--- a/docker/compose/shared/shared.yml
+++ b/docker/compose/shared/shared.yml
@@ -32,12 +32,14 @@ services:
       redis-pwd:
         condition: service_healthy
     volumes:
-      - '../../../back:/var/www/app'
-      - '/var/www/app/node_modules'
+      - '../../../back/apps:/var/www/app/apps:ro'
+      - '../../../back/libs:/var/www/app/libs:ro'
       - '../../volumes/app:/opt/scripts'
       - '../../volumes/log:/var/log/app'
       - '../../volumes/.home:/home'
       - '../../volumes/ssl:/etc/ssl/docker_host:ro'
+    tmpfs:
+      - /var/www/app/dist:mode=777
     networks:
       - fc
       - public

--- a/docker/docker-stack
+++ b/docker/docker-stack
@@ -45,7 +45,6 @@ _command_register "run-prod" "_run_prod" "" # Description to be defined
 
 ## General / utils
 _command_register "help" "_command_list" "Display this help: help <search term>"
-_command_register "clean" "_clean" "Remove node_modules, yarn cache and dist directories"
 
 _command_register "reload-rp" "_reload_rp" "Reload Reverse proxy"
 _command_register "compose" "_compose" "Run a docker compose command on project"


### PR DESCRIPTION
The previous setup of:

    volumes:
      - '../../../back:/var/www/app'
      - '/var/www/app/node_modules'

Meant that `/var/www/app/node_modules` was first shadowed by the bind mount of `back`, then "re-introduced" as an anonymous volume whose contents were automatically copied from the image (see
https://docs.docker.com/engine/storage/volumes/#mounting-a-volume-over-existing-data).

This unnecessarily duplicated the entire `node_modules` directory into as many anonymous volumes as there were containers, and also took several seconds at container creation.Also, since Docker Compose will preserve anonymous volumes by default, it was easy to end up in a situation where the underlying image was rebuilt with new `node_modules` content that was not picked up (as the anonymous volumes contained previous copies). This also caused the creation of an empty `back/node_modules` directory on the host, as well as a `back/dist` subdirectory containing the compilation output.

The alternative setup introduced by this commit:
 - copies the entire contents of `back/` into the image;
 - selectively maps a few subdirectories of `back/` into `/var/www/app`, leaving `node_modules` directly accessible from its image version. It is expected that almost all changes made in development will happen in one of those directories.
 - creates a `tmpfs` mount for the `dist/` subdirectory which is the only place under `/var/www/app` where the app is expected to write.

Similar logic was applied to `admin`.

As a result, no changes are made to the host filesystem outside of `docker/volumes`, making the `_clean` function of `docker-stack` unnecessary (as it was implemented, at least).