### PR TITLE
🐳 (docker): add rabbitmq-cluster 

### DIFF
--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -230,3 +230,5 @@ jobs:
             tags: 'not @hybridge and not @ignore'
           - stack: hybridge
             tags: '@hybridge'
+          - stack: rabbitmq-cluster
+            tags: '@hybridge'

--- a/docker/builds/broker/rabbitmq-cluster.config
+++ b/docker/builds/broker/rabbitmq-cluster.config
@@ -1,0 +1,14 @@
+[
+  {rabbit, [
+    {loopback_users, []}
+  ]},
+  {autocluster, [
+    {peer_discovery_backend, rabbit_peer_discovery_classic_config}
+  ]},
+  {rabbit_peer_discovery_classic_config, [
+    {nodes, ['rabbit@broker-1', 'rabbit@broker-2', 'rabbit@broker-3']}
+  ]},
+  {rabbitmq_management, [
+    {load_definitions, "/etc/rabbitmq/definitions.json"}
+  ]}
+].

--- a/docker/compose/fca-low/.env/core-cluster.env
+++ b/docker/compose/fca-low/.env/core-cluster.env
@@ -1,0 +1,90 @@
+DEFAULT_MODE=dev
+NESTJS_INSTANCE=core-fca-low
+REQUEST_TIMEOUT=6000
+HEALTHCHECK_LIVE=https://localhost:3000/api/v2/livez
+# Session configuration
+SESSION_SECRET=fAh8Seik4_ahcH-3ahth/eiG@huéfuuva=opa
+SESSION_NAME=fc_session
+SESSION_TTL=600000 # 10 minutes
+
+# Maintenance notice
+App_FEATURE_DISPLAY_MAINTENANCE_NOTICE=false
+App_MAINTENANCE_DATETIME=mercredi 14 avril, à partir de 22h
+App_MAINTENANCE_DURATION=une heure
+
+# OidcProvider
+FQDN=core-fca-low.docker.dev-franceconnect.fr
+OidcProvider_PREFIX=/api/v2
+App_PROTOCOL=https
+App_HTTPS_SERVER_CERT=/etc/ssl/docker_host/app.crt
+App_HTTPS_SERVER_KEY=/etc/ssl/docker_host/app.key
+App_ASSETS_PATHS=["../../../apps/core-fca-low/src"]
+App_VIEWS_PATHS=["../../../apps/core-fca-low/src"]
+App_DSFR_ASSETS_PATHS=[{"assetPath":"../../../node_modules/@gouvfr/dsfr/dist/dsfr","prefix":"/dsfr"},{"assetPath":"../../../node_modules/@gouvfr/dsfr/dist/fonts","prefix":"/fonts"},{"assetPath":"../../../node_modules/@gouvfr/dsfr/dist/icons","prefix":"/icons"}, {"assetPath":"../../../node_modules/@gouvfr/dsfr/dist/utility/icons","prefix":"/utility"}]
+App_ASSETS_CACHE_TTL=3600
+App_DEFAULT_IDP_UID=71144ab3-ee1a-4401-b7b3-79b44f7daeeb
+App_SP_AUTHORIZED_FQDNS_CONFIGS=[{"spId": "6495f347513b860e6b931fae4a1ba70c8489a558a0fc74ecdc094d48a4035e77", "spName":"FSA3-LOW","spContact":"serviceclient@fsa3-low.fr","authorizedFqdns":["fia1.fr","fia2.fr"]}]
+App_DEFAULT_EMAIL_RENATER=test@renater.agentconnect.gouv.fr
+App_FEATURE_DISPLAY_TEST_ENV_WARNING=
+
+## Beware, the "kid" of "CRYPTO_SIG_ES256_PRIV_KEYS" and "CRYPTO_SIG_HSM_PUB_KEYS" must be the same !
+OidcProvider_CRYPTO_SIG_ES256_PRIV_KEYS=[{"alg": "ES256", "crv":"P-256","x":"uRxO96Oqn0BEJZYua3rkM9ntzLbt_nDbq4hwSgOUomQ","y":"o9BoK63TMCGmXjOcCZbtOTmw5HdGiy5ZzY4Qo5KG638","d":"sMJDu7_nEjB0SwTKuKR8XiZPHvoUkem3rdgxP39kkfQ","kty":"EC","kid":"pkcs11:ES256:hsm","use":"sig"}]
+OidcProvider_CRYPTO_SIG_RS256_PRIV_KEYS=[{"alg": "RS256", "kty": "RSA","n": "vmTVr5evEFVha25McCxJ8D_MV_52eA6j_0VUFE-bBUWjctqXK-Xf6W1lC2e_51RmL2owzl2w4Fw90cqeBzA1S2PJJdI_ptQcnwaCiXGRUMVqLXKxOsx1zqIj69F781_Ujp7bPYMkGNlsNmsY37roOzZLCFZLIJo6o90mrjT42nTkS-lgabyBMRZu783d_W1hs0CcjcOC4Hq2jEo_DVfy1RF5qj-Cr33LJ22Co6rkWb8zZnS9PFDZBJPz1tp53Gd2V6_BGbgETFMQI9-kss9HQCaH_1VXOFNr-zg7jw-XTHxvaQHEpCkhGrusirQB1o0tf2SheVhHXDUkG2q4aVgBqxurw4YONxBQvYY0xPK-OX1jQaWnaYPmB_v7_bt9wUrL4kYqGiVw5pXZZRIOPYloNhK_p7qLTTNjS4BKgveen_Vq32HZF8sLECQorAL7nSJABd0ReZEOBUyxWZ6KbIwnhykdADV2mBKyrFP0ZDKDQQprstb0V34hYaxuYDZx5obYo0rsPl1659u5KD-s5IAYEuTitdJNT3uWLHgGqLPsd17GHMggQhSuvFIyTH1-mMG3PWF19Oqq0zuZMLw29XDjSDyNRxWauoFzaCzGvWbV2cXsBOob4iik92PPWVJw5BAy6PlK3GxB0ZlSq_Wxp3p0I33BHFxbU8LmbWnAdB-iClk","e": "AQAB","d": "Indul5MGBhbuw9v7ynK6D9v8yhEusR01YwjR57thfNrWc_xOUYwTtNYw7JejjeUheoPmwfUECBmqt0fOw85eV3-A8m_VRgYwCDnNd8QvYkfaqM-Sdep9iSKhDhemMLCwcgEf_0q2RilWBaPtpNLZJ570hlXY09YXt4JZdj_wrNtsWLGu2nVdjd1Zx9-kyDP8885GiQNTtf-A_HSUZX3-X8QCGmfU6KAFHuYcODS_kd-jFnEbsMeSAdom0kZKuTOhoM4YTueZH5gJ2_SohBYx99MB258_Ytr3OUs8vPE9moMMSB4h0vX_IC_JVHKxwn1cNyuob6cjg_W6y5vONoPQCTF7p8_S6BpTzHfxHVIIebaGd2KBqWO_WirUFZNOFa85DoQmhEw-tpKp7Ra1ckZAeBTrV2r5YwIN4YdVqfjJiuKH151-GVrbMssQeNtvCzH-QuoV5nV92D6jSjGSVUndxCcHBbLMZHr-27JW9bSVJ3LmJGR0vU5-yGZH1ViqiLNsjxBwfxD4N5Ga5MRT2e8hlyyrat3SZ8ZZ-IkoW8c4RwnUr9onk3sXCZhQOq9XESWt7HF6iJODRiDYe-AZVc4AVLAF5DPRmFKf8f3J6Rhfnyrue2qBS00DyhFyZGNbw_UaMk5tz1WYpFfcXHanZdB7LP0NnzWjGIgS-qVRaDXxNeE","p": "8gp6yLQ07LqGllcDW2uDgkfYPUO9VCZRv2Zi4gSuJfXQHCcdE9qxMMhybzERUAItcDTY78AgrT8s02B8vWVyFX7bcHrycLFoqc_jCkrIRdY1UDjdZxc-5Js-FCNVG_189yjRuvCXl43JuO2chao2m8ae7efnLA8Ka4axtI98luqcWVL5hZSeeEz6jKOo0Hk2pfgIqJABaJGhkTifhCITrH63IkwYRg4ShVTBkBFQ7IwJG2viK809LnryPtH-WPTeeaYovbo86STZwWOLPBW7KsYqcT_tRebW42PQtqNG8hmAjgLLGUMZVT1Ymdflnf7vX8UjrmYj5vpjnhM9EM0C_w","q": "yV_VAdMEyb0UrUkv1E58sQxEGaaQ982RE11-YT-R6EXOjl6kR-XmTcBWkjzI4trvfQJXi8TUlahxxGiHYgYA56GRjR-CNBot_R_oTff7VWQDHwpQTyhd33cakpdHKgNqPiQ9zYKQom4bBwf8xENKIQQ1V9khtRGsl7q4rmx7lr4oJvLe9tCGSPVGvxs5NHbZLRSiQtQkoOBQ1S2QA68nD2o7CO0-oxJ-UDEzPoWcJJhtxRysE7aJtMPcQTWKApD3Tfs5aH8KtaWhoSlkLatqKOwPcjKpJAOKjUVCDedZbjx2j4ekJyY1aCV1eRz73XjiHcFcNnPuigXffx39wtjqpw","dp": "G9MUlmoRA33V5waNvj632YxE0ZYt97SIBUbR60W6d2awy-u7LgMgB4mjjiDH6ri1XIbWwYkGuKPglVQsQuGcodf5hg68PDRI4eyiHxbFuzGK43QGD8neUw19r3b4W8ViTk-E_MaXxrZoEDhQnBUbPgExWAwmySvZeM79MtKj8f16h9JAGRkitpWy3-QYjg7BN4cyB562ar0DI9ysidYZCOVwTCMPT05i1q0Nq3AyK19V1K8sSvjHJcbAfnRJlxRfVwDBAj6crfish8zXvsqIv7wUOPyuXDDTV0SsQ7K1fzNrUegETR0nlmL9AoKNRQJ_pjTVi0D2s6DpPszbYkkPJQ","dq": "gLiFTBk7Ikl_AhWaQTe6dOHGVi8m03_PkHVe54LfHX4hvte4Y00Nnf2oWOoJ7xjLpTjuBSXYTaHStx2qDHqR8X5Rr8fITs29P-Q5dj1hpv-7DwhktXS0LLfRgIq6rpxoOTipWMhw86M2G5R7emkY5WnvPyxIY5ncnVB55OTrSzxaJitxYouAivpeMqKQOn0N7ccWwWkh0MQSZ3IscG5xpWTeP6KHO24C1_fbLcfyO2JEKI9fX2p7M9VO4U_73BAWRP6lf6pVii9J1d7Dbn336hia9wBzJdYtpofy5ThQ7iowDydBQtUlpmDranOge71drG-BJj2M6SU_692b7AUEWQ","qi": "0-TUiGRoPBWatRlzSQIvwXs5zpGn20QfgmcGQD1LWnogWG-6QwfFsRWJ78FLEK69x35hBdcyzDNC5PzvBPXatr9_bL_Fv10qwMTkFwPOuDZHEzvb3-b_L3MD4JnQ6LbT8g36scv6aEgMNt9eeugRq0bR4xba1oj2pgjfVVKiENQWPlVYZ0HKYHAwdoss4d9x0dI1g-Gl426LreDz5RmDUgzdZ3nAfdnTrLUM69RTmAUjb_GfFWvmlBesFo-npv8qNToZRWmxEClXJZQCoxnzHx29bFe6WY5Jlt3zWCmI3o6LHQx6UiMrN-B_qE4T3plK0bS_w0x-Lbp9bhPbPE9AVA"}]
+OidcClient_CRYPTO_ENC_LOCALE_PRIV_KEYS=[{"e":"AQAB","n":"5OHMkVCg2xG2osiXbClpkW8YVxVeqPeQDrDZH1tiocf3S9kK1ErRP1oI1qwP3-MTZVp3O0NjO7eIkkqdogCl043vVty25KMk-lM-dAXfQFjSKBE5c2Y_mZbsvEyk885ZmEbb--S-lxZuBX1jWs574fOSsqKH5e5Mf_PjKgwZFOW0SFl6pGOp230Em5OfTbCN8AKMkw907b9DXoPocDcr3d3ZEa10f5OCI0aieTxvH5Jaq9ZMOQIj1-tTMpDecFYLO8REiQSsUp-4PLUbIBL2Iq-qwv6opkVetpiLR-wwz7e2Y_dDHCqnVHcCo_oWVFFRgKiL_dhmxFIpSkw4dc1ICQ","d":"vZepC6o9RJo8rkT44XjAYN8ky2YBPnerVe_6OrZJUnfBCowkI0xCXnbnIWPv1mZT973jTCz680mJkJzMTJi6xC4rVsmHmoblp5HzBsqibrvkgZoa-9Nz1XcmbKgUb3y7zJ7NtK97jM3gnx2JgnvONJG-L8jgR3-I0OimgHr6_8nh8Qv66at8fighlefmIp-2UVYPydKp2pi9drQAWFAYW5hgNCcmuMi8814O4hdm3zsJU6w8cwOLf2p_L3No9YonO2GcSO_ZRHqPqdj5lDwtBR2DbYAUpzOYj0FMPoG6MMM6ITK9DgHDtwVuoo6ZxI6aoAMCYZ8zehn9QuACtZZQPQ","p":"8l1JmRGOfMMxlqFaAB9sWFe29P4xIVl5Tez95Hf9qIIlcdNvrm6bep5889sMAfN3LB2NA09rwBdCPdjVT_80XgrxTsxPPOvzmxuHmHaozlkBAAgfNgIASgKaznSf8nbBkp-p6NRIc3JOCJDFopm6C43ZCexBu8or_CK554O8AMM","q":"8cJUELj52DDYoxcGsm6wIyk9QYCIRry3gxJwaHWQt4xTeX65_W27x0WVY4ZXNCIYYMxKQXN5Ud70OsdzExNHk9dn96w2cOT2tKlIixoSyDpbLsYKuQ4KlEz0S2GZJyiAT0C2N_1VlRy_OFAFmauj9SIMm3Wr3UhWa7fWRWThR0M","dp":"Rs_SzRJAG1u8hVInRZnowfb-0Z3jJOdLdeUkWThluHIuFo-8Na7DZpQf1e_OFlPYId-Qb8MorDsfc4qC6Jib6E4yKt-u1xHpXwwwFe-1anS-wg-dbt4uz3DrYh7ZDLJ95CUaM5iygmiHPCFwXQ2lOfL70tZgbkmniEdtIaNvrpk","dq":"vkXv2-l52kk3d8SbpLuxLTs71t3OY74LwME2b0B4Ub3DxQ-UWn2PGNsPJHGLGKDtBuJCXxj_Fwyes9ReIVk_MICMd0W240uRT8ccLT6sIaKsOTftIJCIiwe2Dc4Wt9cMhVOtFovwW5dweGWiwrtwI3JU8dW_Gj3gpo7duWgYVfk","qi":"Cpf7tVogmGoFr-WTWSkctb0KqNtNCY3tU__2b2GI0uW_a9TafQhU8fon4SNBPlicdAYlgO1q23tklyhGpLbw7qYgHkr-zt-v_Vfg5YP8cZYGEqW52Qjl2HeMlCCI0-38RG3wFYwXjGDZk9YW6VAWlc6i1MSLrd7NGRrwH1ZkD7U","kty":"RSA","alg": "RSA-OAEP","kid":"oidc-provider:locale","use":"enc"}]
+OidcProvider_COOKIES_KEYS=["iet7jaetheezaingahThooSiem3Oothu", "aeChoomaeyi5Jeo7Viezoh8aew8ieH3m", "JaeDahngohc3athooy1Eip2ahtei8Aep", "iu5vu5EeD4goow5eipeizequaetaxo0V"]
+OidcProvider_ERROR_URI_BASE=https://github.com/numerique-gouv/proconnect-documentation/blob/main/doc_fs/troubleshooting-fs.md
+# OidcClient
+OidcClient_SCOPE=openid uid given_name usual_name email siren siret organizational_unit belonging_population phone chorusdt
+OidcClient_HTTPS_CLIENT_CERT=/etc/ssl/docker_host/app.crt
+OidcClient_HTTPS_CLIENT_KEY=/etc/ssl/docker_host/app.key
+OidcClient_FAPI=false
+OidcClient_FEATURE_ENABLE_HYYYPERBRIDGE=true
+# HyyyperbridgeBroker
+HyyyperbridgeBroker_QUEUE=rie
+HyyyperbridgeBroker_URLS=["amqp://fca-rie_user:fca-rie_user@broker-1:5672/fca-rie","amqp://fca-rie_user:fca-rie_user@broker-2:5672/fca-rie","amqp://fca-rie_user:fca-rie_user@broker-3:5672/fca-rie"]
+
+# Mongo
+FC_DB_TYPE=mongodb
+Mongoose_HOSTS=mongo-fca-low:27017
+Mongoose_DATABASE=core-fca-low
+Mongoose_USER=fc
+Mongoose_PASSWORD=pass
+Mongoose_TLS=true
+Mongoose_TLS_INSECURE=false
+Mongoose_TLS_ALLOW_INVALID_HOST_NAME=false
+Mongoose_TLS_CA_FILE=/etc/ssl/docker_host/docker-stack-ca.crt
+FC_DB_SYNCHRONIZE=false
+FC_DB_CONNECT_OPTIONS=?replicaSet=rs0
+# Crypto
+AdapterMongo_CLIENT_SECRET_CIPHER_PASS=JZBlwxfKnbn/RV025aw+dQxk+xoQT+Yr
+AdapterMongo_DECRYPT_CLIENT_SECRET_FEATURE=true
+Session_USERINFO_CRYPT_KEY=raePh3i+a4eiwieb-H5iePh6o/gheequ
+## Redis
+Redis_DB=4
+Redis_HOST=redis-pwd
+Redis_PORT=6379
+Redis_PASSWORD=Ivae1feiThoogahquohDei7iwie0ceeM
+Redis_ENABLE_TLS_FOR_SENTINEL_MODE=false
+# Arbitrary DB number, default is 0 and is used by legacy core.
+Session_COOKIE_SECRETS=["yahvaeJ0eiNua6te", "lidubozieKadee7w", "Eigoh6ev8xaiNoox", "veed7Oow7er5Saim"]
+# Mailer
+MAILER=logs
+MAILER_FROM_EMAIL=ne-pas-repondre@franceconnect.gouv.fr
+MAILER_FROM_NAME=NE PAS RÉPONDRE
+## Bluebird potential memory leak safe guard
+## @see https://gitlab.dev-franceconnect.fr/france-connect/fc/-/issues/131
+## @see http://bluebirdjs.com/docs/api/promise.config.html#promise.config
+BLUEBIRD_LONG_STACK_TRACES=0
+BLUEBIRD_DEBUG=0
+## Proxy settings
+NODE_USE_ENV_PROXY=1
+HTTP_PROXY=http://squid:3128
+HTTPS_PROXY=http://squid:3128
+
+## API Entreprise
+ApiEntreprise_API_TOKEN=CeciEstUnTokenDeTest
+ApiEntreprise_API_BASE_URL=https://entreprise.api.gouv.fr
+ApiEntreprise_SHOULD_MOCK_API=true
+ApiEntreprise_FEATURE_FETCH_ORGANIZATION_DATA=true
+
+EmailValidator_FEATURE_MX_RESOLUTION_VALIDATION=true

