### PR TITLE
🩺 broker: add healthcheck and gate core on it

### DIFF
--- a/docker/compose/fca-low/core.yml
+++ b/docker/compose/fca-low/core.yml
@@ -10,6 +10,8 @@ services:
       - "../shared/.env/base-app.env"
       - "../fca-low/.env/core.env"
     depends_on:
+      broker:
+        condition: service_healthy
       squid:
         condition: service_started
 

--- a/docker/compose/shared/compose.yaml
+++ b/docker/compose/shared/compose.yaml
@@ -222,6 +222,11 @@ services:
       dockerfile: 'builds/broker/Dockerfile'
     # Specify hostname to fix cluster name
     hostname: broker
+    healthcheck:
+      test: rabbitmq-diagnostics -q ping
+      interval: 10s
+      timeout: 5s
+      retries: 5
     networks:
       - data
     ports:


### PR DESCRIPTION
**Problem**

The broker (RabbitMQ) had no healthcheck, so core could start before AMQP was ready, causing the hyyyperbridge /readyz check to fail with ECONNREFUSED.

**Proposal**

Add `rabbitmq-diagnostics -q ping` as the broker healthcheck and make core depend on `service_healthy` so it only starts once the broker is accepting connections.