### PR TITLE
🔍 feat: allow federation user search by email in admin

### DIFF
--- a/admin/cypress/integration/federation-user/federation-user-list.spec.js
+++ b/admin/cypress/integration/federation-user/federation-user-list.spec.js
@@ -30,6 +30,24 @@ describe("Federation user list", () => {
       ).should("have.class", "fa-toggle-off");
     });
 
+    it("I can search a federation user by sub", () => {
+      cy.visit(`/federation-user`);
+      cy.get("#searchInput").type(DEACTIVATED_USER_SUB);
+      cy.contains("Rechercher").click();
+
+      cy.get("table tbody tr").should("have.length", 1);
+      cy.get("table").should("contain.text", DEACTIVATED_USER_SUB);
+    });
+
+    it("I can search a federation user by email", () => {
+      cy.visit(`/federation-user`);
+      cy.get("#searchInput").type("user-multiple-idp@fia1.fr");
+      cy.contains("Rechercher").click();
+
+      cy.get("table tbody tr").should("have.length", 1);
+      cy.get("table").should("contain.text", "user-multiple-idp@fia1.fr");
+    });
+
     it("I cannot activate a federation user if totp not filled", () => {
       cy.visit(`/federation-user`);
 

--- a/admin/src/federation-user/federation-user.controller.ts
+++ b/admin/src/federation-user/federation-user.controller.ts
@@ -43,7 +43,7 @@ export class FederationUserController {
         page,
         limit,
         search: querySearch
-          ? { fields: ["sub"], value: querySearch }
+          ? { fields: ["sub", "idpIdentityKeys.idpMail"], value: querySearch }
           : undefined,
         sort: querySortField
           ? { field: querySortField, direction: querySortDirection }

--- a/admin/views/federation-user/list.ejs
+++ b/admin/views/federation-user/list.ejs
@@ -16,7 +16,7 @@
             <%- include('partials/choose-items-number-to-show.ejs') -%>
           </form>
           <%- include('partials/global-errors-handler.ejs') -%>
-          <%- include('partials/search', {userSearch: querySearch, placeholder: "Rechercher par sub" }); %>
+          <%- include('partials/search', {userSearch: querySearch, placeholder: "Rechercher par sub ou e-mail" }); %>
 
           <table class="table table-hover table-light shadow-sm">
             <thead class="thead-light">
@@ -32,7 +32,7 @@
             <% federationUsers.forEach(function(user){ %>
               <tr id="<%= user.sub %>">
                 <td><%= user.sub %></td>
-                <td>
+                <td class="cell-emails">
                   <%
                       user.emails.forEach(function(email, index) {
                         if (index > 0) { %>


### PR DESCRIPTION
**Problem**
Security users can currently search for users in the admin interface only by `sub`. However, they typically only have access to the email address of the user they need to block.

**Proposal**
Add the ability to search for federation users by email address in the admin interface.