### PR TITLE
🔊 display user organization in Y500015 error message

### DIFF
--- a/back/apps/core-fca-low/src/controllers/interaction.controller.ts
+++ b/back/apps/core-fca-low/src/controllers/interaction.controller.ts
@@ -217,7 +217,7 @@ export class InteractionController {
       amr,
       idpAcr,
       idpId,
-      spIdentity: { email, roles },
+      spIdentity: { email, roles, siret, organization_label },
       interactionId,
       isSilentAuthentication,
       spEssentialAcr,
@@ -256,7 +256,9 @@ export class InteractionController {
     const doesNotAcceptPrivateSectorEmployees = spType === "public";
 
     if (!isRoleAgentPublic && doesNotAcceptPrivateSectorEmployees) {
-      throw new CoreFcaAgentNotFromPublicServiceException();
+      throw new CoreFcaAgentNotFromPublicServiceException(
+        `The user's roles are: [${roles.join(", ")}]; the user is linked to the non-public organization: ${organization_label} (SIRET: ${siret})`,
+      );
     }
 
     const interactionAcr = this.oidcAcr.getInteractionAcr({

--- a/quality/cypress/integration/usager/connexion-secteur-prive.feature
+++ b/quality/cypress/integration/usager/connexion-secteur-prive.feature
@@ -10,6 +10,7 @@ Fonctionnalité: Connexion Partenaires
     Alors je suis redirigé vers la page erreur technique
     Et le code d'erreur est "Y500015"
     Et le lien vers le support est affiché
+    Et le message d'erreur est "The user's roles are: []; the user is linked to the non-public organization: Octo-technology (SIRET: 41816609600069)"
     Et le lien est celui par défaut avec le fs "<spName>", le fi "<idpName>" et l'erreur "Y500015"
 
     @ignoreInteg01


### PR DESCRIPTION
**Problem**
Users receiving error `Y500015` are not informed about the organization they are associated with.

**Proposal**
Include the user’s associated organization in the `Y500015` error message to improve clarity and support.