### PR TITLE
🚫 test: remove outdated Kubernetes user blocking test

### DIFF
--- a/quality/cypress/integration/exploitation/blocage-utilisateur.feature
+++ b/quality/cypress/integration/exploitation/blocage-utilisateur.feature
@@ -1,5 +1,4 @@
 #language: fr
-@k8s
 Fonctionnalité: Interface de bloquage des utilisateurs sur l'admin
 
   Scénario: Blocage d'un utilisateur sur l'admin


### PR DESCRIPTION
**Problem**
The Kubernetes user blocking test is no longer reliable because its fixtures are not aligned with the Kubernetes environment, preventing production deployments.

**Proposal**
Remove the Kubernetes user blocking test to avoid false failures until the fixtures are brought back in sync.