### PR TITLE
🩹 fix: remove remaining MongoDB SSL configuration

### DIFF
--- a/pcdbapi/main.py
+++ b/pcdbapi/main.py
@@ -18,9 +18,6 @@ CONFIG = {
     "mongodb_url": os.getenv("MONGODB_URL"),
     "mongodb_username": os.getenv("MONGODB_USERNAME"),
     "mongodb_password": os.getenv("MONGODB_PASSWORD"),
-    "mongodb_certificate_filepath": os.getenv("MONGODB_CERTIFICATE_FILEPATH"),
-    "mongodb_ca_filepath": os.getenv("MONGODB_CA_FILEPATH"),
-    "mongodb_tls": os.getenv("MONGODB_TLS", "false").lower() == "true",
     "client_secret_cipher_pass": os.getenv("CLIENT_SECRET_CIPHER_PASS"),
     "api_secret": os.getenv("API_SECRET"),  # shared secret
     "max_timestamp_diff": 300,  # 5 minutes
@@ -54,8 +51,6 @@ async def lifespan(app: FastAPI):
         CONFIG["mongodb_url"],
         username=CONFIG["mongodb_username"],
         password=CONFIG["mongodb_password"],
-        tls=CONFIG["mongodb_tls"],
-        tlsCAFile=CONFIG["mongodb_ca_filepath"],
     )
 
     app.db = app.mongodb_client.get_default_database()


### PR DESCRIPTION
**Problem**
The SSL connection settings for MongoDB had not been removed from all parts of the codebase.

**Proposal**
Remove the remaining obsolete SSL configuration parameters.