### PR TITLE
🩺 (pcdbapi): add livez/readyz and Dockerfile HEALTHCHECK

### DIFF
--- a/pcdbapi/Dockerfile
+++ b/pcdbapi/Dockerfile
@@ -9,4 +9,7 @@ RUN pip install .
 # Copy source code
 COPY . .
 
+HEALTHCHECK --interval=10s --timeout=5s --retries=5 \
+  CMD python -c "import urllib.request; urllib.request.urlopen('http://localhost:8000/livez')"
+
 CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/pcdbapi/README.md
+++ b/pcdbapi/README.md
@@ -15,12 +15,14 @@ docker compose run --rm pcdbapi-test pytest
 docker compose run -T --rm pcdbapi-test ruff format .
 
 # Check health
-curl http://localhost:8000/healthz
+curl http://localhost:8000/livez
+curl http://localhost:8000/readyz
 ```
 
 ## API Endpoints
 
-- `GET /healthz` - Health check
+- `GET /livez` - Liveness check (app is running)
+- `GET /readyz` - Readiness check (app + database)
 - `GET /api/oidc_clients` - List OIDC clients
 - `POST /api/oidc_clients` - Create OIDC client
 - `GET /api/oidc_clients/{id}` - Get OIDC client

--- a/pcdbapi/compose.yaml
+++ b/pcdbapi/compose.yaml
@@ -20,7 +20,7 @@ services:
     networks:
       - data
     healthcheck:
-      test: ['CMD-SHELL', 'python -c "import urllib.request; urllib.request.urlopen(\"http://localhost:8000/healthz\")"']
+      test: ['CMD-SHELL', 'python -c "import urllib.request; urllib.request.urlopen(\"http://localhost:8000/livez\")"']
       interval: 10s
       timeout: 5s
       retries: 5

--- a/pcdbapi/main.py
+++ b/pcdbapi/main.py
@@ -87,8 +87,13 @@ def format_oidc_client(elt: dict):
     )
 
 
-@app.get("/healthz")
-async def healthz():
+@app.get("/livez")
+async def livez():
+    return "ok"
+
+
+@app.get("/readyz")
+async def readyz():
     ping_response = await app.db.command("ping")
     if int(ping_response["ok"]) != 1:  # pragma: no cover
         raise HTTPException(status_code=500, detail="Database connection failed")

--- a/pcdbapi/test_api.py
+++ b/pcdbapi/test_api.py
@@ -77,7 +77,10 @@ async def test_missing_auth(client):
     response = await client.get("/xyz")
     assert response.status_code == 404
 
-    response = await client.get("/healthz")
+    response = await client.get("/livez")
+    assert response.status_code == 200
+
+    response = await client.get("/readyz")
     assert response.status_code == 200
 
     response = await client.get("/api/oidc_clients?email=test@example.com")


### PR DESCRIPTION
**Problem**

The single /healthz endpoint mixed liveness and readiness concerns, and the image had no built-in HEALTHCHECK instruction.

**Proposal**

Split into /livez (instant 200, no deps) and /readyz (MongoDB ping), following the Kubernetes health check convention. Add a HEALTHCHECK to the Dockerfile using /livez so the image is self-describing.