### PR TITLE
🧱 Add a github job to build api-partner package

### DIFF
--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -146,3 +146,56 @@ jobs:
           subject-name: ghcr.io/proconnect-gouv/federation/fc-exploitation-v2
           subject-digest: ${{ steps.build.outputs.digest }}
           push-to-registry: true
+
+  build_api_partenaires:
+    name: 🐳 Build API Partenaires
+    if: github.actor != 'dependabot[bot]'
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+      contents: read
+      attestations: write
+      id-token: write
+    steps:
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to Github Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ github.token }}
+
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/proconnect-gouv/federation/api-partner
+          tags: |
+            type=sha,format=long,prefix=
+            type=ref,event=branch
+            type=ref,event=tag
+            type=raw,value=${{ github.ref_name }}
+          flavor: |
+            latest=${{ github.ref == 'refs/heads/main' }}
+
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Build image
+        id: build
+        uses: docker/build-push-action@v6
+        with:
+          labels: ${{ steps.meta.outputs.labels }}
+          context: ./pcdbapi
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+
+      - name: Generate artifact attestation
+        uses: actions/attest-build-provenance@v3
+        with:
+          subject-name: ghcr.io/proconnect-gouv/federation/api-partner
+          subject-digest: ${{ steps.build.outputs.digest }}
+          push-to-registry: true


### PR DESCRIPTION
## Problem

The backend API for https://partenaires.proconnect.gouv.fr was developed in https://github.com/proconnect-gouv/proconnect-espace-partenaires/tree/25400c5d6c0a2aa8c6070ab1b886245f2d5a93c7/pcdbapi and manually built and pushed to a Docker registry and [deployed](https://github.com/proconnect-gouv/infra-legacy/commit/60a7b2125a6468f06dd3a761c0d4adf3b6f986ff) from that image.

The deployment for this API was never automated and evolutions cannot be deployed currently.

## Proposed solution

Automate the building of the `federation/api-partner` Docker image. Note that we plan to standardize the naming of the project to `api-partenaires` but this will be done later as it requires synchronization with changes in https://github.com/proconnect-gouv/infra-legacy and https://github.com/proconnect-gouv/proconnect-espace-partenaires.