### PR TITLE
🔧 docker: inline MONGO_VERSION for dependabot

### DIFF
--- a/docker/builds/mongodb/Dockerfile
+++ b/docker/builds/mongodb/Dockerfile
@@ -1,5 +1,4 @@
-ARG MONGO_VERSION=5.0.23
-FROM mongo:${MONGO_VERSION}
+FROM mongo:5.0.23
 
 RUN openssl rand -base64 756 > /mongo-key-file
 COPY ./volumes/ssl/docker-stack-ca.crt /usr/local/share/ca-certificates/

--- a/docker/compose/fca-low/mongo.yml
+++ b/docker/compose/fca-low/mongo.yml
@@ -4,8 +4,6 @@ services:
     build:
       context: '../..'
       dockerfile: 'builds/mongodb/Dockerfile'
-      args:
-        MONGO_VERSION: '5.0.23'
     volumes:
       - '../../volumes/mongo-fca-low/scripts:/opt/scripts'
       - '../../volumes/mongo-fca-low/initdb.d:/docker-entrypoint-initdb.d'


### PR DESCRIPTION
**Problem**

The mongo version is declared twice (Dockerfile `ARG` default and compose `args`) and dependabot's docker-compose updater only tracks base-image references it can parse from a Dockerfile `FROM` line, not values passed via build args. As a result, mongo upgrades still need a hand-written PR.

**Proposal**

Inline the version into `FROM mongo:5.0.23` and drop the build-arg indirection, so dependabot detects it as a base image and opens the upgrade PR itself.

\following https://github.com/proconnect-gouv/proconnect-espace-partenaires/pull/345#issue-comment-box