### PR TITLE
📌 Pin alpine to 3.23.5 in fca-low stack

### DIFF
--- a/docker/compose/fca-low/stack.yml
+++ b/docker/compose/fca-low/stack.yml
@@ -7,7 +7,7 @@ include:
 
 services:
   small:
-    image: alpine
+    image: alpine:3.23.5
     depends_on:
       - "core"
       - "fsa1-low"
@@ -15,7 +15,7 @@ services:
 
   # -- used for e2e tests
   medium:
-    image: alpine
+    image: alpine:3.23.5
     depends_on:
       - "core"
       - "admin"
@@ -32,13 +32,13 @@ services:
       - "dpa2-low"
 
   lemon-ldap:
-    image: alpine
+    image: alpine:3.23.5
     depends_on:
       - "identity-provider-llng"
       - "openldap"
 
   hybridge:
-    image: alpine
+    image: alpine:3.23.5
     depends_on:
       - "core"
       - "fsa1-low"


### PR DESCRIPTION
**Problem**

The fca-low docker-compose stack uses the floating `alpine` tag for its four service containers (small, medium, lemon-ldap, hybridge). That makes e2e test reproducibility dependent on upstream tag movement — any breaking change in the latest image silently leaks into CI runs.

**Proposal**

Pin the image to alpine:3.23.5 explicitly across the four services so the stack builds against a known, stable base.