### PR TITLE
🔧 (csmr-rie): disable axios proxy to let native node env handle it

### DIFF
--- a/back/_doc/env-vars.md
+++ b/back/_doc/env-vars.md
@@ -79,11 +79,12 @@
 
 ### csmr-rie
 
-| Var Name          | Inferred type |
-| ----------------- | ------------- |
-| APP_NAME          | string        |
-| LoggerLegacy_FILE | string        |
-| Logger_THRESHOLD  | string        |
-| REQUEST_TIMEOUT   | string        |
-| RieBroker_QUEUE   | string        |
-| RieBroker_URLS    | json          |
+| Var Name                 | Inferred type |
+| ------------------------ | ------------- |
+| APP_NAME                 | string        |
+| LoggerLegacy_FILE        | string        |
+| Logger_THRESHOLD         | string        |
+| REQUEST_TIMEOUT          | string        |
+| RieBroker_PROXY_DISABLED | boolean       |
+| RieBroker_QUEUE          | string        |
+| RieBroker_URLS           | json          |

--- a/back/apps/csmr-rie/src/config/rie-broker.ts
+++ b/back/apps/csmr-rie/src/config/rie-broker.ts
@@ -1,5 +1,5 @@
 import { ConfigParser } from "@fc/config";
-import { RabbitmqConfig } from "@fc/rabbitmq";
+import { HttpProxyBrokerConfig } from "@fc/csmr-http-proxy";
 
 const env = new ConfigParser(process.env, "RieBroker");
 
@@ -13,4 +13,5 @@ export default {
 
   // Global request timeout used for any outgoing app requests.
   requestTimeout: parseInt(process.env.REQUEST_TIMEOUT, 10),
-} as RabbitmqConfig;
+  proxyDisabled: env.boolean("PROXY_DISABLED"),
+} as HttpProxyBrokerConfig;

--- a/back/apps/csmr-rie/src/csmr-http-proxy.module.spec.ts
+++ b/back/apps/csmr-rie/src/csmr-http-proxy.module.spec.ts
@@ -5,14 +5,41 @@ import { Test } from "@nestjs/testing";
 import { CsmrHttpProxyModule } from "./csmr-http-proxy.module";
 
 describe("CsmrHttpProxyModule Dependency Validation", () => {
+  const baseConfig = {
+    Logger: { threshold: "info" },
+    LoggerLegacy: {},
+    HttpProxyBroker: { requestTimeout: 5000, proxyDisabled: false },
+  };
+
   it("should compile successfully with minimal config", async () => {
+    const configServiceMock = getConfigMock();
+    configServiceMock.get.mockImplementation(
+      (key: string) => baseConfig[key] ?? null,
+    );
+
+    const moduleFixture = await Test.createTestingModule({
+      imports: [
+        CsmrHttpProxyModule,
+        ConfigModule.forRoot(configServiceMock as any),
+        LoggerModule.forRoot([]),
+      ],
+    }).compile();
+
+    expect(moduleFixture).toBeDefined();
+    expect(moduleFixture.get(CsmrHttpProxyModule)).toBeDefined();
+  });
+
+  it("should compile with proxy: false when proxyDisabled is true", async () => {
     const configServiceMock = getConfigMock();
     configServiceMock.get.mockImplementation(
       (key: string) =>
         ({
-          Logger: { threshold: "info" },
-          HttpProxyBroker: { requestTimeout: 5000 },
-        })[key] || {},
+          ...baseConfig,
+          HttpProxyBroker: {
+            ...baseConfig.HttpProxyBroker,
+            proxyDisabled: true,
+          },
+        })[key] ?? null,
     );
 
     const moduleFixture = await Test.createTestingModule({

--- a/back/apps/csmr-rie/src/csmr-http-proxy.module.ts
+++ b/back/apps/csmr-rie/src/csmr-http-proxy.module.ts
@@ -1,9 +1,10 @@
 import { AsyncLocalStorageModule } from "@fc/async-local-storage";
 import { ConfigModule, ConfigService } from "@fc/config";
-import { RabbitmqConfig, RabbitmqModule } from "@fc/rabbitmq";
+import { RabbitmqModule } from "@fc/rabbitmq";
 import { HttpModule } from "@nestjs/axios";
 import { Module } from "@nestjs/common";
 import { CsmrHttpProxyController, HealthController } from "./controllers";
+import { HttpProxyBrokerConfig } from "./dto";
 import { rawTransform, validateStatus } from "./http";
 import { CsmrHttpProxyService } from "./services";
 
@@ -12,12 +13,13 @@ import { CsmrHttpProxyService } from "./services";
     HttpModule.registerAsync({
       imports: [ConfigModule, AsyncLocalStorageModule],
       useFactory: (configService: ConfigService) => {
-        const { requestTimeout: timeout } =
-          configService.get<RabbitmqConfig>("HttpProxyBroker");
+        const { requestTimeout: timeout, proxyDisabled } =
+          configService.get<HttpProxyBrokerConfig>("HttpProxyBroker");
         return {
           timeout,
           validateStatus,
           transformResponse: rawTransform,
+          ...(proxyDisabled && { proxy: false }),
         };
       },
       inject: [ConfigService],

--- a/back/apps/csmr-rie/src/dto/csmr-http-proxy.config.ts
+++ b/back/apps/csmr-rie/src/dto/csmr-http-proxy.config.ts
@@ -2,7 +2,18 @@ import { AppRmqConfig } from "@fc/app";
 import { LoggerConfig, LoggerLegacyConfig } from "@fc/logger";
 import { RabbitmqConfig } from "@fc/rabbitmq";
 import { Type } from "class-transformer";
-import { IsObject, ValidateNested } from "class-validator";
+import {
+  IsBoolean,
+  IsObject,
+  IsOptional,
+  ValidateNested,
+} from "class-validator";
+
+export class HttpProxyBrokerConfig extends RabbitmqConfig {
+  @IsBoolean()
+  @IsOptional()
+  readonly proxyDisabled?: boolean;
+}
 
 export class CsmrHttpProxyConfig {
   @IsObject()
@@ -22,6 +33,6 @@ export class CsmrHttpProxyConfig {
 
   @IsObject()
   @ValidateNested()
-  @Type(() => RabbitmqConfig)
-  readonly HttpProxyBroker: RabbitmqConfig;
+  @Type(() => HttpProxyBrokerConfig)
+  readonly HttpProxyBroker: HttpProxyBrokerConfig;
 }


### PR DESCRIPTION
<div align=center><img src="https://media3.giphy.com/media/v1.Y2lkPWVjMTJjNzA0NWFuajZiOTRpNW40NmV3enkwNm5jcmVvYXpxeHF0Z3JlZW4zYm0xMyZlcD12MV9naWZzX3NlYXJjaCZjdD1n/DMuyGtuND8Sa24C4nQ/giphy.gif" /></div>

---

## Problem

Axios has its own proxy handling that intercepts HTTP_PROXY / HTTPS_PROXY env vars, conflicting with Node's native proxy behaviour (`NODE_USE_ENV_PROXY`) introduced in Node 22 — see [axios/axios#7299](https://github.com/axios/axios/issues/7299).

## Proposal

Add a `proxyDisabled` flag in `CsmrHttpProxyConfig` that sets `proxy: false` on the axios instance, stepping aside so Node's native env proxy takes over.