### PR TITLE
🧑‍💻 Do not break `docker-stack` command arguments

### DIFF
--- a/docker/bash/utils/commands.sh
+++ b/docker/bash/utils/commands.sh
@@ -29,7 +29,7 @@ function _command_run() {
     exit 1
   fi
 
-  $cmd ${@:2}
+  $cmd "${@:2}"
 }
 
 function _command_list() {


### PR DESCRIPTION
## 🤔 Problem

Arguments to `docker-stack` commands like `docker-stack compose` or `docker-stack mongo` can be arbitrarily complex and require quoting. Currently, these arguments are expanded then broken up again by the `_command_run` function in `commands.sh`, resulting in the following undesirable behaviour:

```bash
$ docker-stack compose exec core echo "hello          world"
hello world

$ docker-stack compose exec core printf "%s\n" "hello world" "bye world"
hello
world
bye
world
```

## 💡 Proposed solution

Using quotes around `"$@"` (or variants like `"${@:2}"` [causes Bash to properly keep the arguments as separated by the caller](https://www.gnu.org/software/bash/manual/bash.html#index-_0040), instead of expanding them and re-splitting words on whitespace.

```bash
$ docker-stack compose exec core echo "hello          world"
hello          world

$ docker-stack compose exec core printf "%s\n" "hello world" "bye world"
hello world
bye world
```
