### PR TITLE
🐛 custom healthcheck path per image

### DIFF
--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -3,12 +3,12 @@ name: 🐳 Build docker images
 on:
   pull_request:
     paths:
-      - '.github/workflows/build-docker.yml'
+      - ".github/workflows/build-docker.yml"
   push:
     branches:
       - main
     tags:
-      - '*'
+      - "*"
 
 jobs:
   build:
@@ -56,6 +56,7 @@ jobs:
           build-args: |
             SOURCE_COMMIT=${{ github.sha }}
             INSTANCE=${{ matrix.instance }}
+            HEALTHCHECK_LIVE=${{ matrix.healthcheck_live || 'http://localhost:3000/livez' }}
           context: ${{ matrix.context }}
           labels: ${{ steps.meta.outputs.labels }}
           annotations: ${{ steps.meta.outputs.annotations }}
@@ -104,6 +105,7 @@ jobs:
             context: ./back
           - instance: core-fca-low
             context: ./back
+            healthcheck_live: http://localhost:3000/api/v2/livez
           - instance: csmr-rie
             context: ./back
           - instance: mock-data-provider

--- a/back/Dockerfile
+++ b/back/Dockerfile
@@ -37,8 +37,10 @@ RUN apk add --no-cache bash
 COPY --from=dev_dependencies /var/www/app/node_modules node_modules
 COPY . ./
 
+ARG HEALTHCHECK_LIVE=http://localhost:3000/livez
+ENV HEALTHCHECK_LIVE=${HEALTHCHECK_LIVE}
 HEALTHCHECK --interval=5s --timeout=3s --start-period=5s --retries=3 \
-  CMD  wget --no-verbose --tries=1 --spider --no-check-certificate https://localhost:3000/api/v2/livez || exit 1
+  CMD  wget --no-verbose --tries=1 --spider --no-check-certificate ${HEALTHCHECK_LIVE} || exit 1
 
 CMD yarn start:dev ${NESTJS_INSTANCE}
 
@@ -72,7 +74,9 @@ COPY --from=builder /build/back/dist/apps/${INSTANCE} /var/www/app/dist/instance
 
 WORKDIR /var/www/app
 
+ARG HEALTHCHECK_LIVE=http://localhost:3000/livez
+ENV HEALTHCHECK_LIVE=${HEALTHCHECK_LIVE}
 HEALTHCHECK --interval=5s --timeout=3s --start-period=5s --retries=3 \
-  CMD  wget --no-verbose --tries=1 --spider --no-check-certificate https://localhost:3000/api/v2/livez || exit 1
+  CMD  wget --no-verbose --tries=1 --spider --no-check-certificate ${HEALTHCHECK_LIVE} || exit 1
 
 CMD ["pm2-runtime", "/etc/pm2/app.json"]

--- a/back/apps/csmr-rie/src/main.ts
+++ b/back/apps/csmr-rie/src/main.ts
@@ -27,10 +27,10 @@ async function bootstrap() {
     transport: Transport.RMQ,
     options,
   });
-
-  await app.startAllMicroservices();
-  await app.listen(process.env.PORT);
-  console.log(`Consumer is listening on queue "${options.queue}"`);
+  await Promise.all([
+    app.listen(process.env.PORT || 3000),
+    app.startAllMicroservices(),
+  ]);
 }
 
 void bootstrap();

--- a/docker/compose/fca-low/.env/core.env
+++ b/docker/compose/fca-low/.env/core.env
@@ -1,6 +1,7 @@
 DEFAULT_MODE=dev
 NESTJS_INSTANCE=core-fca-low
 REQUEST_TIMEOUT=6000
+HEALTHCHECK_LIVE=http://localhost:3000/api/v2/livez
 # Session configuration
 SESSION_SECRET=fAh8Seik4_ahcH-3ahth/eiG@huéfuuva=opa
 SESSION_NAME=fc_session

--- a/docker/compose/fca-low/.env/hybridge-rie.env
+++ b/docker/compose/fca-low/.env/hybridge-rie.env
@@ -1,8 +1,8 @@
 # -- global
 APP_NAME=csmr-rie
 APP_ROOT=
-NESTJS_INSTANCE=csmr-rie
 FQDN=csmr-rie.docker.dev-franceconnect.fr
+NESTJS_INSTANCE=csmr-rie
 REQUEST_TIMEOUT=6000
 
 # App


### PR DESCRIPTION
**Problem**

We use /api/v2/livez as the healthcheck path by default to check the liveness of the application. This is not compatible with most images.

**Proposal**

Use /livez as default healthcheck path.
Propose a `HEALTHCHECK_LIVE` args to allow docker to use a custom path for core pcf.