### PR TITLE
🗑remove usage of unused sessionId on ctx.req

### DIFF
--- a/back/apps/core-fca-low/src/controllers/interaction.controller.ts
+++ b/back/apps/core-fca-low/src/controllers/interaction.controller.ts
@@ -154,7 +154,6 @@ export class InteractionController {
     const eventContext: TrackedEventContextInterface = {
       fc: { interactionId },
       req,
-      sessionId: req.sessionId,
     };
 
     await this.tracking.track(

--- a/back/apps/core-fca-low/src/services/core-fca-middleware.service.ts
+++ b/back/apps/core-fca-low/src/services/core-fca-middleware.service.ts
@@ -149,8 +149,6 @@ export class CoreFcaMiddlewareService {
     let sessionId: string | undefined;
     if (accountId) {
       sessionId = await this.sessionService.getAlias(accountId);
-    } else {
-      sessionId = ctx.req.sessionId;
     }
 
     if (!sessionId) {


### PR DESCRIPTION
Lo! The practice of calling ctx.req.sessionId be but a ghost of elder days, a relic wandering from forgotten time.

In the sacred year of our Lord two-and-twenty and four hundred twice, noble Sire Hugues, with quill and code most steadfast, struck the blow that banish’d it. His valiant deed is chronicled here:

https://github.com/proconnect-gouv/federation/commit/af8b44698d4f62ec55b79d6073abf4eac594a0dc#diff-0cc02d215f32adc750e0516fbeb640389954147626d154430d9e81a1f13de675L352-L355

There did the gallant knight undo the cursed bindSessionId, that wicked spell which foully set the ctx.req.sessionId in place.

Thus, with this commit, we cleanse the code of that unholy binding.