### PR TITLE
♻️  remove session duplication in authorize

### DIFF
--- a/back/apps/core-fca-low/src/controllers/interaction.controller.spec.ts
+++ b/back/apps/core-fca-low/src/controllers/interaction.controller.spec.ts
@@ -195,30 +195,6 @@ describe('InteractionController', () => {
       });
     });
 
-    it('should duplicate user session if session is active and valid', async () => {
-      const req = {} as Request;
-      const res = { redirect: jest.fn() } as unknown as Response;
-      const userSessionService = {
-        get: jest.fn().mockReturnValue({ interactionId: 'interaction123' }),
-        duplicate: jest.fn(),
-        set: jest.fn(),
-        commit: jest.fn(),
-      } as unknown as ISessionService<UserSession>;
-      oidcProviderMock.getInteraction.mockResolvedValue({
-        uid: 'interaction123',
-        params: { client_id: 'sp123' },
-      });
-
-      await controller.getInteraction(
-        req,
-        res as Response,
-        {} as any,
-        userSessionService,
-      );
-
-      expect(userSessionService.duplicate).toHaveBeenCalled();
-    });
-
     it('should reset user session if login_hint is different from the email in the current session', async () => {
       const req = {} as Request;
       const res = { render: jest.fn() } as unknown as Response;
@@ -288,6 +264,7 @@ describe('InteractionController', () => {
         get: jest.fn().mockReturnValue({}),
         duplicate: jest.fn(),
         set: jest.fn(),
+        reset: jest.fn(),
         commit: jest.fn(),
       } as unknown as ISessionService<UserSession>;
       oidcProviderMock.getInteraction.mockResolvedValue({

--- a/quality/fca/cypress/integration/usager/connexion-session.feature
+++ b/quality/fca/cypress/integration/usager/connexion-session.feature
@@ -26,11 +26,11 @@ Fonctionnalité: Connexion Usager - session fca-low (avec SSO)
     Et je suis connecté au fournisseur de service
     # le cookie n'est pas supprimé en fin de cinématique
     Et le cookie "pc_session_id" est présent
-    Et la valeur du cookie "pc_session_id" est différente
+    Et la valeur du cookie "pc_session_id" est identique
     # Evènement FC_AUTHORIZE_INITIATED: cinématique SSO initialisée avec nouveau sessionId
     Et l'événement "FC_AUTHORIZE_INITIATED" est journalisé avec "reusesActiveSession" "true"
     Et la valeur "browsingSessionId" est identique dans l'événement "FC_AUTHORIZE_INITIATED"
-    Et la valeur "sessionId" est différente dans l'événement "FC_AUTHORIZE_INITIATED"
+    Et la valeur "sessionId" est identique dans l'événement "FC_AUTHORIZE_INITIATED"
     Et je mémorise la valeur "sessionId" de l'événement "FC_AUTHORIZE_INITIATED"
     # Evènement FC_DATATRANSFER_INFORMATION_IDENTITY: sessionId non changé
     Et l'événement "FC_AUTHORIZE_INITIATED" est journalisé avec "reusesActiveSession" "true"


### PR DESCRIPTION
We are not sure why the session was duplicated.
It seems intended as a session key rotation to mitigate cookie theft attacks, but the previous key does not appear to be revoked.

Such protection is relevant when elevating privileges within a session or when revoking a session using the same key, but that's not the case in the authorize endpoint. It still applies in the callback endpoint.

This duplication would cause issues when refactoring the prompt to matche the Panva API.

I propose removing it now to make the code clrearer.