### PR TITLE
✨ (core-fca-low): support multiple excludes on readyz

### DIFF
--- a/back/apps/core-fca-low/src/controllers/health.controller.spec.ts
+++ b/back/apps/core-fca-low/src/controllers/health.controller.spec.ts
@@ -4,7 +4,7 @@ import { RedisService } from "@fc/redis";
 import { HttpStatus } from "@nestjs/common";
 import { Test, TestingModule } from "@nestjs/testing";
 import { of, throwError } from "rxjs";
-import { ExcludeTarget, HealthController } from "./health.controller";
+import { CheckTarget, HealthController } from "./health.controller";
 
 describe("HealthController", () => {
   let controller: HealthController;
@@ -213,14 +213,28 @@ describe("HealthController", () => {
       it("should exclude a single check", async () => {
         mongoConnectionMock.readyState = 0;
 
-        const result = await controller.readyz(
-          resMock as any,
-          "",
-          ExcludeTarget.MongoDB,
-        );
+        const result = await controller.readyz(resMock as any, "", [
+          CheckTarget.MongoDB,
+        ]);
 
         expect(resMock.status).not.toHaveBeenCalled();
         expect(result).toContain("[+]mongodb excluded: ok");
+      });
+
+      it("should exclude multiple checks", async () => {
+        mongoConnectionMock.readyState = 0;
+        redisServiceMock.client.ping.mockRejectedValue(
+          new Error("ECONNREFUSED"),
+        );
+
+        const result = await controller.readyz(resMock as any, "", [
+          CheckTarget.MongoDB,
+          CheckTarget.Redis,
+        ]);
+
+        expect(resMock.status).not.toHaveBeenCalled();
+        expect(result).toContain("[+]mongodb excluded: ok");
+        expect(result).toContain("[+]redis excluded: ok");
       });
     });
   });
