### PR TITLE
Revert "🗑️ delete api health test"

### DIFF
--- a/quality/cypress/integration/api/api-health.feature
+++ b/quality/cypress/integration/api/api-health.feature
@@ -1,0 +1,27 @@
+#language: fr
+@apiHealth 
+Fonctionnalité: API - health
+
+  Scénario: livez - répond ok
+    Etant donné que je prépare une requête "livez"
+    Quand je lance la requête
+    Alors le statut de la réponse est 200
+    Et le corps de la réponse est "ok"
+
+  @hybridge
+  Scénario: readyz - répond ok quand tous les services sont disponibles
+    Etant donné que je prépare une requête "readyz"
+    Quand je lance la requête
+    Alors le statut de la réponse est 200
+    Et le corps de la réponse est "ok"
+
+  @hybridge
+  Scénario: readyz verbose - détaille l'état de chaque service
+    Etant donné que je prépare une requête "readyz-verbose"
+    Quand je lance la requête
+    Alors le statut de la réponse est 200
+    Et le corps de la réponse contient "[+]mongodb ok"
+    Et le corps de la réponse contient "[+]redis ok"
+    Et le corps de la réponse contient "[+]api-entreprise ok"
+    Et le corps de la réponse contient "[+]hyyyperbridge ok"
+    Et le corps de la réponse contient "readyz check passed"


### PR DESCRIPTION
This test should work.
@BenoitSerrano why did we removed it ? Did I miss a `@tag` for the integration env ?

Reverts proconnect-gouv/federation#1120
Introduced in proconnect-gouv/federation#1117