--- a/docker/compose/fca-low/.env/hybridge-rie-cluster.env
+++ b/docker/compose/fca-low/.env/hybridge-rie-cluster.env
@@ -1,0 +1,19 @@
+# -- global
+APP_NAME=csmr-rie
+APP_ROOT=
+FQDN=csmr-rie.docker.dev-franceconnect.fr
+NESTJS_INSTANCE=csmr-rie
+REQUEST_TIMEOUT=6000
+
+# App
+App_HTTPS_SERVER_CERT=/etc/ssl/docker_host/app.crt
+App_HTTPS_SERVER_KEY=/etc/ssl/docker_host/app.key
+
+# Logger
+Logger_THRESHOLD=debug
+
+
+# Rie
+RieBroker_URLS=["amqp://fca-rie_user:fca-rie_user@broker-1:5672/fca-rie","amqp://fca-rie_user:fca-rie_user@broker-2:5672/fca-rie","amqp://fca-rie_user:fca-rie_user@broker-3:5672/fca-rie"]
+RieBroker_QUEUE=rie
+

--- a/docker/compose/fca-low/core.yml
+++ b/docker/compose/fca-low/core.yml
@@ -19,3 +19,16 @@ services:
     env_file:
       - '../shared/.env/base-app.env'
       - '../fca-low/.env/core-rie.env'
