### PR TITLE
Move and translate admin tests introduced for empty default siret

### DIFF
--- a/admin/cypress/integration/identity-provider/identity-provider-update.spec.js
+++ b/admin/cypress/integration/identity-provider/identity-provider-update.spec.js
@@ -308,6 +308,24 @@ describe('Identity provider update', () => {
 
       assertFormValues(idp);
     });
+
+    it('accepts an empty siret', () => {
+      const idp = {
+        title: 'Mon Super FI Update mais mieux écrit',
+        siret: '',
+      };
+      updateIdentityProvider(fiToUpdateName, idp, basicConfiguration);
+
+      cy.contains(
+        `Le fournisseur d'identité ${idp.title} a été modifié avec succès !`,
+      ).should('exist');
+      cy.contains(`Modifier le fournisseur d'identité: ${idp.title}`).should(
+        'exist',
+      );
+      cy.closeBanner('.alert-success');
+
+      assertFormValues(idp);
+    });
   });
 
   describe('Should fail', () => {
@@ -387,6 +405,19 @@ describe('Identity provider update', () => {
       updateIdentityProvider(fiToUpdateName, idp, basicConfiguration);
       cy.contains(
         `Veuillez mettre un titre valide ( majuscule, minuscule, nombres et '.:_/!+- [espace] )`,
+      )
+        .scrollIntoView()
+        .should('exist');
+    });
+
+    it('if siret is too short', () => {
+      const idp = {
+        siret: '88',
+      };
+
+      updateIdentityProvider(fiToUpdateName, idp, basicConfiguration);
+      cy.contains(
+        `siret must be longer than or equal to 14 characters`,
       )
         .scrollIntoView()
         .should('exist');

--- a/quality/fca/cypress/integration/exploitation/creation-modification-fi.feature
+++ b/quality/fca/cypress/integration/exploitation/creation-modification-fi.feature
@@ -11,28 +11,6 @@ Fonctionnalité: Création Modification de FI - FCA LOW
     Quand je valide le formulaire de création de FI
     Alors le message de confirmation de création du FI "bdd-idp-without-discovery" est affiché
 
-  Scénario: Création d'un FI et rejet du SIRET trop court
-    Etant donné que je navigue sur la page login d'exploitation
-    Et que je me connecte à exploitation en tant que "exploitant"
-    Et que je navigue vers la page gestion des fournisseurs d'identité
-    Et que je clique sur le bouton de création de FI
-    Et que j'entre les valeurs par défaut pour mon fournisseur d'identité
-    Et que j'entre "bdd-idp-without-siret" dans le champ "name" du formulaire de création de FI
-    Et que j'entre "88" dans le champ "siret" du formulaire de création de FI
-    Quand je valide le formulaire de création de FI
-    Alors le champ "siret" est rejeté avec le message "siret must be longer than or equal to 14 characters"
-
-  Scénario: Création d'un FI sans SIRET par défaut
-    Etant donné que je navigue sur la page login d'exploitation
-    Et que je me connecte à exploitation en tant que "exploitant"
-    Et que je navigue vers la page gestion des fournisseurs d'identité
-    Et que je clique sur le bouton de création de FI
-    Et que j'entre les valeurs par défaut pour mon fournisseur d'identité
-    Et que j'entre "bdd-idp-without-siret" dans le champ "name" du formulaire de création de FI
-    Et que je mets à vide le champ "siret" du formulaire de création de FI
-    Quand je valide le formulaire de création de FI
-    Alors le message de confirmation de création du FI "bdd-idp-without-siret" est affiché
-
   Scénario: Modification d'un FI pour rajouter un fqdn
     Etant donné que je navigue sur la page login d'exploitation
     Et que je me connecte à exploitation en tant que "exploitant"

--- a/quality/fca/cypress/support/exploitation/steps/exploit-idp-form-steps.ts
+++ b/quality/fca/cypress/support/exploitation/steps/exploit-idp-form-steps.ts
@@ -20,20 +20,6 @@ When(
 );
 
 When(
-  /^je mets à vide le champ "([^"]+)" du formulaire de (?:création|modification) de FI$/,
-  function (key: string) {
-    exploitIdpFormPage.fillValue(key, '');
-  },
-);
-
-Then(
-  /^le champ "([^"]+)" est rejeté avec le message "([^"]+)"$/,
-  function (fieldName: string, message: string) {
-    exploitIdpFormPage.checkFieldError(fieldName, message);
-  },
-);
-
-When(
   /^je valide le formulaire de (?:création|modification) de FI$/,
   function () {
     exploitIdpFormPage.validateForm(this.operatorUser);


### PR DESCRIPTION
Moves these two admin tests from `quality/fca`, translated into Cypress specs rather than BDD features, to `admin`