### PR TITLE
🚫 ci: prevent unnecessary test runs on main merges

### DIFF
--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -8,7 +8,7 @@ on:
     branches:
       - main
     tags:
-      - "*"
+      - "pc-*"
 
 jobs:
   build:

--- a/.github/workflows/ci-admin-tests.yml
+++ b/.github/workflows/ci-admin-tests.yml
@@ -2,6 +2,8 @@ name: 💚 CI Tests - Federation Admin
 
 on:
   push:
+    branches-ignore:
+      - main
 
 permissions:
   contents: read

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -2,6 +2,8 @@ name: 💚 CI Tests
 
 on:
   push:
+    branches-ignore:
+      - main
 
 permissions:
   contents: read
@@ -227,6 +229,6 @@ jobs:
       matrix:
         include:
           - stack: medium
-            tags: 'not @hybridge and not @ignore'
+            tags: "not @hybridge and not @ignore"
           - stack: hybridge
-            tags: '@hybridge'
+            tags: "@hybridge"


### PR DESCRIPTION
**Problem**
Tests are systematically triggered on merges to `main`, even though they are not meaningful in that context.

**Proposal**
Filter workflow execution to prevent unnecessary test runs when merging into `main`.