### PR TITLE
✨ add default scopes roles and organization_label in pcdb api

### DIFF
--- a/pcdbapi/main.py
+++ b/pcdbapi/main.py
@@ -139,6 +139,8 @@ async def create_oidc_client(data: OidcClient, request: Request):
                 "phone",
                 "idp_id",
                 "custom",
+                "roles",
+                "organization_label",
             ],
         }
     )


### PR DESCRIPTION
**Problem**
In the Espace Partenaires, when Service Providers create a client, the `roles` and `organization_label` scopes are not selected by default.

**Proposal**
Add `roles` and `organization_label` to the default selected scopes when creating a client.