+
+  core-cluster:
+    extends: core
+    env_file:
+      - '../shared/.env/base-app.env'
+      - '../fca-low/.env/core-cluster.env'
+    depends_on:
+      broker-1:
+        condition: service_healthy
+      broker-2:
+        condition: service_healthy
+      broker-3:
+        condition: service_healthy

--- a/docker/compose/fca-low/hybridge.yml
+++ b/docker/compose/fca-low/hybridge.yml
@@ -29,3 +29,32 @@ services:
       - rie
     init: true
     command: 'yarn start:dev csmr-rie'
+
+  hybridge-rie-cluster:
+    hostname: hybridge-rie
+    build:
+      context: '../../../back'
+      target: dev
+    user: ${CURRENT_UID}
+    depends_on:
+      - broker-1
+      - broker-2
+      - broker-3
+    volumes:
+      - '../../../back/apps:/var/www/app/apps:ro'
+      - '../../../back/libs:/var/www/app/libs:ro'
+      - '../../volumes/app:/opt/scripts'
+      - '../../volumes/log/:/var/log/app'
+      - '../../volumes/.home:/home'
+      - ../../volumes/ssl:/etc/ssl/docker_host:ro
+    tmpfs:
+      - /var/www/app/dist:mode=777
+    env_file:
+      - '../shared/.env/base-app.env'
+      - '../fca-low/.env/hybridge-rie-cluster.env'
+    tty: true
+    networks:
+      - rie
+      - data
+    init: true
+    command: 'yarn start:dev csmr-rie'

