### PR TITLE
🔥 (docker): remove Redis_CACERT from remaining env files

### DIFF
--- a/docker/compose/fca-low/.env/core-rie.env
+++ b/docker/compose/fca-low/.env/core-rie.env
@@ -63,7 +63,6 @@ Redis_DB=4
 Redis_HOST=redis-pwd
 Redis_PORT=6379
 Redis_PASSWORD=Ivae1feiThoogahquohDei7iwie0ceeM
-Redis_CACERT=/etc/ssl/docker_host/docker-stack-ca.crt
 Redis_ENABLE_TLS_FOR_SENTINEL_MODE=false
 # Arbitrary DB number, default is 0 and is used by legacy core.
 Session_COOKIE_SECRETS=["yahvaeJ0eiNua6te", "lidubozieKadee7w", "Eigoh6ev8xaiNoox", "veed7Oow7er5Saim"]

--- a/docker/compose/fca-low/.env/fia-rie-low.env
+++ b/docker/compose/fca-low/.env/fia-rie-low.env
@@ -21,7 +21,6 @@ Redis_DB=4
 Redis_HOST=redis-pwd
 Redis_PORT=6379
 Redis_PASSWORD=Ivae1feiThoogahquohDei7iwie0ceeM
-Redis_CACERT=/etc/ssl/docker_host/docker-stack-ca.crt
 Redis_ENABLE_TLS_FOR_SENTINEL_MODE=false
 
 

--- a/docker/compose/fca-low/.env/fia1-low.env
+++ b/docker/compose/fca-low/.env/fia1-low.env
@@ -21,7 +21,6 @@ Redis_DB=4
 Redis_HOST=redis-pwd
 Redis_PORT=6379
 Redis_PASSWORD=Ivae1feiThoogahquohDei7iwie0ceeM
-Redis_CACERT=/etc/ssl/docker_host/docker-stack-ca.crt
 Redis_ENABLE_TLS_FOR_SENTINEL_MODE=false
 
 

--- a/docker/compose/fca-low/.env/fia2-low.env
+++ b/docker/compose/fca-low/.env/fia2-low.env
@@ -20,7 +20,6 @@ Redis_DB=4
 Redis_HOST=redis-pwd
 Redis_PORT=6379
 Redis_PASSWORD=Ivae1feiThoogahquohDei7iwie0ceeM
-Redis_CACERT=/etc/ssl/docker_host/docker-stack-ca.crt
 Redis_ENABLE_TLS_FOR_SENTINEL_MODE=false
 
 

--- a/docker/compose/fca-low/.env/fsa1-low.env
+++ b/docker/compose/fca-low/.env/fsa1-low.env
@@ -20,7 +20,6 @@ Redis_DB=4
 Redis_HOST=redis-pwd
 Redis_PORT=6379
 Redis_PASSWORD=Ivae1feiThoogahquohDei7iwie0ceeM
-Redis_CACERT=/etc/ssl/docker_host/docker-stack-ca.crt
 Redis_ENABLE_TLS_FOR_SENTINEL_MODE=false
 
 

--- a/docker/compose/fca-low/.env/fsa2-low.env
+++ b/docker/compose/fca-low/.env/fsa2-low.env
@@ -20,7 +20,6 @@ Redis_DB=4
 Redis_HOST=redis-pwd
 Redis_PORT=6379
 Redis_PASSWORD=Ivae1feiThoogahquohDei7iwie0ceeM
-Redis_CACERT=/etc/ssl/docker_host/docker-stack-ca.crt
 Redis_ENABLE_TLS_FOR_SENTINEL_MODE=false
 
 

--- a/docker/compose/fca-low/.env/fsa3-low.env
+++ b/docker/compose/fca-low/.env/fsa3-low.env
@@ -20,7 +20,6 @@ Redis_DB=4
 Redis_HOST=redis-pwd
 Redis_PORT=6379
 Redis_PASSWORD=Ivae1feiThoogahquohDei7iwie0ceeM
-Redis_CACERT=/etc/ssl/docker_host/docker-stack-ca.crt
 Redis_ENABLE_TLS_FOR_SENTINEL_MODE=false
 
 

--- a/docker/compose/fca-low/.env/moncomptepro.env
+++ b/docker/compose/fca-low/.env/moncomptepro.env
@@ -21,7 +21,6 @@ Redis_DB=4
 Redis_HOST=redis-pwd
 Redis_PORT=6379
 Redis_PASSWORD=Ivae1feiThoogahquohDei7iwie0ceeM
-Redis_CACERT=/etc/ssl/docker_host/docker-stack-ca.crt
 Redis_ENABLE_TLS_FOR_SENTINEL_MODE=false
 
 # -- Session


### PR DESCRIPTION
**Problem**

Redis_CACERT was still set in 8 env files (core-rie, moncomptepro, fsa1-3, fia1-2, fia-rie) pointing at docker-stack-ca.crt, but the local redis-pwd service runs plain (no --tls, no SSL volume) since https://github.com/proconnect-gouv/federation/commit/fc80092a038f8d712dad024fbb34edae843d6265. A client with CACERT set would attempt TLS against a non-TLS server and fail. core.env already dropped this line in
https://github.com/proconnect-gouv/federation/commit/fc80092a038f8d712dad024fbb34edae843d6265 — the sweep was never finished.

**Proposal**

Drop Redis_CACERT from the 8 remaining env files, completing the parity with core.env. Redis TLS is now uniformly opt-in via env (matching how the mongo TLS removal left its TLS fields optional).
docker-stack-ca.crt is kept — still needed by postgres, nginx, and NODE_EXTRA_CA_CERTS.