### PR TITLE
🔧 api: make MongoDB TLS configurable via env

### DIFF
--- a/pcdbapi/compose.yaml
+++ b/pcdbapi/compose.yaml
@@ -8,6 +8,7 @@ services:
       - MONGODB_PASSWORD=pass
       - MONGODB_CERTIFICATE_FILEPATH=/etc/ssl/mongo.pem
       - MONGODB_CA_FILEPATH=/etc/ssl/docker-stack-ca.crt
+      - MONGODB_TLS=true
       - API_SECRET=pcdb-api-secret-key
       - CLIENT_SECRET_CIPHER_PASS=test-pcdbapi-secret-cipher-passs
       - CANT_RUN_TESTS=1
@@ -42,6 +43,7 @@ services:
       - MONGODB_PASSWORD=pass
       - MONGODB_CERTIFICATE_FILEPATH=/etc/ssl/mongo.pem
       - MONGODB_CA_FILEPATH=/etc/ssl/docker-stack-ca.crt
+      - MONGODB_TLS=true
       - CLIENT_SECRET_CIPHER_PASS=test-pcdbapi-secret-cipher-passs
       - API_SECRET=pcdb-api-secret-key
     depends_on:

--- a/pcdbapi/main.py
+++ b/pcdbapi/main.py
@@ -20,6 +20,7 @@ CONFIG = {
     "mongodb_password": os.getenv("MONGODB_PASSWORD"),
     "mongodb_certificate_filepath": os.getenv("MONGODB_CERTIFICATE_FILEPATH"),
     "mongodb_ca_filepath": os.getenv("MONGODB_CA_FILEPATH"),
+    "mongodb_tls": os.getenv("MONGODB_TLS", "false").lower() == "true",
     "client_secret_cipher_pass": os.getenv("CLIENT_SECRET_CIPHER_PASS"),
     "api_secret": os.getenv("API_SECRET"),  # shared secret
     "max_timestamp_diff": 300,  # 5 minutes
@@ -53,7 +54,7 @@ async def lifespan(app: FastAPI):
         CONFIG["mongodb_url"],
         username=CONFIG["mongodb_username"],
         password=CONFIG["mongodb_password"],
-        tls=True,
+        tls=CONFIG["mongodb_tls"],
         tlsCAFile=CONFIG["mongodb_ca_filepath"],
     )
 


### PR DESCRIPTION
**Problem**

MongoClient was hardcoded with tls=True, blocking local/dev deployments that connect without TLS and forcing code edits per environment.

**Proposal**

Read MONGODB_TLS from the environment (defaulting to false) and feed the parsed boolean into the MongoClient tls argument so each deployment can opt in/out of TLS without touching code.