### PR TITLE
🔊 add logs for acr_values

### DIFF
--- a/back/libs/oidc-acr/src/oidc-acr.service.spec.ts
+++ b/back/libs/oidc-acr/src/oidc-acr.service.spec.ts
@@ -1,5 +1,6 @@
 import { ConfigService } from "@fc/config";
 import { UserSession } from "@fc/core";
+import { LoggerService } from "@fc/logger";
 import { getConfigMock } from "@mocks/config";
 import { Test, TestingModule } from "@nestjs/testing";
 import { OidcAcrService } from "./oidc-acr.service";
@@ -9,13 +10,16 @@ describe("OidcAcrService", () => {
   let service: OidcAcrService;
 
   const configServiceMock = getConfigMock();
+  const loggerServiceMock = { warn: jest.fn() };
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
-      providers: [OidcAcrService, ConfigService],
+      providers: [OidcAcrService, ConfigService, LoggerService],
     })
       .overrideProvider(ConfigService)
       .useValue(configServiceMock)
+      .overrideProvider(LoggerService)
+      .useValue(loggerServiceMock)
       .compile();
 
     service = module.get<OidcAcrService>(OidcAcrService);

--- a/back/libs/oidc-acr/src/oidc-acr.service.ts
+++ b/back/libs/oidc-acr/src/oidc-acr.service.ts
@@ -6,11 +6,15 @@ import { ConfigService } from "@fc/config";
 import { AppConfig, UserSession } from "@fc/core";
 import { OidcProviderConfig } from "@fc/oidc-provider";
 
+import { LoggerService } from "@fc/logger";
 import { AcrClaims, AcrValues, ExtendedInteraction } from "./oidc-acr.type";
 
 @Injectable()
 export class OidcAcrService {
-  constructor(private readonly config: ConfigService) {}
+  constructor(
+    private readonly config: ConfigService,
+    private readonly logger: LoggerService,
+  ) {}
 
   /**
    *  @returns the ACR for the current session, or undefined if the essential ACR requirement is not satisfied
@@ -104,6 +108,11 @@ export class OidcAcrService {
     }
 
     if (isString(params?.acr_values)) {
+      this.logger.warn({
+        code: "oidc-acr:acr_values_params_present",
+        acrValues: params.acr_values,
+        promptDetails: prompt.details,
+      });
       return {
         acrValues: this.getFilteredAcrValues(params.acr_values).join(" "),
       };


### PR DESCRIPTION
**Problem**
The `acr_values` field is deprecated and should no longer be used, but removing it outright could introduce regressions for existing users.

**Proposal**
Add logging to track occurrences of this parameter in order to assess usage before deprecating it safely.