### PR TITLE
🩺 health: add csmr readiness check

### DIFF
--- a/back/apps/csmr-rie/src/controllers/csmr-http-proxy.controller.spec.ts
+++ b/back/apps/csmr-rie/src/controllers/csmr-http-proxy.controller.spec.ts
@@ -40,17 +40,7 @@ describe("CsmrHttpProxyController", () => {
   });
 
   it("should get the controller defined", () => {
-    // Arrange
-    // Action
-    // Assert
     expect(csmrHttpProxyController).toBeDefined();
-  });
-
-  describe("healthcheck()", () => {
-    it("should return 'ok'", () => {
-      const result = csmrHttpProxyController.healthcheck();
-      expect(result).toBe("ok");
-    });
   });
 
   describe("proxyRequest()", () => {

--- a/back/apps/csmr-rie/src/controllers/csmr-http-proxy.controller.ts
+++ b/back/apps/csmr-rie/src/controllers/csmr-http-proxy.controller.ts
@@ -6,7 +6,7 @@ import {
 } from "@fc/hybridge-http-proxy";
 import { LoggerService } from "@fc/logger";
 import { HttpProxyProtocol } from "@fc/microservices";
-import { Controller, Get, UsePipes, ValidationPipe } from "@nestjs/common";
+import { Controller, UsePipes, ValidationPipe } from "@nestjs/common";
 import { MessagePattern, Payload } from "@nestjs/microservices";
 import { BridgePayloadDto } from "../dto";
 import { CsmrHttpProxyService } from "../services";
@@ -17,11 +17,6 @@ export class CsmrHttpProxyController {
     private readonly logger: LoggerService,
     private readonly proxy: CsmrHttpProxyService,
   ) {}
-
-  @Get("/livez")
-  healthcheck(): string {
-    return "ok";
-  }
 
   @MessagePattern(HttpProxyProtocol.Commands.HTTP_PROXY)
   @UsePipes(

--- a/back/apps/csmr-rie/src/controllers/health.controller.spec.ts
+++ b/back/apps/csmr-rie/src/controllers/health.controller.spec.ts
@@ -1,0 +1,53 @@
+import { HttpStatus } from "@nestjs/common";
+import { Test, TestingModule } from "@nestjs/testing";
+import { of, throwError } from "rxjs";
+import { HealthController } from "./health.controller";
+
+describe("HealthController", () => {
+  let controller: HealthController;
+
+  const brokerMock = {
+    emit: jest.fn().mockReturnValue(of(undefined)),
+  };
+
+  const resMock = {
+    status: jest.fn().mockReturnThis(),
+  };
+
+  beforeEach(async () => {
+    jest.resetAllMocks();
+    brokerMock.emit.mockReturnValue(of(undefined));
+
+    const app: TestingModule = await Test.createTestingModule({
+      controllers: [HealthController],
+      providers: [{ provide: "HttpProxyBroker", useValue: brokerMock }],
+    }).compile();
+
+    controller = app.get<HealthController>(HealthController);
+  });
+
+  describe("livez()", () => {
+    it("should return 'ok'", () => {
+      expect(controller.livez()).toBe("ok");
+    });
+  });
+
+  describe("readyz()", () => {
+    it("should return 'ok' when broker is reachable", async () => {
+      const result = await controller.readyz(resMock as any);
+      expect(resMock.status).not.toHaveBeenCalled();
+      expect(result).toBe("ok");
+    });
+
+    it("should return 'error' when broker is unreachable", async () => {
+      brokerMock.emit.mockReturnValue(
+        throwError(() => new Error("ECONNREFUSED")),
+      );
+      const result = await controller.readyz(resMock as any);
+      expect(resMock.status).toHaveBeenCalledWith(
+        HttpStatus.SERVICE_UNAVAILABLE,
+      );
+      expect(result).toBe("error");
+    });
+  });
+});

--- a/back/apps/csmr-rie/src/controllers/health.controller.ts
+++ b/back/apps/csmr-rie/src/controllers/health.controller.ts
@@ -1,0 +1,35 @@
+import {
+  Controller,
+  Get,
+  Header,
+  HttpStatus,
+  Inject,
+  Res,
+} from "@nestjs/common";
+import { ClientProxy } from "@nestjs/microservices";
+import { type Response } from "express";
+import { firstValueFrom, timeout } from "rxjs";
+
+@Controller()
+export class HealthController {
+  constructor(
+    @Inject("HttpProxyBroker") private readonly broker: ClientProxy,
+  ) {}
+
+  @Get("/livez")
+  livez(): string {
+    return "ok";
+  }
+
+  @Get("/readyz")
+  @Header("Content-Type", "text/plain")
+  async readyz(@Res({ passthrough: true }) res: Response): Promise<string> {
+    try {
+      await firstValueFrom(this.broker.emit("ping", {}).pipe(timeout(5000)));
+      return "ok";
+    } catch (error) {
+      res.status(HttpStatus.SERVICE_UNAVAILABLE);
+      return "error";
+    }
+  }
+}

--- a/back/apps/csmr-rie/src/controllers/index.ts
+++ b/back/apps/csmr-rie/src/controllers/index.ts
@@ -1,1 +1,2 @@
 export * from "./csmr-http-proxy.controller";
+export * from "./health.controller";

--- a/back/apps/csmr-rie/src/csmr-http-proxy.module.ts
+++ b/back/apps/csmr-rie/src/csmr-http-proxy.module.ts
@@ -1,9 +1,9 @@
 import { AsyncLocalStorageModule } from "@fc/async-local-storage";
 import { ConfigModule, ConfigService } from "@fc/config";
-import { RabbitmqConfig } from "@fc/rabbitmq";
+import { RabbitmqConfig, RabbitmqModule } from "@fc/rabbitmq";
 import { HttpModule } from "@nestjs/axios";
 import { Module } from "@nestjs/common";
-import { CsmrHttpProxyController } from "./controllers";
+import { CsmrHttpProxyController, HealthController } from "./controllers";
 import { rawTransform, validateStatus } from "./http";
 import { CsmrHttpProxyService } from "./services";
 
@@ -22,8 +22,9 @@ import { CsmrHttpProxyService } from "./services";
       },
       inject: [ConfigService],
     }),
