### PR TITLE
🐛 do no assign acr field if acrs not recognized

### DIFF
--- a/back/libs/oidc-client/src/services/oidc-client.service.spec.ts
+++ b/back/libs/oidc-client/src/services/oidc-client.service.spec.ts
@@ -805,6 +805,34 @@ describe("OidcClientService", () => {
       expect(result.claims.acr).toBe("eidas2");
     });
 
+    it("should map EntraID acrs to eidas 1 if not recognized", async () => {
+      // Given
+      identityProviderMock.getById.mockResolvedValue({
+        ...idpMock,
+        isEntraID: true,
+      });
+      const tokensWithAcrs = {
+        ...tokensMock,
+        claims: jest.fn().mockReturnValue({ sub: "user-sub", acrs: ["p1"] }),
+      };
+      (openidClient.authorizationCodeGrant as jest.Mock).mockResolvedValue(
+        tokensWithAcrs,
+      );
+
+      // When
+      const result = await service.getToken({
+        idpId: "idp-id",
+        req: reqMock as any,
+        idpState: "state",
+        idpNonce: "nonce",
+        spId: "sp-id",
+        spName: "sp-name",
+      });
+
+      // Then
+      expect(result.claims.acr).toBe("eidas1");
+    });
+
     it("should filter acrs for EntraID keeping only c-prefixed values", async () => {
       // Given
       identityProviderMock.getById.mockResolvedValue({

--- a/back/libs/oidc-client/src/services/oidc-client.service.ts
+++ b/back/libs/oidc-client/src/services/oidc-client.service.ts
@@ -22,7 +22,7 @@ import { ClientProxy } from "@nestjs/microservices";
 import { plainToInstance } from "class-transformer";
 import { validate } from "class-validator";
 import { Request } from "express";
-import { chain, cloneDeep, filter, isObject } from "lodash";
+import { chain, cloneDeep, isObject, map } from "lodash";
 import {
   authorizationCodeGrant,
   AuthorizationResponseError,
@@ -73,6 +73,14 @@ export class OidcClientService {
     "phone",
     "chorusdt",
   ].join(" ");
+
+  entraIdAcrValuesMapping = {
+    c1: "eidas1",
+    c2: "eidas2",
+    c3: "eidas3",
+  };
+
+  prioritizedAcrValues = ["eidas3", "eidas2", "eidas1"];
 
   constructor(
     private readonly config: ConfigService,
@@ -423,8 +431,16 @@ export class OidcClientService {
       // This behavior is specific to MS Entra ID's authentication contexts
       // We consider only values of the form c1, c2, c3, mutually exclusive,
       // and map them to equivalent eidas levels
-      const acrs = filter(token.claims.acrs, (level) => level.startsWith("c"));
-      acr = acrs.toString().replace("c", "eidas");
+      const proConnectAcrs = map(
+        token.claims.acrs,
+        (level) => this.entraIdAcrValuesMapping[level],
+      ).filter(Boolean);
+      const proConnectHighestAcr = this.prioritizedAcrValues.find((level) =>
+        proConnectAcrs.includes(level),
+      );
+      if (!!proConnectHighestAcr) {
+        acr = proConnectHighestAcr;
+      }
     }
 
     token.claims.acr = acr;


### PR DESCRIPTION
**Problem**
Entra ID Identity Providers sometimes return `acrs` values that cannot be interpreted.

**Proposal**
Fallback to a default value of `eidas1` when the `acrs` field cannot be parsed. ``