### PR TITLE
🐛 oidc-client: wire customFetch on non-discovery Configuration

### DIFF
--- a/back/libs/oidc-client/src/services/oidc-client.service.spec.ts
+++ b/back/libs/oidc-client/src/services/oidc-client.service.spec.ts
@@ -425,6 +425,26 @@ describe("OidcClientService", () => {
       expect(result).toEqual({ config: configMock, idp: idpWithoutDiscovery });
     });
 
+    it("should set customFetch on non-discovery config routed through hyyyperbridge when bypassHybridgeInternet and useTheHyyyperbridge are both true", async () => {
+      // Given
+      configServiceMock.get.mockReturnValue({
+        timeout: 6000,
+        bypassHybridgeInternet: true,
+      });
+      const idp = { ...idpMock, discovery: false, useTheHyyyperbridge: true };
+      const configMock: Record<string | symbol, any> = {};
+      identityProviderMock.getById.mockResolvedValue(idp);
+      (openidClient.Configuration as jest.Mock).mockReturnValue(configMock);
+      jest.spyOn(service, "fetch").mockResolvedValue(new Response());
+
+      // When
+      await service.getProviderConfig("idp-id");
+      configMock[openidClient.customFetch]("url", {});
+
+      // Then
+      expect(service.fetch).toHaveBeenCalledWith(true, "url", {});
+    });
+
     it("should throw OidcClientIssuerDiscoveryFailedException on discovery failure", async () => {
       // Given
       identityProviderMock.getById.mockResolvedValue(idpMock);

--- a/back/libs/oidc-client/src/services/oidc-client.service.ts
+++ b/back/libs/oidc-client/src/services/oidc-client.service.ts
@@ -238,6 +238,10 @@ export class OidcClientService {
         idp.federationClientMetadata,
         ClientSecretPost(idp.federationClientMetadata.client_secret),
       );
+      config[customFetch] = this.fetch.bind(
+        this,
+        bypassHybridgeInternet && idp.useTheHyyyperbridge,
+      );
     } else {
       try {
         config = await discovery(


### PR DESCRIPTION
**Problem**

For IdPs that don't use discovery, `Configuration` was created without `[customFetch]`, so `authorizationCodeGrant` and other token requests bypassed the hyyyperbridge even when `idp.useTheHyyyperbridge` was set.

**Proposal**

Assign `config[customFetch]` after the non-discovery `new Configuration()` call, mirroring the same binding used in the discovery branch. 

see https://github.com/panva/openid-client/blob/v6.8.4/docs/variables/customFetch.md