### PR TITLE
⬇️ chore: align local PostgreSQL version with production

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -69,6 +69,11 @@ updates:
       interval: "weekly"
   - package-ecosystem: "docker-compose"
     directory: "/docker/compose/shared"
+    ignore:
+      - dependency-name: postgres
+        update-types:
+          - "version-update:semver-major"
+          - "version-update:semver-minor"
     labels:
       - dependencies
     schedule:
@@ -77,11 +82,6 @@ updates:
     cooldown:
       default-days: 7
     directory: "/pcdbapi"
-    ignore:
-      - dependency-name: postgres
-        update-types:
-          - "version-update:semver-major"
-          - "version-update:semver-minor"
     labels:
       - dependencies
     schedule:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -77,6 +77,11 @@ updates:
     cooldown:
       default-days: 7
     directory: "/pcdbapi"
+    ignore:
+      - dependency-name: postgres
+        update-types:
+          - "version-update:semver-major"
+          - "version-update:semver-minor"
     labels:
       - dependencies
     schedule:

--- a/docker/compose/shared/compose.yaml
+++ b/docker/compose/shared/compose.yaml
@@ -260,7 +260,7 @@ services:
         ipv4_address: 172.16.4.105
 
   pg-admin:
-    image: postgres:18
+    image: postgres:16
     environment:
       - "POSTGRES_DB=pg-db"
       - "POSTGRES_USER=pg-user"


### PR DESCRIPTION
**Problem**
The local PostgreSQL version (18) is newer than the production version (16), which may lead to inconsistencies between development and production environments.

**Proposal**
Downgrade the local PostgreSQL version to 16 so it matches the production environment.