--- a/docker/compose/fca-low/stack.yml
+++ b/docker/compose/fca-low/stack.yml
@@ -49,3 +49,18 @@ services:
       - 'squid'
       - 'hybridge-rie'
       - 'fia-rie-low'
+
+  rabbitmq-cluster:
+    image: alpine
+    depends_on:
+      - 'core-cluster'
+      - 'fsa1-low'
+      - 'fia1-low'
+      ### RIE
+      - 'squid'
+      - 'hybridge-rie-cluster'
+      - 'fia-rie-low'
+      ### Cluster brokers
+      - 'broker-1'
+      - 'broker-2'
+      - 'broker-3'

--- a/docker/compose/shared/.env/rabbitmq.env
+++ b/docker/compose/shared/.env/rabbitmq.env
@@ -1,0 +1,1 @@
+RABBITMQ_ERLANG_COOKIE=Ivae1feiThoogahquohDei7iwie0ceeM

--- a/docker/compose/shared/shared.yml
+++ b/docker/compose/shared/shared.yml
@@ -228,6 +228,66 @@ services:
       - '5672:5672'
       - '15672:15672'
 
+  broker-1:
+    image: rabbitmq:3.12.4-management
+    hostname: broker-1
+    env_file:
+      - ../shared/.env/rabbitmq.env
+    environment:
+      RABBITMQ_NODENAME: rabbit@broker-1
+    volumes:
+      - '../../builds/broker/rabbitmq-cluster.config:/etc/rabbitmq/rabbitmq.config:ro'
+      - '../../builds/broker/definitions.json:/etc/rabbitmq/definitions.json:ro'
+    healthcheck:
+      test: rabbitmq-diagnostics -q ping
+      interval: 10s
+      timeout: 5s
+      retries: 5
+    networks:
+      - data
+
+  broker-2:
+    image: rabbitmq:3.12.4-management
+    hostname: broker-2
+    env_file:
+      - ../shared/.env/rabbitmq.env
+    environment:
+      RABBITMQ_NODENAME: rabbit@broker-2
+    volumes:
+      - '../../builds/broker/rabbitmq.config:/etc/rabbitmq/rabbitmq.config:ro'
+      - '../../builds/broker/definitions.json:/etc/rabbitmq/definitions.json:ro'
+    depends_on:
+      broker-1:
+        condition: service_healthy
+    healthcheck:
+      test: rabbitmq-diagnostics -q ping
+      interval: 10s
+      timeout: 5s
+      retries: 5
+    networks:
+      - data
+
+  broker-3:
+    image: rabbitmq:3.12.4-management
+    hostname: broker-3
+    env_file:
+      - ../shared/.env/rabbitmq.env
+    environment:
+      RABBITMQ_NODENAME: rabbit@broker-3
+    volumes:
+      - '../../builds/broker/rabbitmq.config:/etc/rabbitmq/rabbitmq.config:ro'
+      - '../../builds/broker/definitions.json:/etc/rabbitmq/definitions.json:ro'
+    depends_on:
+      broker-1:
+        condition: service_healthy
+    healthcheck:
+      test: rabbitmq-diagnostics -q ping
+      interval: 10s
+      timeout: 5s
+      retries: 5
+    networks:
+      - data
+
   ####################
   # Data storage
   ####################


