### PR TITLE
⚡️ disable healthchecks because of zombie processes

### DIFF
--- a/back/Dockerfile
+++ b/back/Dockerfile
@@ -37,11 +37,6 @@ RUN apk add --no-cache bash
 COPY --from=dev_dependencies /var/www/app/node_modules node_modules
 COPY . ./
 
-ARG HEALTHCHECK_LIVE=http://localhost:3000/livez
-ENV HEALTHCHECK_LIVE=${HEALTHCHECK_LIVE}
-HEALTHCHECK --interval=5s --timeout=3s --start-period=5s --retries=3 \
-  CMD  wget --no-verbose --tries=1 --spider --no-check-certificate ${HEALTHCHECK_LIVE} || exit 1
-
 CMD yarn start:dev ${NESTJS_INSTANCE}
 
 FROM ${NODE_IMAGE} AS builder
@@ -73,10 +68,5 @@ COPY --from=dependencies /var/www/app/node_modules /var/www/app/node_modules
 COPY --from=builder /build/back/dist/apps/${INSTANCE} /var/www/app/dist/instances/app
 
 WORKDIR /var/www/app
-
-ARG HEALTHCHECK_LIVE=http://localhost:3000/livez
-ENV HEALTHCHECK_LIVE=${HEALTHCHECK_LIVE}
-HEALTHCHECK --interval=5s --timeout=3s --start-period=5s --retries=3 \
-  CMD  wget --no-verbose --tries=1 --spider --no-check-certificate ${HEALTHCHECK_LIVE} || exit 1
 
 CMD ["pm2-runtime", "/etc/pm2/app.json"]


### PR DESCRIPTION
## Problème

```
root      1598  0.0  0.0 720324 14592 ?        Sl   09:29   0:14 /usr/bin/containerd-shim-runc-v2 -namespace moby -id 3b472a976dc9cb2d1c999da7af38380edabb112e0085705192fbcc7f8f6ec9cb -address /run/containerd/containerd.sock
fcapp     1762  0.0  0.4 1134944 80880 ?       Ssl  09:29   0:15  \_ node /usr/local/bin/pm2-runtime /etc/pm2/app.json
fcapp     2896  0.1  0.5 1126188 85212 ?       Ssl  09:29   0:22  |   \_ node /var/www/app/dist/instances/app/main.js
fcapp     3044  0.0  0.0      0     0 ?        Z    09:29   0:00  |   \_ [ssl_client] <defunct>
fcapp     3223  0.0  0.0      0     0 ?        Z    09:29   0:00  |   \_ [ssl_client] <defunct>
fcapp     3416  0.0  0.0      0     0 ?        Z    09:29   0:00  |   \_ [ssl_client] <defunct>
fcapp     3546  0.0  0.0      0     0 ?        Z    09:29   0:00  |   \_ [ssl_client] <defunct>
fcapp     3718  0.0  0.0      0     0 ?        Z    09:29   0:00  |   \_ [ssl_client] <defunct>
fcapp     3848  0.0  0.0      0     0 ?        Z    09:29   0:00  |   \_ [ssl_client] <defunct>
fcapp     4118  0.0  0.0      0     0 ?        Z    09:29   0:00  |   \_ [ssl_client] <defunct>
fcapp     4259  0.0  0.0      0     0 ?        Z    09:29   0:00  |   \_ [ssl_client] <defunct>
fcapp     4422  0.0  0.0      0     0 ?        Z    09:29   0:00  |   \_ [ssl_client] <defunct>
fcapp     4572  0.0  0.0      0     0 ?        Z    09:30   0:00  |   \_ [ssl_client] <defunct>
fcapp     4730  0.0  0.0      0     0 ?        Z    09:30   0:00  |   \_ [ssl_client] <defunct>
fcapp     4886  0.0  0.0      0     0 ?        Z    09:30   0:00  |   \_ [ssl_client] <defunct>
fcapp     5022  0.0  0.0      0     0 ?        Z    09:30   0:00  |   \_ [ssl_client] <defunct>
fcapp     5188  0.0  0.0      0     0 ?        Z    09:30   0:00  |   \_ [ssl_client] <defunct>
fcapp     5334  0.0  0.0      0     0 ?        Z    09:30   0:00  |   \_ [ssl_client] <defunct>
fcapp     5502  0.0  0.0      0     0 ?        Z    09:30   0:00  |   \_ [ssl_client] <defunct>
fcapp     5657  0.0  0.0      0     0 ?        Z    09:30   0:00  |   \_ [ssl_client] <defunct>
```