### PR TITLE
🐛 fix: handle domains without MX records according to RFC behavior

### DIFF
--- a/back/libs/email-validator/src/services/email-validator.service.spec.ts
+++ b/back/libs/email-validator/src/services/email-validator.service.spec.ts
@@ -309,4 +309,70 @@ describe(EmailValidatorService.name, () => {
       expect(result.suggestion).toBe("user@test.example.com");
     });
   });
+
+  describe("computeIsDomainReachable", () => {
+    it("should return true when MX records are found", async () => {
+      // Given
+
+      jest.spyOn(global, "fetch").mockResolvedValueOnce({
+        json: jest.fn().mockResolvedValue({
+          Answer: [{ name: "example.com.", type: 15, TTL: 300, data: "0 ." }],
+        }),
+      } as unknown as Response);
+
+      // When
+      const result = await service["computeIsDomainReachable"]("example.com");
+
+      // Then
+      expect(result).toBe(true);
+    });
+
+    it("should return true when no MX records are found but the DNS resolution succeeds", async () => {
+      // Given
+      jest
+        .spyOn(global, "fetch")
+        .mockResolvedValueOnce({
+          json: jest.fn().mockResolvedValue({
+            Answer: undefined,
+          }),
+        } as unknown as Response)
+        .mockResolvedValueOnce({
+          json: jest.fn().mockResolvedValue({
+            Answer: [
+              { name: "ehpad-avs.fr.", type: 15, TTL: 300, data: "0 ." },
+            ],
+          }),
+        } as unknown as Response);
+
+      // When
+      const result = await service["computeIsDomainReachable"]("ehpad-avs.fr");
+
+      // Then
+      expect(result).toBe(true);
+    });
+
+    it("should return false when no MX records are found and the DNS resolution fails", async () => {
+      // Given
+      jest
+        .spyOn(global, "fetch")
+        .mockResolvedValueOnce({
+          json: jest.fn().mockResolvedValue({
+            Answer: undefined,
+          }),
+        } as unknown as Response)
+        .mockResolvedValueOnce({
+          json: jest.fn().mockResolvedValue({
+            Answer: undefined,
+          }),
+        } as unknown as Response);
+
+      // When
+      const result = await service["computeIsDomainReachable"](
+        "does-not-exist-1234567890.fr",
+      );
+
+      // Then
+      expect(result).toBe(false);
+    });
+  });
 });

--- a/back/libs/email-validator/src/services/email-validator.service.ts
+++ b/back/libs/email-validator/src/services/email-validator.service.ts
@@ -96,14 +96,30 @@ export class EmailValidatorService {
 
     if (!featureMxResolutionValidation) return false;
 
+    const isDomainReachable = await this.computeIsDomainReachable(emailDomain);
+    return isDomainReachable;
+  }
+
+  private async computeIsDomainReachable(domain: string): Promise<boolean> {
     try {
-      const response = await fetch(
-        `https://dns.google/resolve?name=${encodeURIComponent(emailDomain)}&type=MX`,
+      const mxResponse = await fetch(
+        `https://dns.google/resolve?name=${encodeURIComponent(domain)}&type=MX`,
       );
-      const { Answer } = (await response.json()) as {
+      const mxData = (await mxResponse.json()) as {
         Answer?: { name: string }[];
       };
-      return Array.isArray(Answer) && Answer.length > 0;
+      const { Answer } = mxData;
+      if (Answer) {
+        return Array.isArray(Answer) && Answer.length > 0;
+      }
+      const dnsResponse = await fetch(
+        `https://dns.google/resolve?name=${encodeURIComponent(domain)}`,
+      );
+      const dnsData = (await dnsResponse.json()) as {
+        Answer?: { name: string }[];
+      };
+
+      return Array.isArray(dnsData.Answer) && dnsData.Answer.length > 0;
     } catch {
       return false;
     }


### PR DESCRIPTION
**Problem**
Some domains do not have MX records and are incorrectly considered invalid, even though the RFC specifies that in such cases the domain should be treated as if its MX record points to the domain itself.

**Proposal**
Use a DNS lookup fallback to validate the domain when no MX records are present.