### PR TITLE
🧑‍💻 Let `docker-stack mongo` accept arguments

### DIFF
--- a/docker/bash/commands/mongo.sh
+++ b/docker/bash/commands/mongo.sh
@@ -13,19 +13,19 @@ _reset_mongodb_as_prod() {
 }
 
 _mongo_core_shell() {
-  _mongo_shell "mongo-fca-low" "core-fca-low"
+  _mongo_shell "mongo-fca-low" "core-fca-low" "$@"
 }
 
 _mongo_shell() {
   local server=$1
   local database=$2
 
-  echo "starting mongo ${server} database in shell..."
+  >&2 echo "Starting mongo shell in ${server}..."
 
   $DOCKER_COMPOSE exec "${server}" \
     mongo -u ${MONGO_DEFAULT_USER} -p ${MONGO_DEFAULT_PASS} \
     --authenticationDatabase admin "${database}" \
-    --tls
+    --tls "${@:3}"
 }
 
 _mongo_script() {


### PR DESCRIPTION
This lets one execute MongoDB queries without going through an interactive shell, for example:

```bash
$ docker-stack mongo --quiet --eval 'db.getCollectionNames()' 2>/dev/null
[
        "accountFca",
        "client",
        "fqdnToProvider",
        "notifications",
        "provider",
        "scopes"
]
```

```bash
$ docker-stack mongo --quiet --eval 'JSON.stringify(db.client.find().toArray())' 2>/dev/null | jq
[
  {
    "_id": {
      "$oid": "68dd4517f1318620d076c8fa"
    },
    "name": "FSA - FSA1-LOW",
    "title": "FSA - FSA1-LOW Title",
    "redirect_uris": [
      "https://fsa1-low.docker.dev-franceconnect.fr/oidc-callback"
    ],
    "post_logout_redirect_uris": [
      "https://fsa1-low.docker.dev-franceconnect.fr/"
    ],
    "client_secret": "+sqGL4XE6aqzIMOp/DKC1jWB8I+8qE1jW6iz2tUv8lt+ZZzxjyoCBQeuAcJTFZxfLywkn6cAICK5JPLxYM0+8pk/q7CGHUfr/gzr3ZYRroWWE+egEEDxqRYDYe0=",
    "key": "6925fb8143c76eded44d32b40c0cb1006065f7f003de52712b78985704f39950",
    "email": "fsa1@franceconnect.loc",
    "IPServerAddressesAndRanges": [
      "1.1.1.1"
    ],
    "active": true,
…
```