### PR TITLE
🚸 add default roles in admin

### DIFF
--- a/admin/src/service-provider/service-provider.controller.spec.ts
+++ b/admin/src/service-provider/service-provider.controller.spec.ts
@@ -113,6 +113,7 @@ describe("ServiceProviderController", () => {
     "phone",
     "idp_id",
     "custom",
+    "roles",
   ];
 
   const userMock = "toto";

--- a/admin/src/service-provider/service-provider.controller.ts
+++ b/admin/src/service-provider/service-provider.controller.ts
@@ -42,6 +42,7 @@ export class ServiceProviderController {
     "phone",
     "idp_id",
     "custom",
+    "roles",
   ];
   constructor(
     @InjectRepository(ServiceProviderFromDb, "fc-mongo")


### PR DESCRIPTION
**Problem**
The `roles` field currently has to be added manually each time a new Service Provider is created.

**Proposal**
Add the `roles` scope to the default preselected scopes in the admin interface.