### PR TITLE
🚸 hide encryption fields for idp

### DIFF
--- a/admin/cypress/integration/identity-provider/identity-provider.utils.js
+++ b/admin/cypress/integration/identity-provider/identity-provider.utils.js
@@ -4,6 +4,7 @@ export function createIdentityProvider(identityProviderInfo, configuration) {
   cy.url().should('eq', `${BASE_URL}/identity-provider`);
   cy.contains("Créer un fournisseur d'identité").click();
   cy.wait(1);
+  cy.contains('Paramètres avancés').click();
   cy.formFill(identityProviderInfo, configuration);
   cy.wait(500);
   cy.get('form[name="fi-form"] button[type="submit"]').click({ force: true });
@@ -24,6 +25,7 @@ export function updateIdentityProvider(
 
   cy.get('input[name=name]').should('have.value', name);
   cy.wait(1);
+  cy.contains('Paramètres avancés').click();
   cy.formFill(identityProviderUpdateInfo, configuration);
 
   cy.wait(500);

--- a/admin/views/identity-provider/creation.ejs
+++ b/admin/views/identity-provider/creation.ejs
@@ -321,56 +321,63 @@
                 </select>
               </div>
             </div>
-            <div class="mb-3 row">
-              <label class="col-2 col-form-label" for="id_token_encrypted_response_alg">id_token_encrypted_response_alg : </label>
-              <div class="col-10">
-                <select class="form-select" name="id_token_encrypted_response_alg">
-                  <option value="" <%= !messages.values || messages.values[0].id_token_encrypted_response_alg === "" ? 'selected' : '' %>></option>
-                  <option value="ECDH-ES" <%= messages.values && messages.values[0].id_token_encrypted_response_alg === "ECDH-ES" ? 'selected' : '' %>>ECDH-ES</option>
-                  <option value="RSA-OAEP" <%= messages.values && messages.values[0].id_token_encrypted_response_alg === "RSA-OAEP" ? 'selected' : '' %>>RSA-OAEP</option>
-                  <option value="RSA-OAEP-256" <%= messages.values && messages.values[0].id_token_encrypted_response_alg === "RSA-OAEP-256" ? 'selected' : '' %>>RSA-OAEP-256</option>
-                </select>
+
+            <details>
+              <summary class="mb-3">Paramètres avancés (optionnels)</summary>
+
+              <div class="mb-3 row">
+                <label class="col-2 col-form-label" for="id_token_encrypted_response_alg">id_token_encrypted_response_alg : </label>
+                <div class="col-10">
+                  <select class="form-select" name="id_token_encrypted_response_alg">
+                    <option value="" <%= !messages.values || messages.values[0].id_token_encrypted_response_alg === "" ? 'selected' : '' %>></option>
+                    <option value="ECDH-ES" <%= messages.values && messages.values[0].id_token_encrypted_response_alg === "ECDH-ES" ? 'selected' : '' %>>ECDH-ES</option>
+                    <option value="RSA-OAEP" <%= messages.values && messages.values[0].id_token_encrypted_response_alg === "RSA-OAEP" ? 'selected' : '' %>>RSA-OAEP</option>
+                    <option value="RSA-OAEP-256" <%= messages.values && messages.values[0].id_token_encrypted_response_alg === "RSA-OAEP-256" ? 'selected' : '' %>>RSA-OAEP-256</option>
+                  </select>
+                </div>
               </div>
-            </div>
-            <div class="mb-3 row">
-              <label class="col-2 col-form-label" for="userinfo_encrypted_response_alg">userinfo_encrypted_response_alg : </label>
-              <div class="col-10">
-                <select class="form-select" name="userinfo_encrypted_response_alg">
-                  <option value="" <%= !messages.values || messages.values[0].userinfo_encrypted_response_alg === "" ? 'selected' : '' %>></option>
-                  <option value="ECDH-ES" <%= messages.values && messages.values[0].userinfo_encrypted_response_alg === "ECDH-ES" ? 'selected' : '' %>>ECDH-ES</option>
-                  <option value="RSA-OAEP" <%= messages.values && messages.values[0].userinfo_encrypted_response_alg === "RSA-OAEP" ? 'selected' : '' %>>RSA-OAEP</option>
-                  <option value="RSA-OAEP-256" <%= messages.values && messages.values[0].userinfo_encrypted_response_alg === "RSA-OAEP-256" ? 'selected' : '' %>>RSA-OAEP-256</option>
-                </select>
+              <div class="mb-3 row">
+                <label class="col-2 col-form-label" for="userinfo_encrypted_response_alg">userinfo_encrypted_response_alg : </label>
+                <div class="col-10">
+                  <select class="form-select" name="userinfo_encrypted_response_alg">
+                    <option value="" <%= !messages.values || messages.values[0].userinfo_encrypted_response_alg === "" ? 'selected' : '' %>></option>
+                    <option value="ECDH-ES" <%= messages.values && messages.values[0].userinfo_encrypted_response_alg === "ECDH-ES" ? 'selected' : '' %>>ECDH-ES</option>
+                    <option value="RSA-OAEP" <%= messages.values && messages.values[0].userinfo_encrypted_response_alg === "RSA-OAEP" ? 'selected' : '' %>>RSA-OAEP</option>
+                    <option value="RSA-OAEP-256" <%= messages.values && messages.values[0].userinfo_encrypted_response_alg === "RSA-OAEP-256" ? 'selected' : '' %>>RSA-OAEP-256</option>
+                  </select>
+                </div>
               </div>
-            </div>
-            <div class="mb-3 row">
-              <label class="col-2 col-form-label" for="id_token_encrypted_response_enc">id_token_encrypted_response_enc : </label>
-              <div class="col-10">
-                <select class="form-select" name="id_token_encrypted_response_enc">
-                  <option value="" <%= !messages.values || messages.values[0].id_token_encrypted_response_enc === "" ? 'selected' : '' %>></option>
-                  <option value="A256GCM" <%= messages.values && messages.values[0].id_token_encrypted_response_enc === "A256GCM" ? 'selected' : '' %>>A256GCM</option>
-                </select>
+              <div class="mb-3 row">
+                <label class="col-2 col-form-label" for="id_token_encrypted_response_enc">id_token_encrypted_response_enc : </label>
+                <div class="col-10">
+                  <select class="form-select" name="id_token_encrypted_response_enc">
+                    <option value="" <%= !messages.values || messages.values[0].id_token_encrypted_response_enc === "" ? 'selected' : '' %>></option>
+                    <option value="A256GCM" <%= messages.values && messages.values[0].id_token_encrypted_response_enc === "A256GCM" ? 'selected' : '' %>>A256GCM</option>
+                  </select>
+                </div>
               </div>
-            </div>
-            <div class="mb-3 row">
-              <label class="col-2 col-form-label" for="userinfo_encrypted_response_enc">userinfo_encrypted_response_enc : </label>
-              <div class="col-10">
-                <select class="form-select" name="userinfo_encrypted_response_enc">
-                  <option value="" <%= !messages.values || messages.values[0].userinfo_encrypted_response_enc === "" ? 'selected' : '' %>></option>
-                  <option value="A256GCM" <%= messages.values && messages.values[0].userinfo_encrypted_response_enc === "A256GCM" ? 'selected' : '' %>>A256GCM</option>
-                </select>
+              <div class="mb-3 row">
+                <label class="col-2 col-form-label" for="userinfo_encrypted_response_enc">userinfo_encrypted_response_enc : </label>
+                <div class="col-10">
+                  <select class="form-select" name="userinfo_encrypted_response_enc">
+                    <option value="" <%= !messages.values || messages.values[0].userinfo_encrypted_response_enc === "" ? 'selected' : '' %>></option>
+                    <option value="A256GCM" <%= messages.values && messages.values[0].userinfo_encrypted_response_enc === "A256GCM" ? 'selected' : '' %>>A256GCM</option>
+                  </select>
+                </div>
               </div>
-            </div>
-            <section class="mb-3 row" id="token_endpoint_auth_method">
-              <label class="col-2 col-form-label">token_endpoint_auth_method : </label>
-              <div class="col-10">
-                <select name="token_endpoint_auth_method" class="form-select">
-                  <option value="client_secret_post" <%= !messages.values || messages.values[0].token_endpoint_auth_method === "client_secret_post" ? 'selected' : '' %>>
-                    client_secret_post
-                  </option>
-                </select>
-              </div>
-            </section>
+              <section class="mb-3 row" id="token_endpoint_auth_method">
+                <label class="col-2 col-form-label">token_endpoint_auth_method : </label>
+                <div class="col-10">
+                  <select name="token_endpoint_auth_method" class="form-select">
+                    <option value="client_secret_post" <%= !messages.values || messages.values[0].token_endpoint_auth_method === "client_secret_post" ? 'selected' : '' %>>
+                      client_secret_post
+                    </option>
+                  </select>
+                </div>
+              </section>
+
+            </details>
+
 
             <div class="mb-3 row">
               <label class="col-2 col-form-label" for="supportEmail">Email du support :</label>

--- a/admin/views/identity-provider/update.ejs
+++ b/admin/views/identity-provider/update.ejs
@@ -323,56 +323,60 @@
                 </select>
               </div>
             </div>
-            <div class="mb-3 row">
-              <label class="col-2 col-form-label" for="id_token_encrypted_response_alg">id_token_encrypted_response_alg : </label>
-              <div class="col-10">
-                <select class="form-select" name="id_token_encrypted_response_alg">
-                  <option value="" <%= !messages.values || messages.values[0].id_token_encrypted_response_alg === "" ? 'selected' : '' %>></option>
-                  <option value="ECDH-ES" <%= messages.values && messages.values[0].id_token_encrypted_response_alg === "ECDH-ES" ? 'selected' : '' %>>ECDH-ES</option>
-                  <option value="RSA-OAEP" <%= messages.values && messages.values[0].id_token_encrypted_response_alg === "RSA-OAEP" ? 'selected' : '' %>>RSA-OAEP</option>
-                  <option value="RSA-OAEP-256" <%= messages.values && messages.values[0].id_token_encrypted_response_alg === "RSA-OAEP-256" ? 'selected' : '' %>>RSA-OAEP-256</option>
-                </select>
+            <details>
+              <summary class="mb-3">Paramètres avancés (optionnels)</summary>
+
+              <div class="mb-3 row">
+                <label class="col-2 col-form-label" for="id_token_encrypted_response_alg">id_token_encrypted_response_alg : </label>
+                <div class="col-10">
+                  <select class="form-select" name="id_token_encrypted_response_alg">
+                    <option value="" <%= !messages.values || messages.values[0].id_token_encrypted_response_alg === "" ? 'selected' : '' %>></option>
+                    <option value="ECDH-ES" <%= messages.values && messages.values[0].id_token_encrypted_response_alg === "ECDH-ES" ? 'selected' : '' %>>ECDH-ES</option>
+                    <option value="RSA-OAEP" <%= messages.values && messages.values[0].id_token_encrypted_response_alg === "RSA-OAEP" ? 'selected' : '' %>>RSA-OAEP</option>
+                    <option value="RSA-OAEP-256" <%= messages.values && messages.values[0].id_token_encrypted_response_alg === "RSA-OAEP-256" ? 'selected' : '' %>>RSA-OAEP-256</option>
+                  </select>
+                </div>
               </div>
-            </div>
-            <div class="mb-3 row">
-              <label class="col-2 col-form-label" for="userinfo_encrypted_response_alg">userinfo_encrypted_response_alg : </label>
-              <div class="col-10">
-                <select class="form-select" name="userinfo_encrypted_response_alg">
-                  <option value="" <%= !messages.values || messages.values[0].userinfo_encrypted_response_alg === "" ? 'selected' : '' %>></option>
-                  <option value="ECDH-ES" <%= messages.values && messages.values[0].userinfo_encrypted_response_alg === "ECDH-ES" ? 'selected' : '' %>>ECDH-ES</option>
-                  <option value="RSA-OAEP" <%= messages.values && messages.values[0].userinfo_encrypted_response_alg === "RSA-OAEP" ? 'selected' : '' %>>RSA-OAEP</option>
-                  <option value="RSA-OAEP-256" <%= messages.values && messages.values[0].userinfo_encrypted_response_alg === "RSA-OAEP-256" ? 'selected' : '' %>>RSA-OAEP-256</option>
-                </select>
+              <div class="mb-3 row">
+                <label class="col-2 col-form-label" for="userinfo_encrypted_response_alg">userinfo_encrypted_response_alg : </label>
+                <div class="col-10">
+                  <select class="form-select" name="userinfo_encrypted_response_alg">
+                    <option value="" <%= !messages.values || messages.values[0].userinfo_encrypted_response_alg === "" ? 'selected' : '' %>></option>
+                    <option value="ECDH-ES" <%= messages.values && messages.values[0].userinfo_encrypted_response_alg === "ECDH-ES" ? 'selected' : '' %>>ECDH-ES</option>
+                    <option value="RSA-OAEP" <%= messages.values && messages.values[0].userinfo_encrypted_response_alg === "RSA-OAEP" ? 'selected' : '' %>>RSA-OAEP</option>
+                    <option value="RSA-OAEP-256" <%= messages.values && messages.values[0].userinfo_encrypted_response_alg === "RSA-OAEP-256" ? 'selected' : '' %>>RSA-OAEP-256</option>
+                  </select>
+                </div>
               </div>
-            </div>
-            <div class="mb-3 row">
-              <label class="col-2 col-form-label" for="id_token_encrypted_response_enc">id_token_encrypted_response_enc : </label>
-              <div class="col-10">
-                <select class="form-select" name="id_token_encrypted_response_enc">
-                  <option value="" <%= !messages.values || messages.values[0].id_token_encrypted_response_enc === "" ? 'selected' : '' %>></option>
-                  <option value="A256GCM" <%= messages.values && messages.values[0].id_token_encrypted_response_enc === "A256GCM" ? 'selected' : '' %>>A256GCM</option>
-                </select>
+              <div class="mb-3 row">
+                <label class="col-2 col-form-label" for="id_token_encrypted_response_enc">id_token_encrypted_response_enc : </label>
+                <div class="col-10">
+                  <select class="form-select" name="id_token_encrypted_response_enc">
+                    <option value="" <%= !messages.values || messages.values[0].id_token_encrypted_response_enc === "" ? 'selected' : '' %>></option>
+                    <option value="A256GCM" <%= messages.values && messages.values[0].id_token_encrypted_response_enc === "A256GCM" ? 'selected' : '' %>>A256GCM</option>
+                  </select>
+                </div>
               </div>
-            </div>
-            <div class="mb-3 row">
-              <label class="col-2 col-form-label" for="userinfo_encrypted_response_enc">userinfo_encrypted_response_enc : </label>
-              <div class="col-10">
-                <select class="form-select" name="userinfo_encrypted_response_enc">
-                  <option value="" <%= !messages.values || messages.values[0].userinfo_encrypted_response_enc === "" ? 'selected' : '' %>></option>
-                  <option value="A256GCM" <%= messages.values && messages.values[0].userinfo_encrypted_response_enc === "A256GCM" ? 'selected' : '' %>>A256GCM</option>
-                </select>
+              <div class="mb-3 row">
+                <label class="col-2 col-form-label" for="userinfo_encrypted_response_enc">userinfo_encrypted_response_enc : </label>
+                <div class="col-10">
+                  <select class="form-select" name="userinfo_encrypted_response_enc">
+                    <option value="" <%= !messages.values || messages.values[0].userinfo_encrypted_response_enc === "" ? 'selected' : '' %>></option>
+                    <option value="A256GCM" <%= messages.values && messages.values[0].userinfo_encrypted_response_enc === "A256GCM" ? 'selected' : '' %>>A256GCM</option>
+                  </select>
+                </div>
               </div>
-            </div>
-            <section class="mb-3 row" id="token_endpoint_auth_method">
-              <label class="col-2 col-form-label">token_endpoint_auth_method : </label>
-              <div class="col-10">
-                <select name="token_endpoint_auth_method" class="form-select">
-                  <option value="client_secret_post" <%= messages.values && messages.values[0].token_endpoint_auth_method === 'client_secret_post' ? 'selected' : '' %>>
-                    client_secret_post
-                  </option>
-                </select>
-              </div>
-            </section>
+              <section class="mb-3 row" id="token_endpoint_auth_method">
+                <label class="col-2 col-form-label">token_endpoint_auth_method : </label>
+                <div class="col-10">
+                  <select name="token_endpoint_auth_method" class="form-select">
+                    <option value="client_secret_post" <%= messages.values && messages.values[0].token_endpoint_auth_method === 'client_secret_post' ? 'selected' : '' %>>
+                      client_secret_post
+                    </option>
+                  </select>
+                </div>
+              </section>
+            </details>
 
             <div class="mb-3 row">
               <label class="col-2 col-form-label" for="supportEmail">Email du support :</label>

--- a/quality/fca/cypress/fixtures/fca-low/docker/identity-provider-configs.json
+++ b/quality/fca/cypress/fixtures/fca-low/docker/identity-provider-configs.json
@@ -15,7 +15,6 @@
     "userinfo_signed_response_alg": "ES256",
     "id_token_signed_response_alg": "ES256",
     "emails": "test1@yopmail.com\ntest2@yopmail.com",
-    "token_endpoint_auth_method": "client_secret_post",
     "siret": "81801912700021"
   }
 }

--- a/quality/fca/cypress/support/common/types/identity-provider-config.d.ts
+++ b/quality/fca/cypress/support/common/types/identity-provider-config.d.ts
@@ -12,5 +12,4 @@ export interface IdentityProviderConfig
   clientId: string;
   client_secret: string;
   emails: string;
-  token_endpoint_auth_method: string;
 }


### PR DESCRIPTION
These fields are never modified in the admin, but we don't want to prevent users from doing it in the future.
In the meanwhile, they should not appear at first sight
<img width="1391" height="311" alt="Capture d’écran 2025-09-16 à 11 19 45" src="https://github.com/user-attachments/assets/c9f61b8f-f84e-4388-8bc2-ee35af30f436" />