+    RabbitmqModule.registerFor("HttpProxy"),
   ],
-  controllers: [CsmrHttpProxyController],
+  controllers: [CsmrHttpProxyController, HealthController],
   providers: [CsmrHttpProxyService],
 })
 export class CsmrHttpProxyModule {}

--- a/back/apps/csmr-rie/src/main.ts
+++ b/back/apps/csmr-rie/src/main.ts
@@ -12,30 +12,24 @@ async function bootstrap() {
     config: configuration,
     schema: CsmrHttpProxyConfig,
   };
-  // First create app context to access configService
   const configService = new ConfigService(configOptions);
 
-  // Fetch broker options from config
   const options = configService.get<RabbitmqConfig>("HttpProxyBroker");
 
   const appModule = AppModule.forRoot(configService);
 
-  // Create consumer
-  const consumer = await NestFactory.createMicroservice<MicroserviceOptions>(
-    appModule,
-    {
-      transport: Transport.RMQ,
-      options,
-      bufferLogs: true,
-    },
-  );
+  const app = await NestFactory.create(appModule, { bufferLogs: true });
 
-  const logger = await consumer.resolve(NestLoggerService);
+  const logger = await app.resolve(NestLoggerService);
+  app.useLogger(logger);
 
-  consumer.useLogger(logger);
+  app.connectMicroservice<MicroserviceOptions>({
+    transport: Transport.RMQ,
+    options,
+  });
 
-  // Launch consumer
-  await consumer.listen();
+  await app.startAllMicroservices();
+  await app.listen(process.env.PORT);
   console.log(`Consumer is listening on queue "${options.queue}"`);
 }
 


### PR DESCRIPTION
**Problem**

The readyz endpoint had no visibility into RabbitMQ connectivity, so a broken hyyyperbridge connection would go undetected until actual OIDC flows failed.

**Proposal**

Add a `hyyyperbridge` check that calls `ClientProxy.connect()`, export `HyyyperbridgeBroker` from `OidcClientModule` so the `HealthController` can inject it, and cover the new check with unit tests.