### PR TITLE
✨ (pcf, csmr-rie): add quorum queue type for rabbitmq-cluster

### DIFF
--- a/back/apps/core-fca-low/src/config/hyyyperbridge-broker.ts
+++ b/back/apps/core-fca-low/src/config/hyyyperbridge-broker.ts
@@ -6,7 +6,7 @@ const env = new ConfigParser(process.env, "HyyyperbridgeBroker");
 export default {
   payloadEncoding: "base64",
   queue: env.string("QUEUE"),
-  queueOptions: { durable: true },
+  queueOptions: { durable: true, arguments: { "x-queue-type": "quorum" } },
   // Global request timeout used for any outgoing app requests.
   requestTimeout: parseInt(process.env.REQUEST_TIMEOUT, 10),
   urls: env.json("URLS"),

--- a/back/apps/csmr-rie/src/config/rie-broker.ts
+++ b/back/apps/csmr-rie/src/config/rie-broker.ts
@@ -8,6 +8,7 @@ export default {
   queue: env.string("QUEUE"),
   queueOptions: {
     durable: true,
+    arguments: { "x-queue-type": "quorum" },
   },
   payloadEncoding: "base64",
 


### PR DESCRIPTION
**Problem**

RabbitMQ cluster nodes use classic queues by default, which do not replicate data across nodes — a single-node failure loses messages.

**Proposal**

Set `x-queue-type: quorum` on `HyyyperbridgeBroker` and `RieBroker` queues so data is replicated across the cluster and survives node restarts.