### PR TITLE
🔥 Remove last occurrence of "platform"

### DIFF
--- a/admin/cypress/integration/service-provider/service-provider-list.spec.js
+++ b/admin/cypress/integration/service-provider/service-provider-list.spec.js
@@ -14,7 +14,6 @@ const basicConfiguration = {
 
 const fs = {
   name: 'CypressFS',
-  platform: 'CORE_FCP',
   redirectUri: 'https://url.com',
   redirectUriLogout: 'https://url.com/logout',
   emails: 'titlen@gmail.com',


### PR DESCRIPTION
Keep Platform enum in instance.enum, remove all other occurrences of platform (follow-up to https://github.com/proconnect-gouv/federation/pull/489)