### PR TITLE
🔧 dependabot: watch mongodb Dockerfile

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -50,6 +50,12 @@ updates:
           - "version-update:semver-major"
           - "version-update:semver-minor"
   - package-ecosystem: "docker"
+    directory: "/docker/builds/mongodb"
+    labels:
+      - dependencies
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "docker"
     directory: "/admin"
     labels:
       - dependencies


### PR DESCRIPTION
**Problem**

The `docker/builds/mongodb/Dockerfile` was not tracked by dependabot, so the `mongo` base image would never receive automated update PRs.

**Proposal**

Add a docker ecosystem entry for `/docker/builds/mongodb` so dependabot monitors and proposes weekly updates for the mongo base image.