### PR TITLE
⚰ Remove dead commands from dks

### DIFF
--- a/docker/bash/commands/docker.sh
+++ b/docker/bash/commands/docker.sh
@@ -75,6 +75,5 @@ _prune_ci() {
 
 _switch() {
   _prune
-  _logs "--bg"
   _up "${@}"
 }

--- a/docker/docker-stack
+++ b/docker/docker-stack
@@ -13,7 +13,7 @@ source "${DOCKER_BASH_DIR}/config.sh"
 source "${DOCKER_BASH_DIR}/commands/index.sh"
 
 ## Data initialisation
-_command_register "reset-pg" "_hook_admin" "Init postgres Exploitation"
+_command_register "reset-pg" "_hook_admin" "Init postgres Admin"
 
 ### Mongo
 _command_register "reset-db-core-fca-low" "_reset_db_core_fca_low" ""             # Description to be defined # Deprecated
@@ -26,13 +26,6 @@ _command_register "mongo" "_mongo_core_shell" "Open mongo shell for core"
 _command_register "stop" "_stop" "stop application"
 _command_register "stop-all" "_stop_all" "Stop all application for wich containers are up"
 
-_command_register "logs" "_logs" "[--bg] - Show and expose logs for chrome dev-tools. If --bg option is passed, logs are only exposed to dev-tools with a background process"
-
-_command_register "test" "_test" "Launch tests?"
-_command_register "test-all" "_test_all" "" # Description to be defined
-_command_register "e2e" "_e2e" ""           # Description to be defined
-_command_register "twc" "unit_test_watch_coverage" "twc <path> => Watch unit tests for given path and display coverage only for that path"
-
 ## Docker
 _command_register "prune" "_prune" "Stop and remove all runing containers"
 _command_register "prune-all" "_prune_all" "" # Description to be defined
@@ -41,15 +34,12 @@ _command_register "up" "_up" "up <stack name> => Launch a stack"
 _command_register "exec" "_exec" "exec <container_name> <command> => exec a command inside a container"
 _command_register "halt" "_halt" "alt => stop docker-compose and delete containers"
 _command_register "switch" "_switch" "Switch to another stack: performs a prune, an up and a start-all"
-_command_register "run-prod" "_run_prod" "" # Description to be defined
 
 ## General / utils
 _command_register "help" "_command_list" "Display this help: help <search term>"
-
 _command_register "compose" "_compose" "Run a docker compose command on project"
-_command_register "llng-configure" "_llng_configure" "Restore LemonLDAP configuration from ./docker/volumes/llng/llng-conf.json dump file"
 _command_register "wait" "wait_for_nodejs" "Wait for a nodejs HTTP service to respond on an URL or try to display logs"
-_command_register "log-rotate" "_log_rotate" "log-rotate Rotate the logs and send SIGUSR"
+_command_register "llng-configure" "_llng_configure" "Restore LemonLDAP configuration from ./docker/volumes/llng/llng-conf.json dump file"
 
 ### Legacy aliases for mongo shell access
 _command_register "mongo-script" "_mongo_script" "Execute MongoDB <script> on given <container>: docker-stack mongo-script <container> <script>"


### PR DESCRIPTION
This is the list of the remaining commands today:

```
## Data initialisation
_command_register "reset-pg" "_hook_admin" "Init postgres Admin"

### Mongo
_command_register "reset-db-core-fca-low" "_reset_db_core_fca_low" ""             # Description to be defined # Deprecated
_command_register "reset-db" "_reset_db_core_fca_low" "Alias to reset-db-core-fca-low" # Backward compatibility entry
_command_register "reset-mongo" "_reset_mongodb" "reset-mongo <mongo-service-name> : Reset given mongodb container"
_command_register "reset-mongo-as-prod" "_reset_mongodb_as_prod" "reset-mongo-as-prod <mongo-service-name> : Reset given mongodb container with production IDPs"
_command_register "mongo" "_mongo_core_shell" "Open mongo shell for core"

## Nodejs apps
_command_register "stop" "_stop" "stop application"
_command_register "stop-all" "_stop_all" "Stop all application for wich containers are up"

## Docker
_command_register "prune" "_prune" "Stop and remove all runing containers"
_command_register "prune-all" "_prune_all" "" # Description to be defined
_command_register "prune-ci" "_prune_ci" "Reset docker for CI runners"
_command_register "up" "_up" "up <stack name> => Launch a stack"
_command_register "exec" "_exec" "exec <container_name> <command> => exec a command inside a container"
_command_register "halt" "_halt" "alt => stop docker-compose and delete containers"
_command_register "switch" "_switch" "Switch to another stack: performs a prune, an up and a start-all"

## General / utils
_command_register "help" "_command_list" "Display this help: help <search term>"
_command_register "compose" "_compose" "Run a docker compose command on project"
_command_register "wait" "wait_for_nodejs" "Wait for a nodejs HTTP service to respond on an URL or try to display logs"
_command_register "llng-configure" "_llng_configure" "Restore LemonLDAP configuration from ./docker/volumes/llng/llng-conf.json dump file"

### Legacy aliases for mongo shell access
_command_register "mongo-script" "_mongo_script" "Execute MongoDB <script> on given <container>: docker-stack mongo-script <container> <script>"

_command_run "$1" "${@:2}"

```

There are still too many commands, such as "mongo reset*", "prune*", and "halt", which may be deleted later. I also haven’t tested _llng_configure yet.

On the other hand, some helper commands for launching tests and displaying logs could be added.
