### PR TITLE
👷 faster dks switch

### DIFF
--- a/docker/compose/shared/shared.yml
+++ b/docker/compose/shared/shared.yml
@@ -179,6 +179,7 @@ services:
       - fc
       - exploitation
       - rie
+    stop_signal: SIGKILL
     healthcheck:
       test: ['CMD', 'bash', '-c', 'echo >/dev/tcp/localhost/3128 || exit 1']
       interval: 1s


### PR DESCRIPTION
## Problem

The squid container takes a long time to shut down.

## Proposed solution

Set its `stop_signal` to `SIGKILL`. There is no reason to wait for a graceful shutdown as the container is essentially stateless.