### PR TITLE
✨ (pcf): add sentinel support to redis config

### DIFF
--- a/back/_doc/env-vars.md
+++ b/back/_doc/env-vars.md
@@ -59,8 +59,11 @@
 | Redis_DB                                        | number        |
 | Redis_ENABLE_TLS_FOR_SENTINEL_MODE              | boolean       |
 | Redis_HOST                                      | string        |
+| Redis_NAME                                      | string        |
 | Redis_PASSWORD                                  | string        |
 | Redis_PORT                                      | number        |
+| Redis_SENTINELS                                 | stringArray   |
+| Redis_SENTINEL_PASSWORD                         | string        |
 | Session_COOKIE_SECRETS                          | json          |
 | Session_USERINFO_CRYPT_KEY                      | string        |
 

--- a/back/apps/core-fca-low/src/config/redis.ts
+++ b/back/apps/core-fca-low/src/config/redis.ts
@@ -6,12 +6,22 @@ const env = new ConfigParser(process.env, "Redis");
 const ca = env.file("CACERT", true);
 const tlsSettings = ca ? { ca } : undefined;
 
+const sentinels = env.stringArray("SENTINELS").map((entry) => {
+  const [host, port] = entry.split(":");
+  return { host, port: parseInt(port, 10) };
+});
+
+const useSentinels = sentinels.length > 0;
+
 export default {
-  host: env.string("HOST"),
-  port: env.number("PORT"),
+  host: useSentinels ? undefined : env.string("HOST"),
+  port: useSentinels ? undefined : env.number("PORT"),
   password: env.string("PASSWORD"),
   db: env.number("DB"),
-  tls: tlsSettings,
+  sentinels: useSentinels ? sentinels : undefined,
+  name: useSentinels ? env.string("NAME") : undefined,
+  sentinelPassword: env.string("SENTINEL_PASSWORD", true),
   sentinelTLS: tlsSettings,
+  tls: tlsSettings,
   enableTLSForSentinelMode: env.boolean("ENABLE_TLS_FOR_SENTINEL_MODE"),
 } as RedisConfig;


### PR DESCRIPTION
**Problem**

`redis.ts` reads direct-connect env vars (`HOST`, `PORT`, `PASSWORD`,
`DB`, `TLS`) but not the sentinel ones. The `RedisConfig` DTO already
declares the sentinel fields (`sentinels`, `name`,
`sentinelPassword`) — they just had no env-var source.

**Proposal**

Read `Redis_SENTINELS`, `Redis_NAME`, `Redis_SENTINEL_PASSWORD`. When
`Redis_SENTINELS` is non-empty, populate the sentinel fields and
leave `host`/`port` undefined; otherwise keep the direct-connect
fields. 