### PR DESCRIPTION
**Problem**

Local dev has only a plain single-node `broker` (port 5672). 
Production runs a 3-node RabbitMQ cluster for HA, but there is no way to exercise the `amqp-connection-manager` URL failover path locally.

**Proposal**

`dks switch rabbitmq-cluster` — local replica of the production HA topology so the broker code path (`@hybridge` e2e tests) can be exercised against a clustered broker without deploying to k8s.

- `broker-1` (seed) / `broker-2` / `broker-3` — `rabbitmq:3.12.4-management` nodes sharing `RABBITMQ_ERLANG_COOKIE`, loading the existing `definitions.json` via `rabbitmq-cluster.config`. `broker-2/3` use static peer discovery (classic_config backend) to join `broker-1` automatically on fresh start; the cluster config is isolated to `rabbitmq-cluster.config` so the standalone `broker` service is unaffected.
- `core-cluster` — `core` variant whose env points at the cluster URL list  (`HyyyperbridgeBroker_URLS`); keeps `hostname: core` so nginx routes transparently without a new vhost. `env_file` is a full copy of `core.env` with only the broker URLs swapped (same shape as `core-sentinel.env`).
- `hybridge-rie-cluster` — `hybridge-rie` variant pointing `RieBroker_URLS` at the cluster; joined to both the `rie` and `data` networks so it can resolve the broker hostnames via docker DNS (the plain `hybridge-rie` reaches broker via the rie network gateway + host port forwarding, which doesn't apply to the port-less cluster brokers).
- `rabbitmq-cluster` stack — aggregator that starts the full cluster + cluster-aware services in one command; waits for all broker nodes + the cluster services to be healthy before the stack is considered up.
- `rie` queue declared as a [quorum queue][quorum-queue] (`queueOptions.arguments["x-queue-type"] = "quorum"`) so it is replicated across the cluster nodes — without this, scaling only gives connection-level HA, not data HA. Existing classic queues must be deleted before the first start or the declaration will fail.

**Verified**

`dks switch rabbitmq-cluster` → 3-node cluster (`cluster_status` shows `broker-1`, `broker-2`, `broker-3`), `rie` queue is `quorum` with all 3 nodes as members, leader failover on broker-1 stop works (leader moves to a surviving node), rejoins cleanly when broker-1 comes back.

[quorum-queue]: https://www.rabbitmq.com/docs/quorum-queues