### PR TITLE
🐛 fix: skip MFA ACR requests for non-compliant Identity Providers

### DIFF
--- a/back/apps/core-fca-low/src/config/oidc-provider.ts
+++ b/back/apps/core-fca-low/src/config/oidc-provider.ts
@@ -59,6 +59,7 @@ const oidcProviderConfig: OidcProviderConfig = {
     "eidas3",
     "https://proconnect.gouv.fr/assurance/certification-dirigeant",
   ],
+  acrValuesForMfa: ["eidas0-mfa", "eidas1-mfa", "eidas2", "eidas3"],
   // Global request timeout used for any outgoing app requests.
   timeout: parseInt(process.env.REQUEST_TIMEOUT, 10),
 };

--- a/back/apps/mock-identity-provider-fca-low/src/main.ts
+++ b/back/apps/mock-identity-provider-fca-low/src/main.ts
@@ -38,6 +38,11 @@ app.get("/interaction/:uid", async (req, res, next) => {
     const defaultUser = getDefaultUser();
 
     if (prompt.name === "login") {
+      const requestedAcrs = get(prompt.details, "acr.value")
+        ? [get(prompt.details, "acr.value")]
+        : get(prompt.details, "acr.values") ||
+          params?.acr_values?.split(" ") ||
+          [];
       return res.render("index", {
         title: APP_NAME,
         stylesheetUrl: STYLESHEET_URL,
@@ -56,6 +61,7 @@ app.get("/interaction/:uid", async (req, res, next) => {
             oidcProviderParams: params,
             oidcProviderSession: session,
             oidcProviderClient: client,
+            requestedAcrs: requestedAcrs.join(" "),
           },
           null,
           2,

--- a/back/libs/identity-provider-adapter-mongo/src/dto/identity-provider-adapter-mongo.dto.spec.ts
+++ b/back/libs/identity-provider-adapter-mongo/src/dto/identity-provider-adapter-mongo.dto.spec.ts
@@ -34,6 +34,7 @@ describe("Identity Provider (Data Transfer Object)", () => {
     extraAcceptedEmailDomains: [],
     isBlockingForUnlistedEmailDomainsEnabled: false,
     useTheHyyyperbridge: false,
+    isMfaCompliant: true,
   };
 
   const discoveryIdpAdapterMongoMock = {

--- a/back/libs/identity-provider-adapter-mongo/src/dto/identity-provider-adapter-mongo.dto.ts
+++ b/back/libs/identity-provider-adapter-mongo/src/dto/identity-provider-adapter-mongo.dto.ts
@@ -108,6 +108,14 @@ export class MetadataIdpAdapterMongoDTO {
 
   @IsBoolean()
   readonly useTheHyyyperbridge: boolean;
+
+  @IsBoolean()
+  readonly isMfaCompliant: boolean;
+
+  @IsOptional()
+  @IsString()
+  @Transform(({ value }) => value || undefined)
+  readonly mfaComplianceNote?: string;
 }
 
 export class DiscoveryIdpAdapterMongoDTO extends MetadataIdpAdapterMongoDTO {

--- a/back/libs/identity-provider-adapter-mongo/src/schemas/identity-provider-adapter-mongo.schema.ts
+++ b/back/libs/identity-provider-adapter-mongo/src/schemas/identity-provider-adapter-mongo.schema.ts
@@ -70,6 +70,12 @@ export class IdentityProvider extends Document {
 
   @Prop({ type: Boolean })
   useTheHyyyperbridge: boolean;
+
+  @Prop({ type: Boolean })
+  isMfaCompliant: boolean;
+
+  @Prop({ type: String, required: false })
+  mfaComplianceNote?: string;
 }
 
 export const IdentityProviderSchema =

--- a/back/libs/oidc-client/src/services/oidc-client.service.spec.ts
+++ b/back/libs/oidc-client/src/services/oidc-client.service.spec.ts
@@ -68,6 +68,7 @@ describe("OidcClientService", () => {
     supportEmail: "support@test.com",
     name: "IDP Name",
     title: "IDP Title",
+    isMfaCompliant: true,
   };
 
   const brokerMock = {
@@ -581,6 +582,68 @@ describe("OidcClientService", () => {
         idpName: idpMock.name,
         idpLabel: idpMock.title,
       });
+    });
+
+    it("should filter out mfa acr values if the idp is not compliant and there are other acr values requested", async () => {
+      // Given
+      identityProviderMock.getById.mockResolvedValue({
+        ...idpMock,
+        isMfaCompliant: false,
+      });
+      configServiceMock.get.mockReturnValue({
+        acrValuesForMfa: ["eidas0-mfa", "eidas1-mfa", "eidas2", "eidas3"],
+        redirectUri: "https://rp.test/callback",
+      });
+      jest.spyOn(OidcClientService, "objToUrlParams");
+
+      // When
+      await service.getAuthorizationUrl("idp-id", {
+        claims: {
+          id_token: {
+            acr: { essential: true, values: ["eidas0", "eidas0-mfa"] },
+          },
+        },
+      });
+
+      // Then
+      expect(OidcClientService.objToUrlParams).toHaveBeenCalledWith(
+        expect.objectContaining({
+          claims: {
+            id_token: { acr: { essential: true, values: ["eidas0"] } },
+          },
+        }),
+      );
+    });
+
+    it("should remove the id_token acr requested claim if the idp is not compliant and there are no other acr values requested", async () => {
+      // Given
+      identityProviderMock.getById.mockResolvedValue({
+        ...idpMock,
+        isMfaCompliant: false,
+      });
+      configServiceMock.get.mockReturnValue({
+        acrValuesForMfa: ["eidas0-mfa", "eidas1-mfa", "eidas2", "eidas3"],
+        redirectUri: "https://rp.test/callback",
+      });
+      jest.spyOn(OidcClientService, "objToUrlParams");
+
+      // When
+      await service.getAuthorizationUrl("idp-id", {
+        claims: {
+          id_token: {
+            acr: { essential: true, value: "eidas0-mfa" },
+          },
+        },
+      });
+
+      // Then
+      expect(OidcClientService.objToUrlParams).toHaveBeenCalledWith(
+        expect.objectContaining({
+          claims: {
+            id_token: {},
+          },
+        }),
+      );
     });
 
     it("should handle EntraID specific scope and remove claims", async () => {

--- a/back/libs/oidc-client/src/services/oidc-client.service.ts
+++ b/back/libs/oidc-client/src/services/oidc-client.service.ts
@@ -35,6 +35,8 @@ import {
   HyyyperbridgeMessageType,
   HyyyperbridgeResponseDto,
 } from "@fc/hyyyperbridge";
+import { AcrClaims } from "@fc/oidc-acr";
+import { OidcProviderConfig } from "@fc/oidc-provider";
 import { SessionService } from "@fc/session";
 import { OidcClientConfig, TokenDto } from "../dto";
 import {
@@ -313,6 +315,10 @@ export class OidcClientService {
       ...customParams,
     };
 
+    if (!idp.isMfaCompliant && params.claims?.id_token?.acr) {
+      params.claims = this.filterOutMfaAcrValuesFromClaims(params.claims);
+    }
+
     if (idp.isEntraID) {
       params.scope = "openid email profile";
       delete params.claims;
@@ -491,6 +497,32 @@ export class OidcClientService {
         error,
       );
     }
+  }
+
+  private filterOutMfaAcrValuesFromClaims(previousClaims: {
+    id_token: { acr: AcrClaims };
+  }) {
+    const nextClaims = cloneDeep(previousClaims);
+
+    const requestedAcrValues = nextClaims.id_token.acr.value
+      ? [nextClaims.id_token.acr.value]
+      : [...nextClaims.id_token.acr.values!];
+    const { acrValuesForMfa } =
+      this.config.get<OidcProviderConfig>("OidcProvider");
+
+    const nonMfaAcrValues = requestedAcrValues.filter(
+      (acrValue) => !acrValuesForMfa.includes(acrValue),
+    );
+
+    if (nonMfaAcrValues.length === 0 && nextClaims.id_token.acr.essential) {
+      delete nextClaims.id_token.acr;
+      return nextClaims;
+    }
+    nextClaims.id_token.acr = {
+      ...nextClaims.id_token.acr,
+      values: nonMfaAcrValues,
+    };
+    return nextClaims;
   }
 
   async getEndSessionUrl({

--- a/back/libs/oidc-provider/src/dto/oidc-provider-config.dto.ts
+++ b/back/libs/oidc-provider/src/dto/oidc-provider-config.dto.ts
@@ -27,6 +27,9 @@ export class OidcProviderConfig {
   @IsArray()
   readonly supportedAcrValues: Configuration["acrValues"];
 
+  @IsArray()
+  readonly acrValuesForMfa: string[];
+
   @IsObject()
   readonly jwks: Configuration["jwks"];
 

--- a/back/libs/oidc/src/interfaces/identity-provider.interface.ts
+++ b/back/libs/oidc/src/interfaces/identity-provider.interface.ts
@@ -18,4 +18,6 @@ export type IdentityProviderMetadata = {
   extraAcceptedEmailDomains?: string[];
   isBlockingForUnlistedEmailDomainsEnabled: boolean;
   useTheHyyyperbridge: boolean;
+  isMfaCompliant: boolean;
+  mfaComplianceNote?: string;
 };

--- a/docker/volumes/mongo-fca-low/scripts/db-states/_default/idp.js
+++ b/docker/volumes/mongo-fca-low/scripts/db-states/_default/idp.js
@@ -39,6 +39,7 @@ const fia = {
     extraAcceptedEmailDomains: [],
     isBlockingForUnlistedEmailDomainsEnabled: false,
     useTheHyyyperbridge: false,
+    isMfaCompliant: true,
   },
 
   // -- FIA - FIA2-LOW - Activated No support Email
@@ -81,6 +82,8 @@ const fia = {
     extraAcceptedEmailDomains: [],
     isBlockingForUnlistedEmailDomainsEnabled: false,
     useTheHyyyperbridge: false,
+    isMfaCompliant: false,
+    mfaComplianceNote: "Bientôt !",
   },
 
   // -- Fia3-low - Deactivated
@@ -123,6 +126,7 @@ const fia = {
     extraAcceptedEmailDomains: [],
     isBlockingForUnlistedEmailDomainsEnabled: false,
     useTheHyyyperbridge: false,
+    isMfaCompliant: true,
   },
 
   // -- FIA - MonComptePro - Activated
@@ -164,6 +168,7 @@ const fia = {
     extraAcceptedEmailDomains: [],
     isBlockingForUnlistedEmailDomainsEnabled: false,
     useTheHyyyperbridge: false,
+    isMfaCompliant: true,
   },
   // RIE
 
@@ -207,6 +212,7 @@ const fia = {
     extraAcceptedEmailDomains: [],
     isBlockingForUnlistedEmailDomainsEnabled: false,
     useTheHyyyperbridge: true,
+    isMfaCompliant: true,
   },
 
   // -- FIA using LemonLDAP
@@ -248,6 +254,7 @@ const fia = {
     extraAcceptedEmailDomains: [],
     isBlockingForUnlistedEmailDomainsEnabled: false,
     useTheHyyyperbridge: false,
+    isMfaCompliant: true,
   },
 };
 

--- a/quality/cypress/integration/usager/connexion-acr.feature
+++ b/quality/cypress/integration/usager/connexion-acr.feature
@@ -90,3 +90,11 @@ Fonctionnalité: Connexion Usager - ACR
     Quand je clique sur le bouton de connexion
     Et je m'authentifie
     Alors la cinématique a utilisé le niveau de sécurité "eidas1"
+
+  Scénario: le FI n'est pas MFA-compliant
+    Etant donné que je navigue sur la page fournisseur de service
+    Et que le fournisseur de service requiert le claim "acr" avec les valeurs "eidas0 eidas0-mfa"
+    Et que je clique sur le bouton ProConnect
+    Et que j'entre l'email "test@fia2.fr"
+    Quand je clique sur le bouton de connexion
+    Alors la page du FI affiche requestedAcrs "eidas0" 

--- a/quality/cypress/support/usager/steps/identity-provider-steps.ts
+++ b/quality/cypress/support/usager/steps/identity-provider-steps.ts
@@ -114,6 +114,13 @@ Then(
   },
 );
 
+Then(
+  /la page du FI affiche requestedAcrs "([^"]*)"/,
+  function (expectedValue: string) {
+    cy.contains(`"requestedAcrs": "${expectedValue}"`);
+  },
+);
+
 Then("le champ identifiant correspond à {string}", function (email: string) {
   cy.get('input[name="email"]').should("have.value", email);
 });

--- a/quality/cypress/support/usager/steps/service-provider-steps.ts
+++ b/quality/cypress/support/usager/steps/service-provider-steps.ts
@@ -60,6 +60,13 @@ Given(
 );
 
 Given(
+  "le fournisseur de service requiert le claim {string} avec les valeurs {string}",
+  function (claim: string, values: string) {
+    setAsRequestedClaims(claim, values.split(" "));
+  },
+);
+
+Given(
   "le fournisseur de service ne requiert pas le claim {string}",
   function (claim: string) {
     removeFromRequestedClaims(claim);


### PR DESCRIPTION
**Problem**
Identity Providers that are not MFA-compliant cannot handle requested ACRs related to MFA, causing authentication failures.

**Proposal**
For Identity Providers flagged as non-MFA-compliant, do not send MFA-related requested ACRs during authentication.