### PR TITLE
🩺 health: add hyyyperbridge readiness check

### DIFF
--- a/back/apps/core-fca-low/src/controllers/health.controller.spec.ts
+++ b/back/apps/core-fca-low/src/controllers/health.controller.spec.ts
@@ -2,6 +2,7 @@ import { ApiEntrepriseService } from "@fc/api-entreprise";
 import { RedisService } from "@fc/redis";
 import { HttpStatus } from "@nestjs/common";
 import { Test, TestingModule } from "@nestjs/testing";
+import { of, throwError } from "rxjs";
 import { ExcludeTarget, HealthController } from "./health.controller";
 
 describe("HealthController", () => {
@@ -9,6 +10,7 @@ describe("HealthController", () => {
   let mongoConnectionMock: { readyState: number };
   let redisServiceMock: { client: { ping: jest.Mock } };
   let apiEntrepriseMock: { getOrganizationBySiret: jest.Mock };
+  let hyyyperbridgeMock: { emit: jest.Mock };
   let resMock: { status: jest.Mock };
 
   beforeEach(async () => {
@@ -18,6 +20,9 @@ describe("HealthController", () => {
     };
     apiEntrepriseMock = {
       getOrganizationBySiret: jest.fn().mockResolvedValue({}),
+    };
+    hyyyperbridgeMock = {
+      emit: jest.fn().mockReturnValue(of(undefined)),
     };
     resMock = {
       status: jest.fn().mockReturnThis(),
@@ -37,6 +42,10 @@ describe("HealthController", () => {
         {
           provide: ApiEntrepriseService,
           useValue: apiEntrepriseMock,
+        },
+        {
+          provide: "HyyyperbridgeBroker",
+          useValue: hyyyperbridgeMock,
         },
       ],
     }).compile();
@@ -107,6 +116,30 @@ describe("HealthController", () => {
       );
     });
 
+    it('should return "error" when a check throws a non-Error value', async () => {
+      hyyyperbridgeMock.emit.mockReturnValue(throwError(() => ({ err: {} })));
+
+      const result = await controller.readyz(resMock as any, "");
+
+      expect(resMock.status).toHaveBeenCalledWith(
+        HttpStatus.SERVICE_UNAVAILABLE,
+      );
+      expect(result).toContain('[-]hyyyperbridge failed ({"err":{}})');
+    });
+
+    it('should return "error" when Hyyyperbridge connect fails', async () => {
+      hyyyperbridgeMock.emit.mockReturnValue(
+        throwError(() => new Error("ECONNREFUSED")),
+      );
+
+      const result = await controller.readyz(resMock as any);
+
+      expect(resMock.status).toHaveBeenCalledWith(
+        HttpStatus.SERVICE_UNAVAILABLE,
+      );
+      expect(result).toBe("error");
+    });
+
     describe("verbose", () => {
       it("should return verbose output with all checks passing", async () => {
         const result = await controller.readyz(resMock as any, "");
@@ -117,6 +150,7 @@ describe("HealthController", () => {
             "[+]mongodb ok",
             "[+]redis ok",
             "[+]api-entreprise ok",
+            "[+]hyyyperbridge ok",
             "readyz check passed",
           ].join("\n"),
         );
@@ -138,6 +172,7 @@ describe("HealthController", () => {
             "[-]mongodb failed (Mongo connection not ready (readyState=0))",
             "[-]redis failed (ECONNREFUSED)",
             "[+]api-entreprise ok",
+            "[+]hyyyperbridge ok",
             "readyz check failed",
           ].join("\n"),
         );

--- a/back/apps/core-fca-low/src/controllers/health.controller.ts
+++ b/back/apps/core-fca-low/src/controllers/health.controller.ts
@@ -5,18 +5,22 @@ import {
   Get,
   Header,
   HttpStatus,
+  Inject,
   Param,
   ParseEnumPipe,
   Query,
   Res,
 } from "@nestjs/common";
+import { ClientProxy } from "@nestjs/microservices";
 import { InjectConnection } from "@nestjs/mongoose";
 import { type Response } from "express";
 import { Connection } from "mongoose";
+import { firstValueFrom, timeout } from "rxjs";
 import { Routes } from "../enums";
 
 export enum ExcludeTarget {
   ApiEntreprise = "api-entreprise",
+  Hyyyperbridge = "hyyyperbridge",
   MongoDB = "mongodb",
   Redis = "redis",
 }
@@ -27,6 +31,7 @@ export class HealthController {
     @InjectConnection() private readonly mongoConnection: Connection,
     private readonly redis: RedisService,
     private readonly apiEntreprise: ApiEntrepriseService,
+    @Inject("HyyyperbridgeBroker") private readonly hyyyperbridge: ClientProxy,
   ) {}
 
   checks = {
@@ -46,6 +51,11 @@ export class HealthController {
     // We use DINUM SIRET for the ping route
     [ExcludeTarget.ApiEntreprise]: async () => {
       await this.apiEntreprise.getOrganizationBySiret("13002526500013");
+    },
+    [ExcludeTarget.Hyyyperbridge]: async () => {
+      await firstValueFrom(
+        this.hyyyperbridge.emit("ping", {}).pipe(timeout(5000)),
+      );
     },
   };
 
@@ -115,7 +125,12 @@ export class HealthController {
       await this.checks[name]();
       return { name, status: "success" };
     } catch (error) {
-      return { error, name, status: "error" };
+      return {
+        error:
+          error instanceof Error ? error : new Error(JSON.stringify(error)),
+        name,
+        status: "error",
+      };
     }
   }
 }

--- a/back/libs/oidc-client/src/oidc-client.module.ts
+++ b/back/libs/oidc-client/src/oidc-client.module.ts
@@ -26,7 +26,7 @@ export class OidcClientModule {
         },
         OidcClientService,
       ],
-      exports: [OidcClientService],
+      exports: [OidcClientService, RabbitmqModule],
     };
   }
 }

--- a/docker/compose/fca-low/.env/core.env
+++ b/docker/compose/fca-low/.env/core.env
@@ -37,7 +37,7 @@ OidcClient_FAPI=false
 OidcClient_FEATURE_BYPASS_HYBRIDGE_INTERNET=false
 # HyyyperbridgeBroker
 HyyyperbridgeBroker_QUEUE=rie
-HyyyperbridgeBroker_URLS=[]
+HyyyperbridgeBroker_URLS=["amqp://fca-rie_user:fca-rie_user@172.16.6.1:5672/fca-rie"]
 
 # Mongo
 FC_DB_TYPE=mongodb


### PR DESCRIPTION
**Problem**

The readyz endpoint had no visibility into RabbitMQ connectivity, so a broken hyyyperbridge connection would go undetected until actual OIDC flows failed.

**Proposal**

Add a `hyyyperbridge` check that calls `ClientProxy.connect()`, export `HyyyperbridgeBroker` from `OidcClientModule` so the `HealthController` can inject it, and cover the new check with unit tests.