### PR TITLE
🐛 fix: initialize collaborators with an empty array

### DIFF
--- a/pcdbapi/main.py
+++ b/pcdbapi/main.py
@@ -144,6 +144,7 @@ async def create_oidc_client(data: OidcClient, request: Request):
                 "roles",
                 "organization_label",
             ],
+            "collaborators": [],
         }
     )
     result = await app.collection.insert_one(d)


### PR DESCRIPTION
**Problem**
When creating a new OIDC client, the `collaborators` field is left as `undefined`.

**Proposal**
Initialize the `collaborators` field with an empty array when creating a new OIDC client.