### PR TITLE
🩺 docker: add readyz healthcheck to base-core

### DIFF
--- a/docker/compose/shared/shared.yml
+++ b/docker/compose/shared/shared.yml
@@ -53,6 +53,12 @@ services:
         condition: service_healthy
       redis-pwd:
         condition: service_healthy
+    healthcheck:
+      test: ['CMD', 'wget', '-qO', '/dev/null', '--no-check-certificate', 'https://localhost:3000/api/v2/readyz?exclude=api-entreprise,hyyyperbridge']
+      interval: 10s
+      timeout: 5s
+      retries: 3
+      start_period: 60s
     volumes:
       - '../../../back/apps:/var/www/app/apps:ro'
       - '../../../back/libs:/var/www/app/libs:ro'


### PR DESCRIPTION

**Problem**

No healthcheck on base-core means compose cannot gate dependent services on core being truly ready. 
The aggregate /readyz also bundles transitive deps (api-entreprise external API, hyyyperbridge RIE round-trip) — gating container health on those couples core to a
third party's uptime and a peer consumer, flapping unhealthy when they blip (cascading-failure anti-pattern).

**Proposal**

Add a healthcheck using /api/v2/readyz so services can declare `condition: service_healthy` against core. 
Exclude api-entreprise and hyyyperbridge so the check reflects core's own hard deps (mongo,redis) only — livez would be too weak (green before deps connect).
Uses wget (busybox, guaranteed on Alpine) with a 60s start_period to cover TypeScript compilation time in dev mode.