@@ -229,7 +243,7 @@ describe("HealthController", () => {
     it("should return ok for a healthy individual check", async () => {
       const result = await controller.readyzCheck(
         resMock as any,
-        ExcludeTarget.MongoDB,
+        CheckTarget.MongoDB,
       );
 
       expect(resMock.status).not.toHaveBeenCalled();
@@ -241,7 +255,7 @@ describe("HealthController", () => {
 
       const result = await controller.readyzCheck(
         resMock as any,
-        ExcludeTarget.MongoDB,
+        CheckTarget.MongoDB,
       );
 
       expect(resMock.status).toHaveBeenCalledWith(

--- a/back/apps/core-fca-low/src/controllers/health.controller.ts
+++ b/back/apps/core-fca-low/src/controllers/health.controller.ts
@@ -9,6 +9,7 @@ import {
   HttpStatus,
   Inject,
   Param,
+  ParseArrayPipe,
   ParseEnumPipe,
   Query,
   Res,
@@ -20,7 +21,7 @@ import { Connection } from "mongoose";
 import { firstValueFrom, timeout } from "rxjs";
 import { Routes } from "../enums";
 
-export enum ExcludeTarget {
+export enum CheckTarget {
   ApiEntreprise = "api-entreprise",
   Hyyyperbridge = "hyyyperbridge",
   MongoDB = "mongodb",
@@ -38,24 +39,24 @@ export class HealthController {
   ) {}
 
   checks = {
-    [ExcludeTarget.MongoDB]: async () => {
+    [CheckTarget.MongoDB]: async () => {
       if (this.mongoConnection.readyState !== 1) {
         throw new Error(
           `Mongo connection not ready (readyState=${this.mongoConnection.readyState})`,
         );
       }
     },
-    [ExcludeTarget.Redis]: async () => {
+    [CheckTarget.Redis]: async () => {
       const pong = await this.redis.client.ping();
       if (pong !== "PONG") {
         throw new Error(`unexpected redis client response: ${pong}`);
       }
     },
     // We use DINUM SIRET for the ping route
-    [ExcludeTarget.ApiEntreprise]: async () => {
+    [CheckTarget.ApiEntreprise]: async () => {
       await this.apiEntreprise.getOrganizationBySiret("13002526500013");
     },
-    [ExcludeTarget.Hyyyperbridge]: async () => {
+    [CheckTarget.Hyyyperbridge]: async () => {
       const { bypassHybridgeInternet } =
         this.config.get<OidcClientConfig>("OidcClient");
       if (!bypassHybridgeInternet) return "bypass";
@@ -79,10 +80,10 @@ export class HealthController {
   async readyz(
     @Res({ passthrough: true }) res: Response,
     @Query("verbose") verbose?: string,
-    @Query("exclude", new ParseEnumPipe(ExcludeTarget, { optional: true }))
-    exclude?: ExcludeTarget,
+    @Query("exclude", new ParseArrayPipe({ items: String, optional: true }))
+    exclude: CheckTarget[] = [],
   ): Promise<string> {
-    const excludeSet = new Set(exclude ? [exclude] : []);
+    const excludeSet = new Set(exclude);
 
     const results = await this.runChecks(excludeSet);
     const allHealthy = results.every((r) => r.status !== "error");
@@ -106,7 +107,7 @@ export class HealthController {
   @Header("Content-Type", "text/plain")
   async readyzCheck(
     @Res({ passthrough: true }) res: Response,
-    @Param("check", new ParseEnumPipe(ExcludeTarget)) check: ExcludeTarget,
+    @Param("check", new ParseEnumPipe(CheckTarget)) check: CheckTarget,
   ): Promise<string> {
     const result = await this.runCheck(check);
 

--- a/quality/cypress/fixtures/fca-low/docker/api-common.json
+++ b/quality/cypress/fixtures/fca-low/docker/api-common.json
@@ -101,6 +101,14 @@
       "verbose": ""
     }
   },
+  "readyz-excludes": {
+    "method": "GET",
+    "url": "https://core-fca-low.docker.dev-franceconnect.fr/api/v2/readyz",
+    "qs": {
+      "exclude": ["api-entreprise", "hyyyperbridge"],
+      "verbose": ""
+    }
+  },
   "redirect-to-idp": {
     "method": "POST",
     "url": "https://core-fca-low.docker.dev-franceconnect.fr/api/v2/redirect-to-idp",

--- a/quality/cypress/fixtures/fca-low/integ01/api-common.json
+++ b/quality/cypress/fixtures/fca-low/integ01/api-common.json
@@ -18,6 +18,29 @@
     "method": "GET",
     "url": "https://fca.integ01.dev-agentconnect.fr/api/v2/.well-known/openid-configuration"
   },
+  "livez": {
+    "method": "GET",
+    "url": "https://fca.integ01.dev-agentconnect.fr/api/v2/livez"
+  },
+  "readyz": {
+    "method": "GET",
+    "url": "https://fca.integ01.dev-agentconnect.fr/api/v2/readyz"
+  },
+  "readyz-verbose": {
+    "method": "GET",
+    "url": "https://fca.integ01.dev-agentconnect.fr/api/v2/readyz",
+    "qs": {
+      "verbose": ""
+    }
+  },
+  "readyz-excludes": {
+    "method": "GET",
+    "url": "https://fca.integ01.dev-agentconnect.fr/api/v2/readyz",
+    "qs": {
+      "exclude": ["api-entreprise", "hyyyperbridge"],
+      "verbose": ""
+    }
+  },
   "redirect-to-idp": {
     "method": "POST",
     "url": "https://fca.integ01.dev-agentconnect.fr/api/v2/redirect-to-idp",

--- a/quality/cypress/integration/api/api-health.feature
+++ b/quality/cypress/integration/api/api-health.feature
@@ -1,0 +1,27 @@
+#language: fr
+@apiHealth 
+Fonctionnalité: API - health
+
+  Scénario: livez - répond ok
+    Etant donné que je prépare une requête "livez"
+    Quand je lance la requête
+    Alors le statut de la réponse est 200
+    Et le corps de la réponse est "ok"
+
+  @hybridge
+  Scénario: readyz - répond ok quand tous les services sont disponibles
+    Etant donné que je prépare une requête "readyz"
+    Quand je lance la requête
+    Alors le statut de la réponse est 200
+    Et le corps de la réponse est "ok"
+
+  @hybridge
+  Scénario: readyz verbose - détaille l'état de chaque service
+    Etant donné que je prépare une requête "readyz-verbose"
+    Quand je lance la requête
+    Alors le statut de la réponse est 200
+    Et le corps de la réponse contient "[+]mongodb ok"
+    Et le corps de la réponse contient "[+]redis ok"
+    Et le corps de la réponse contient "[+]api-entreprise ok"
+    Et le corps de la réponse contient "[+]hyyyperbridge ok"
+    Et le corps de la réponse contient "readyz check passed"

--- a/quality/cypress/integration/api/api-health.feature
+++ b/quality/cypress/integration/api/api-health.feature
@@ -1,5 +1,5 @@
 #language: fr
-@apiHealth 
+
 Fonctionnalité: API - health
 
   Scénario: livez - répond ok

--- a/quality/cypress/integration/api/api-health.feature
+++ b/quality/cypress/integration/api/api-health.feature
@@ -25,3 +25,11 @@ Fonctionnalité: API - health
     Et le corps de la réponse contient "[+]api-entreprise ok"
     Et le corps de la réponse contient "[+]hyyyperbridge ok"
     Et le corps de la réponse contient "readyz check passed"
+
+  Scénario: readyz excludes - exclut plusieurs services de la vérification
+    Etant donné que je prépare une requête "readyz-excludes"
+    Quand je lance la requête
+    Alors le statut de la réponse est 200
+    Et le corps de la réponse contient "[+]api-entreprise excluded: ok"
+    Et le corps de la réponse contient "[+]hyyyperbridge excluded: ok"
+    Et le corps de la réponse contient "readyz check passed"


### PR DESCRIPTION
**Problem**

The `/readyz` endpoint only accepted a single `?exclude=` value, making it impossible to skip more than one check per request.

**Proposal**

Switch to `ParseArrayPipe` so repeated `?exclude=` params are collected into an array. 
Rename `ExcludeTarget` → `CheckTarget` for clarity (used by both the exclude list and the per-check route).

Introduced in https://github.com/proconnect-gouv/federation/pull/1117
Reverts https://github.com/proconnect-gouv/federation/pull/1120
Closes #1123 
