### PR TITLE
🩺 health: implement ping/pong pattern for broker readiness

### DIFF
--- a/back/apps/core-fca-low/src/controllers/health.controller.spec.ts
+++ b/back/apps/core-fca-low/src/controllers/health.controller.spec.ts
@@ -10,7 +10,7 @@ describe("HealthController", () => {
   let mongoConnectionMock: { readyState: number };
   let redisServiceMock: { client: { ping: jest.Mock } };
   let apiEntrepriseMock: { getOrganizationBySiret: jest.Mock };
-  let hyyyperbridgeMock: { emit: jest.Mock };
+  let hyyyperbridgeMock: { send: jest.Mock };
   let resMock: { status: jest.Mock };
 
   beforeEach(async () => {
@@ -22,7 +22,7 @@ describe("HealthController", () => {
       getOrganizationBySiret: jest.fn().mockResolvedValue({}),
     };
     hyyyperbridgeMock = {
-      emit: jest.fn().mockReturnValue(of(undefined)),
+      send: jest.fn().mockReturnValue(of("pong")),
     };
     resMock = {
       status: jest.fn().mockReturnThis(),
@@ -117,7 +117,7 @@ describe("HealthController", () => {
     });
 
     it('should return "error" when a check throws a non-Error value', async () => {
-      hyyyperbridgeMock.emit.mockReturnValue(throwError(() => ({ err: {} })));
+      hyyyperbridgeMock.send.mockReturnValue(throwError(() => ({ err: {} })));
 
       const result = await controller.readyz(resMock as any, "");
 
@@ -127,10 +127,21 @@ describe("HealthController", () => {
       expect(result).toContain('[-]hyyyperbridge failed ({"err":{}})');
     });
 
-    it('should return "error" when Hyyyperbridge connect fails', async () => {
-      hyyyperbridgeMock.emit.mockReturnValue(
+    it('should return "error" when Hyyyperbridge is unreachable', async () => {
+      hyyyperbridgeMock.send.mockReturnValue(
         throwError(() => new Error("ECONNREFUSED")),
       );
+
+      const result = await controller.readyz(resMock as any);
+
+      expect(resMock.status).toHaveBeenCalledWith(
+        HttpStatus.SERVICE_UNAVAILABLE,
+      );
+      expect(result).toBe("error");
+    });
+
+    it('should return "error" when Hyyyperbridge returns unexpected response', async () => {
+      hyyyperbridgeMock.send.mockReturnValue(of("not-pong"));
 
       const result = await controller.readyz(resMock as any);
 

--- a/back/apps/core-fca-low/src/controllers/health.controller.ts
+++ b/back/apps/core-fca-low/src/controllers/health.controller.ts
@@ -53,9 +53,12 @@ export class HealthController {
       await this.apiEntreprise.getOrganizationBySiret("13002526500013");
     },
     [ExcludeTarget.Hyyyperbridge]: async () => {
-      await firstValueFrom(
-        this.hyyyperbridge.emit("ping", {}).pipe(timeout(5000)),
+      const pong = await firstValueFrom(
+        this.hyyyperbridge.send<string>("ping", {}).pipe(timeout(5000)),
       );
+      if (pong !== "pong") {
+        throw new Error(`unexpected response: ${pong}`);
+      }
     },
   };
 

--- a/back/apps/csmr-rie/src/controllers/csmr-http-proxy.controller.spec.ts
+++ b/back/apps/csmr-rie/src/controllers/csmr-http-proxy.controller.spec.ts
@@ -43,6 +43,12 @@ describe("CsmrHttpProxyController", () => {
     expect(csmrHttpProxyController).toBeDefined();
   });
 
+  describe("ping()", () => {
+    it('should return "pong"', () => {
+      expect(csmrHttpProxyController.ping()).toBe("pong");
+    });
+  });
+
   describe("proxyRequest()", () => {
     const baseBridgePayloadMock: BridgePayloadDto = Object.freeze({
       url: "https://test.com/getToken",

--- a/back/apps/csmr-rie/src/controllers/csmr-http-proxy.controller.ts
+++ b/back/apps/csmr-rie/src/controllers/csmr-http-proxy.controller.ts
@@ -18,6 +18,11 @@ export class CsmrHttpProxyController {
     private readonly proxy: CsmrHttpProxyService,
   ) {}
 
+  @MessagePattern("ping")
+  ping(): string {
+    return "pong";
+  }
+
   @MessagePattern(HttpProxyProtocol.Commands.HTTP_PROXY)
   @UsePipes(
     new ValidationPipe({

--- a/back/apps/csmr-rie/src/controllers/health.controller.spec.ts
+++ b/back/apps/csmr-rie/src/controllers/health.controller.spec.ts
@@ -1,3 +1,5 @@
+import { LoggerService } from "@fc/logger";
+import { getLoggerMock } from "@mocks/logger";
 import { HttpStatus } from "@nestjs/common";
 import { Test, TestingModule } from "@nestjs/testing";
 import { of, throwError } from "rxjs";
@@ -7,8 +9,10 @@ describe("HealthController", () => {
   let controller: HealthController;
 
   const brokerMock = {
-    emit: jest.fn().mockReturnValue(of(undefined)),
+    send: jest.fn().mockReturnValue(of("pong")),
   };
+
+  const loggerMock = getLoggerMock();
 
   const resMock = {
     status: jest.fn().mockReturnThis(),
@@ -16,11 +20,14 @@ describe("HealthController", () => {
 
   beforeEach(async () => {
     jest.resetAllMocks();
-    brokerMock.emit.mockReturnValue(of(undefined));
+    brokerMock.send.mockReturnValue(of("pong"));
 
     const app: TestingModule = await Test.createTestingModule({
       controllers: [HealthController],
-      providers: [{ provide: "HttpProxyBroker", useValue: brokerMock }],
+      providers: [
+        { provide: "HttpProxyBroker", useValue: brokerMock },
+        { provide: LoggerService, useValue: loggerMock },
+      ],
     }).compile();
 
     controller = app.get<HealthController>(HealthController);
@@ -33,14 +40,14 @@ describe("HealthController", () => {
   });
 
   describe("readyz()", () => {
-    it("should return 'ok' when broker is reachable", async () => {
+    it("should return 'ok' when broker responds pong", async () => {
       const result = await controller.readyz(resMock as any);
       expect(resMock.status).not.toHaveBeenCalled();
       expect(result).toBe("ok");
     });
 
     it("should return 'error' when broker is unreachable", async () => {
-      brokerMock.emit.mockReturnValue(
+      brokerMock.send.mockReturnValue(
         throwError(() => new Error("ECONNREFUSED")),
       );
       const result = await controller.readyz(resMock as any);
@@ -48,6 +55,47 @@ describe("HealthController", () => {
         HttpStatus.SERVICE_UNAVAILABLE,
       );
       expect(result).toBe("error");
+    });
+
+    it("should return 'error' when broker returns unexpected response", async () => {
+      brokerMock.send.mockReturnValue(of("not-pong"));
+      const result = await controller.readyz(resMock as any);
+      expect(resMock.status).toHaveBeenCalledWith(
+        HttpStatus.SERVICE_UNAVAILABLE,
+      );
+      expect(result).toBe("error");
+    });
+
+    it("should return 'error' when broker throws a non-Error value", async () => {
+      brokerMock.send.mockReturnValue(throwError(() => ({ code: 503 })));
+      const result = await controller.readyz(resMock as any, "");
+      expect(resMock.status).toHaveBeenCalledWith(
+        HttpStatus.SERVICE_UNAVAILABLE,
+      );
+      expect(result).toBe(
+        '[-]broker failed ({"code":503})\nreadyz check failed',
+      );
+    });
+
+    describe("verbose", () => {
+      it("should return verbose output when broker responds pong", async () => {
+        const result = await controller.readyz(resMock as any, "");
+        expect(resMock.status).not.toHaveBeenCalled();
+        expect(result).toBe("[+]broker ok\nreadyz check passed");
+      });
+
+      it("should return verbose output when broker is unreachable", async () => {
+        brokerMock.send.mockReturnValue(
+          throwError(() => new Error("ECONNREFUSED")),
+        );
+        const result = await controller.readyz(resMock as any, "");
+        expect(resMock.status).toHaveBeenCalledWith(
+          HttpStatus.SERVICE_UNAVAILABLE,
+        );
+        expect(result).toBe(
+          "[-]broker failed (ECONNREFUSED)\nreadyz check failed",
+        );
+      });
     });
   });
 });

--- a/back/apps/csmr-rie/src/controllers/health.controller.ts
+++ b/back/apps/csmr-rie/src/controllers/health.controller.ts
@@ -1,9 +1,11 @@
+import { LoggerService } from "@fc/logger";
 import {
   Controller,
   Get,
   Header,
   HttpStatus,
   Inject,
+  Query,
   Res,
 } from "@nestjs/common";
 import { ClientProxy } from "@nestjs/microservices";
@@ -14,6 +16,7 @@ import { firstValueFrom, timeout } from "rxjs";
 export class HealthController {
   constructor(
     @Inject("HttpProxyBroker") private readonly broker: ClientProxy,
+    private readonly logger: LoggerService,
   ) {}
 
   @Get("/livez")
@@ -23,12 +26,33 @@ export class HealthController {
 
   @Get("/readyz")
   @Header("Content-Type", "text/plain")
-  async readyz(@Res({ passthrough: true }) res: Response): Promise<string> {
+  async readyz(
+    @Res({ passthrough: true }) res: Response,
+    @Query("verbose") verbose?: string,
+  ): Promise<string> {
     try {
-      await firstValueFrom(this.broker.emit("ping", {}).pipe(timeout(5000)));
+      const pong = await firstValueFrom(
+        this.broker.send<string>("ping", {}).pipe(timeout(5000)),
+      );
+      if (pong !== "pong") {
+        throw new Error(`unexpected response: ${pong}`);
+      }
+
+      if (verbose !== undefined) {
+        return ["[+]broker ok", "readyz check passed"].join("\n");
+      }
       return "ok";
     } catch (error) {
+      this.logger.error(error);
       res.status(HttpStatus.SERVICE_UNAVAILABLE);
+
+      if (verbose !== undefined) {
+        const message =
+          error instanceof Error ? error.message : JSON.stringify(error);
+        return [`[-]broker failed (${message})`, "readyz check failed"].join(
+          "\n",
+        );
+      }
       return "error";
     }
   }

--- a/back/apps/csmr-rie/src/services/csmr-http-proxy.service.spec.ts
+++ b/back/apps/csmr-rie/src/services/csmr-http-proxy.service.spec.ts
@@ -1,4 +1,6 @@
 import { BridgePayload, BridgeResponse } from "@fc/hybridge-http-proxy";
+import { LoggerService } from "@fc/logger";
+import { getLoggerMock } from "@mocks/logger";
 import { HttpService } from "@nestjs/axios";
 import { Test, TestingModule } from "@nestjs/testing";
 import { lastValueFrom } from "rxjs";
@@ -14,6 +16,8 @@ describe("CsmrHttpProxyService", () => {
     post: jest.fn(),
   };
 
+  const loggerMock = getLoggerMock();
+
   const lastValueMock = jest.mocked(lastValueFrom);
 
   const httpResponseMock = Symbol("httpResponseMock");
@@ -23,10 +27,12 @@ describe("CsmrHttpProxyService", () => {
     jest.restoreAllMocks();
 
     const module: TestingModule = await Test.createTestingModule({
-      providers: [HttpService, CsmrHttpProxyService],
+      providers: [HttpService, LoggerService, CsmrHttpProxyService],
     })
       .overrideProvider(HttpService)
       .useValue(httpService)
+      .overrideProvider(LoggerService)
+      .useValue(loggerMock)
       .compile();
 
     service = module.get<CsmrHttpProxyService>(CsmrHttpProxyService);

--- a/back/apps/csmr-rie/src/services/csmr-http-proxy.service.ts
+++ b/back/apps/csmr-rie/src/services/csmr-http-proxy.service.ts
@@ -1,4 +1,5 @@
 import { BridgePayload, BridgeResponse } from "@fc/hybridge-http-proxy";
+import { LoggerService } from "@fc/logger";
 import { HttpService } from "@nestjs/axios";
 import { Injectable } from "@nestjs/common";
 import { AxiosRequestConfig, AxiosResponse } from "axios";
@@ -6,7 +7,10 @@ import { lastValueFrom } from "rxjs";
 
 @Injectable()
 export class CsmrHttpProxyService {
-  constructor(private http: HttpService) {}
+  constructor(
+    private readonly logger: LoggerService,
+    private http: HttpService,
+  ) {}
 
   /**
    * get the data from FI based on Bridge request params
@@ -27,9 +31,26 @@ export class CsmrHttpProxyService {
 
     const options: Array<unknown> = [url, requestData, config].filter(Boolean);
 
+    this.logger.debug({
+      config,
+      method,
+      msg: `${method.toUpperCase()} ${url}`,
+      requestData,
+      url,
+    });
     const { status, statusText, headers, data } = await lastValueFrom<
       AxiosResponse<string>
     >(this.http[method](...options));
+
+    this.logger.debug({
+      data,
+      headers,
+      method,
+      msg: `${method.toUpperCase()} ${url} ${status}`,
+      status,
+      statusText,
+      url,
+    });
 
     const response: BridgeResponse = {
       status,

--- a/docker/compose/fca-low/.env/hybridge-rie.env
+++ b/docker/compose/fca-low/.env/hybridge-rie.env
@@ -9,6 +9,9 @@ REQUEST_TIMEOUT=6000
 App_HTTPS_SERVER_CERT=/etc/ssl/docker_host/app.crt
 App_HTTPS_SERVER_KEY=/etc/ssl/docker_host/app.key
 
+# Logger
+Logger_THRESHOLD=debug
+
 # LoggerLegacy
 LoggerLegacy_FILE=/var/log/app/csmr-rie.log
 

--- a/quality/cypress/fixtures/fca-low/docker/api-common.json
+++ b/quality/cypress/fixtures/fca-low/docker/api-common.json
@@ -86,6 +86,21 @@
     "method": "POST",
     "url": "https://core-fca-low.docker.dev-franceconnect.fr/api/v2/token"
   },
+  "livez": {
+    "method": "GET",
+    "url": "https://core-fca-low.docker.dev-franceconnect.fr/api/v2/livez"
+  },
+  "readyz": {
+    "method": "GET",
+    "url": "https://core-fca-low.docker.dev-franceconnect.fr/api/v2/readyz"
+  },
+  "readyz-verbose": {
+    "method": "GET",
+    "url": "https://core-fca-low.docker.dev-franceconnect.fr/api/v2/readyz",
+    "qs": {
+      "verbose": ""
+    }
+  },
   "redirect-to-idp": {
     "method": "POST",
     "url": "https://core-fca-low.docker.dev-franceconnect.fr/api/v2/redirect-to-idp",

--- a/quality/cypress/integration/api/api-health.feature
+++ b/quality/cypress/integration/api/api-health.feature
@@ -1,0 +1,27 @@
+#language: fr
+@apiHealth 
+Fonctionnalité: API - health
+
+  Scénario: livez - répond ok
+    Etant donné que je prépare une requête "livez"
+    Quand je lance la requête
+    Alors le statut de la réponse est 200
+    Et le corps de la réponse est "ok"
+
+  @hybridge
+  Scénario: readyz - répond ok quand tous les services sont disponibles
+    Etant donné que je prépare une requête "readyz"
+    Quand je lance la requête
+    Alors le statut de la réponse est 200
+    Et le corps de la réponse est "ok"
+
+  @hybridge
+  Scénario: readyz verbose - détaille l'état de chaque service
+    Etant donné que je prépare une requête "readyz-verbose"
+    Quand je lance la requête
+    Alors le statut de la réponse est 200
+    Et le corps de la réponse contient "[+]mongodb ok"
+    Et le corps de la réponse contient "[+]redis ok"
+    Et le corps de la réponse contient "[+]api-entreprise ok"
+    Et le corps de la réponse contient "[+]hyyyperbridge ok"
+    Et le corps de la réponse contient "readyz check passed"

--- a/quality/cypress/support/api/steps/api-response-steps.ts
+++ b/quality/cypress/support/api/steps/api-response-steps.ts
@@ -113,6 +113,14 @@ Then("le corps de la réponse contient un JWT", function () {
     });
 });
 
+Then("le corps de la réponse est {string}", function (expected: string) {
+  cy.get("@apiResponse").its("body").should("equal", expected);
+});
+
+Then("le corps de la réponse contient {string}", function (expected: string) {
+  cy.get("@apiResponse").its("body").should("include", expected);
+});
+
 Then(
   "le corps de la réponse contient une erreur avec les champs error et error_description",
   function () {


### PR DESCRIPTION
**Problem**

Health checks used fire-and-forget `emit()` with `@EventPattern`, which only confirms message delivery to the queue — not that the remote service is alive and processing messages.

**Proposal**

Switch to request/reply using `send()` with `@MessagePattern("ping")` returning `"pong"`. Both sides now verify the full RabbitMQ roundtrip and that the remote responds correctly. Tests cover unreachable broker and unexpected response cases.