### PR TITLE
Add migration script scopes roles organization label

### DIFF
--- a/back/migrations/20260526121027-delete_available_scopes_in_database.ts
+++ b/back/migrations/20260526121027-delete_available_scopes_in_database.ts
@@ -1,0 +1,15 @@
+/**
+ * @param db {import('mongodb').Db}
+ * @param client {import('mongodb').MongoClient}
+ * @returns {Promise<void>}
+ */
+export const up = async (db, client) => {
+  await db.collection("scopes").deleteMany({});
+};
+
+/**
+ * @param db {import('mongodb').Db}
+ * @param client {import('mongodb').MongoClient}
+ * @returns {Promise<void>}
+ */
+export const down = async (db, client) => {};

--- a/back/migrations/20260526122818-set_roles_and_organization_label_for_every_sp.ts
+++ b/back/migrations/20260526122818-set_roles_and_organization_label_for_every_sp.ts
@@ -1,0 +1,33 @@
+/**
+ * @param db {import('mongodb').Db}
+ * @param client {import('mongodb').MongoClient}
+ * @returns {Promise<void>}
+ */
+export const up = async (db, client) => {
+  await db
+    .collection("client")
+    .updateMany(
+      { scopes: { $ne: "organization_label" } },
+      { $addToSet: { scopes: "organization_label" } },
+    );
+  await db
+    .collection("client")
+    .updateMany(
+      { scopes: { $ne: "roles" } },
+      { $addToSet: { scopes: "roles" } },
+    );
+};
+
+/**
+ * @param db {import('mongodb').Db}
+ * @param client {import('mongodb').MongoClient}
+ * @returns {Promise<void>}
+ */
+export const down = async (db, client) => {
+  await db
+    .collection("client")
+    .updateMany(
+      { scopes: { $in: ["organization_label", "roles"] } },
+      { $pull: { scopes: { $in: ["organization_label", "roles"] } } },
+    );
+};


### PR DESCRIPTION
**Problem**
The `roles` and `organization_label` scopes need to be added to all existing Service Providers.

**Proposal**
Add a migration script to automatically apply these scopes to all Service Providers.