### PR TITLE
feat: do not send acr requests to non-compliant MFA Identity Providers

### DIFF
--- a/back/apps/core-fca-low/src/services/core-fca-controller.service.ts
+++ b/back/apps/core-fca-low/src/services/core-fca-controller.service.ts
@@ -18,7 +18,6 @@ import { OidcAcrService } from "@fc/oidc-acr";
 import { OidcClientService } from "@fc/oidc-client";
 import { OidcProviderService } from "@fc/oidc-provider";
 import { SessionService } from "@fc/session";
-import { isEmpty } from "lodash";
 
 @Injectable()
 export class CoreFcaControllerService {
@@ -95,33 +94,26 @@ export class CoreFcaControllerService {
 
     this.coreFcaService.ensureEmailIsAuthorizedForSp(spId, idpLoginHint);
 
-    const authorizeParams: { [key: string]: any } = {
-      acr_values: null,
+    const interaction = await this.oidcProvider.getInteraction(req, res);
+    const filteredAcrParams = this.oidcAcr.getFilteredAcrParamsFromInteraction(
+      interaction,
+      idpId,
+    );
+
+    const customAuthorizeParams = {
       login_hint: idpLoginHint,
       siret_hint: spSiretHint,
       sp_id: spId,
       sp_name: spName,
       remember_me: rememberMe,
-      claims: {
-        id_token: {
-          amr: null,
-          acr: null,
-        },
-      },
     };
 
-    const interaction = await this.oidcProvider.getInteraction(req, res);
-    const { acrValues, acrClaims } =
-      this.oidcAcr.getFilteredAcrParamsFromInteraction(interaction, idpId);
-
-    if (!isEmpty(acrClaims)) {
-      authorizeParams.claims.id_token.acr = acrClaims;
-    } else if (!isEmpty(acrValues)) {
-      authorizeParams.acr_values = acrValues;
-    }
-
     const { authorizationUrl, nonce, state, idpName, idpLabel } =
-      await this.oidcClient.getAuthorizationUrl(idpId, authorizeParams);
+      await this.oidcClient.getAuthorizationUrl(
+        idpId,
+        filteredAcrParams,
+        customAuthorizeParams,
+      );
 
     const sessionPayload: UserSession = {
       idpId,

--- a/back/apps/mock-identity-provider-fca-low/src/index.ejs
+++ b/back/apps/mock-identity-provider-fca-low/src/index.ejs
@@ -64,8 +64,8 @@
             <br>
             <button type="submit">Se connecter</button>
         </form>
-        <details>
-            <summary id="open-debug-info">Informations de débogage</summary>
+        <details id="open-debug-info">
+            <summary>Informations de débogage</summary>
             <pre><code><%= locals.debugInfo %></code></pre>
         </details>
     </section>

--- a/back/libs/identity-provider-adapter-mongo/src/dto/identity-provider-adapter-mongo.dto.spec.ts
+++ b/back/libs/identity-provider-adapter-mongo/src/dto/identity-provider-adapter-mongo.dto.spec.ts
@@ -34,6 +34,7 @@ describe("Identity Provider (Data Transfer Object)", () => {
     extraAcceptedEmailDomains: [],
     isBlockingForUnlistedEmailDomainsEnabled: false,
     useTheHyyyperbridge: false,
+    isMfaCompliant: true,
   };
 
   const discoveryIdpAdapterMongoMock = {

--- a/back/libs/identity-provider-adapter-mongo/src/dto/identity-provider-adapter-mongo.dto.ts
+++ b/back/libs/identity-provider-adapter-mongo/src/dto/identity-provider-adapter-mongo.dto.ts
@@ -108,6 +108,9 @@ export class MetadataIdpAdapterMongoDTO {
 
   @IsBoolean()
   readonly useTheHyyyperbridge: boolean;
+
+  @IsBoolean()
+  readonly isMfaCompliant: boolean;
 }
 
 export class DiscoveryIdpAdapterMongoDTO extends MetadataIdpAdapterMongoDTO {

--- a/back/libs/identity-provider-adapter-mongo/src/schemas/identity-provider-adapter-mongo.schema.ts
+++ b/back/libs/identity-provider-adapter-mongo/src/schemas/identity-provider-adapter-mongo.schema.ts
@@ -70,6 +70,9 @@ export class IdentityProvider extends Document {
 
   @Prop({ type: Boolean })
   useTheHyyyperbridge: boolean;
+
+  @Prop({ type: Boolean })
+  isMfaCompliant: boolean;
 }
 
 export const IdentityProviderSchema =

--- a/back/libs/oidc-client/src/services/oidc-client.service.spec.ts
+++ b/back/libs/oidc-client/src/services/oidc-client.service.spec.ts
@@ -68,6 +68,7 @@ describe("OidcClientService", () => {
     supportEmail: "support@test.com",
     name: "IDP Name",
     title: "IDP Title",
+    isMfaCompliant: true,
   };
 
   const brokerMock = {
@@ -569,9 +570,16 @@ describe("OidcClientService", () => {
       });
     });
 
-    it("should return authorization URL with nonce and state", async () => {
+    it("should return authorization URL with nonce and state and acrClaims", async () => {
       // When
-      const result = await service.getAuthorizationUrl("idp-id", {});
+      const result = await service.getAuthorizationUrl(
+        "idp-id",
+        {
+          acrClaims: { essential: true, values: ["eidas1", "eidas2"] },
+          acrValues: undefined,
+        },
+        {},
+      );
 
       // Then
       expect(result).toEqual({
@@ -583,6 +591,40 @@ describe("OidcClientService", () => {
       });
     });
 
+    it("should set the id_token acr requested claim to null if the idp is not compliant", async () => {
+      // Given
+      identityProviderMock.getById.mockResolvedValue({
+        ...idpMock,
+        isMfaCompliant: false,
+      });
+      configServiceMock.get.mockReturnValue({
+        redirectUri: "https://rp.test/callback",
+      });
+      jest.spyOn(OidcClientService, "objToUrlParams");
+
+      // When
+      await service.getAuthorizationUrl(
+        "idp-id",
+        {
+          acrClaims: { essential: true, values: ["eidas0", "eidas0-mfa"] },
+          acrValues: undefined,
+        },
+        {},
+      );
+
+      // Then
+      expect(OidcClientService.objToUrlParams).toHaveBeenCalledWith(
+        expect.objectContaining({
+          claims: {
+            id_token: {
+              acr: null,
+              amr: null,
+            },
+          },
+        }),
+      );
+    });
+
     it("should handle EntraID specific scope and remove claims", async () => {
       // Given
       identityProviderMock.getById.mockResolvedValue({
@@ -591,9 +633,14 @@ describe("OidcClientService", () => {
       });
 
       // When
-      await service.getAuthorizationUrl("idp-id", {
-        claims: { test: "value" },
-      });
+      await service.getAuthorizationUrl(
+        "idp-id",
+        {
+          acrClaims: { essential: true, values: ["foo"] },
+          acrValues: undefined,
+        },
+        {},
+      );
 
       // Then
       expect(openidClient.buildAuthorizationUrl).toHaveBeenCalled();
@@ -601,7 +648,11 @@ describe("OidcClientService", () => {
 
     it("should merge custom params with default params", async () => {
       // When
-      await service.getAuthorizationUrl("idp-id", { acr_values: "eidas3" });
+      await service.getAuthorizationUrl(
+        "idp-id",
+        { acrClaims: undefined, acrValues: "eidas3" },
+        {},
+      );
 
       // Then
       expect(openidClient.buildAuthorizationUrl).toHaveBeenCalled();

--- a/back/libs/oidc-client/src/services/oidc-client.service.ts
+++ b/back/libs/oidc-client/src/services/oidc-client.service.ts
@@ -9,7 +9,7 @@ import { ClientProxy } from "@nestjs/microservices";
 import { plainToInstance } from "class-transformer";
 import { validate } from "class-validator";
 import { Request } from "express";
-import { chain, cloneDeep, isObject, map } from "lodash";
+import { chain, cloneDeep, isEmpty, isObject, map } from "lodash";
 import {
   authorizationCodeGrant,
   AuthorizationResponseError,
@@ -35,6 +35,7 @@ import {
   HyyyperbridgeMessageType,
   HyyyperbridgeResponseDto,
 } from "@fc/hyyyperbridge";
+import { AcrClaims, AcrValues } from "@fc/oidc-acr";
 import { SessionService } from "@fc/session";
 import { OidcClientConfig, TokenDto } from "../dto";
 import {
@@ -287,6 +288,7 @@ export class OidcClientService {
 
   async getAuthorizationUrl(
     idpId: string,
+    { acrClaims, acrValues }: { acrClaims?: AcrClaims; acrValues?: AcrValues },
     customParams: { [key: string]: any },
   ): Promise<{
     authorizationUrl: string;
@@ -301,17 +303,26 @@ export class OidcClientService {
     const { redirectUri: redirect_uri } =
       this.config.get<OidcClientConfig>("OidcClient");
 
-    const defaultParams: { [key: string]: any } = {
+    const params: { [key: string]: any } = {
       scope: this.SCOPES,
       nonce,
       state,
       redirect_uri,
-    };
-
-    const params = {
-      ...defaultParams,
+      acr_values: null,
+      claims: {
+        id_token: {
+          amr: null,
+          acr: null,
+        },
+      },
       ...customParams,
     };
+
+    if (!isEmpty(acrClaims) && idp.isMfaCompliant) {
+      params.claims.id_token.acr = acrClaims;
+    } else if (!isEmpty(acrValues)) {
+      params.acr_values = acrValues;
+    }
 
     if (idp.isEntraID) {
       params.scope = "openid email profile";

--- a/back/libs/oidc/src/interfaces/identity-provider.interface.ts
+++ b/back/libs/oidc/src/interfaces/identity-provider.interface.ts
@@ -18,4 +18,5 @@ export type IdentityProviderMetadata = {
   extraAcceptedEmailDomains?: string[];
   isBlockingForUnlistedEmailDomainsEnabled: boolean;
   useTheHyyyperbridge: boolean;
+  isMfaCompliant: boolean;
 };

--- a/back/migrations/20260708100033-fix_default_value_for_isMfaCompliant.ts
+++ b/back/migrations/20260708100033-fix_default_value_for_isMfaCompliant.ts
@@ -3,7 +3,10 @@ import type { Db } from "mongodb";
 export const up = async (db: Db) => {
   await db
     .collection("provider")
-    .updateMany({}, { $set: { isMfaCompliant: false } });
+    .updateMany(
+      { isMfaCompliant: { $exists: false } },
+      { $set: { isMfaCompliant: false } },
+    );
 
   await db
     .collection("client")

--- a/docker/volumes/mongo-fca-low/scripts/db-states/_default/idp.js
+++ b/docker/volumes/mongo-fca-low/scripts/db-states/_default/idp.js
@@ -39,6 +39,7 @@ const fia = {
     extraAcceptedEmailDomains: [],
     isBlockingForUnlistedEmailDomainsEnabled: false,
     useTheHyyyperbridge: false,
+    isMfaCompliant: true,
   },
 
   // -- FIA - FIA2-LOW - Activated No support Email
@@ -81,6 +82,8 @@ const fia = {
     extraAcceptedEmailDomains: [],
     isBlockingForUnlistedEmailDomainsEnabled: false,
     useTheHyyyperbridge: false,
+    isMfaCompliant: false,
+    mfaComplianceNote: "Bientôt !",
   },
 
   // -- Fia3-low - Deactivated
@@ -123,6 +126,7 @@ const fia = {
     extraAcceptedEmailDomains: [],
     isBlockingForUnlistedEmailDomainsEnabled: false,
     useTheHyyyperbridge: false,
+    isMfaCompliant: true,
   },
 
   // -- FIA - MonComptePro - Activated
@@ -164,6 +168,7 @@ const fia = {
     extraAcceptedEmailDomains: [],
     isBlockingForUnlistedEmailDomainsEnabled: false,
     useTheHyyyperbridge: false,
+    isMfaCompliant: true,
   },
   // RIE
 
@@ -207,6 +212,7 @@ const fia = {
     extraAcceptedEmailDomains: [],
     isBlockingForUnlistedEmailDomainsEnabled: false,
     useTheHyyyperbridge: true,
+    isMfaCompliant: true,
   },
 
   // -- FIA using LemonLDAP
@@ -248,6 +254,7 @@ const fia = {
     extraAcceptedEmailDomains: [],
     isBlockingForUnlistedEmailDomainsEnabled: false,
     useTheHyyyperbridge: false,
+    isMfaCompliant: true,
   },
 };
 

--- a/quality/cypress/integration/usager/connexion-acr.feature
+++ b/quality/cypress/integration/usager/connexion-acr.feature
@@ -90,3 +90,27 @@ Fonctionnalité: Connexion Usager - ACR
     Quand je clique sur le bouton de connexion
     Et je m'authentifie
     Alors la cinématique a utilisé le niveau de sécurité "eidas1"
+
+  Scénario: le FI n'est pas MFA-compliant et retourne un claim acr demandé
+    Etant donné que je navigue sur la page fournisseur de service
+    Et que le fournisseur de service requiert le claim "acr" avec les valeurs "eidas0-mfa eidas1-mfa eidas2 eidas3"
+    Et que je clique sur le bouton ProConnect
+    Et que j'entre l'email "test@fia2.fr"
+    Et que je clique sur le bouton de connexion
+    Et que le fournisseur d'identité garantit un niveau de sécurité "eidas1-mfa"
+    Et que la page du FI n'affiche pas de requestedAcrs
+    Quand je m'authentifie
+    Alors la cinématique a utilisé le niveau de sécurité "eidas1-mfa"
+
+  Scénario: le FI n'est pas MFA-compliant et ne retourne pas de claim acr demandé
+    Etant donné que je navigue sur la page fournisseur de service
+    Et que le fournisseur de service requiert le claim "acr" avec les valeurs "eidas0-mfa eidas1-mfa eidas2 eidas3"
+    Et que je clique sur le bouton ProConnect
+    Et que j'entre l'email "test@fia2.fr"
+    Et que je clique sur le bouton de connexion
+    Et que le fournisseur d'identité garantit un niveau de sécurité "eidas1"
+    Et que la page du FI n'affiche pas de requestedAcrs
+    Quand je m'authentifie
+    Alors je suis redirigé vers la page erreur du fournisseur de service
+    Et le titre de l'erreur fournisseur de service est "access_denied"
+    Et la description de l'erreur fournisseur de service est "requested%20ACRs%20could%20not%20be%20satisfied"

--- a/quality/cypress/support/usager/steps/identity-provider-steps.ts
+++ b/quality/cypress/support/usager/steps/identity-provider-steps.ts
@@ -1,8 +1,13 @@
 import { Then, When } from "@badeball/cypress-cucumber-preprocessor";
+import { get } from "lodash";
 import {
   getIdentityProviderByDescription,
   getServiceProviderByDescription,
 } from "../../common/helpers";
+
+function getDebugInfo() {
+  return cy.get(`details#open-debug-info code`).invoke("text");
+}
 
 Then(
   /je suis redirigé vers la page login du fournisseur d'identité "([^"]*)"/,
@@ -113,6 +118,19 @@ Then(
     cy.contains(`"remember_me": "${expectedValue}"`);
   },
 );
+
+Then(/la page du FI n'affiche pas de requestedAcrs/, function () {
+  getDebugInfo().then((content) => {
+    const { oidcProviderPrompt, oidcProviderParams } = JSON.parse(content);
+    const requestedAcrs: string[] = get(oidcProviderPrompt.details, "acr.value")
+      ? [get(oidcProviderPrompt.details, "acr.value")]
+      : get(oidcProviderPrompt.details, "acr.values") ||
+        oidcProviderParams?.acr_values?.split(" ") ||
+        [];
+
+    expect(requestedAcrs).to.be.empty;
+  });
+});
 
 Then("le champ identifiant correspond à {string}", function (email: string) {
   cy.get('input[name="email"]').should("have.value", email);

--- a/quality/cypress/support/usager/steps/service-provider-steps.ts
+++ b/quality/cypress/support/usager/steps/service-provider-steps.ts
@@ -60,6 +60,13 @@ Given(
 );
 
 Given(
+  "le fournisseur de service requiert le claim {string} avec les valeurs {string}",
+  function (claim: string, values: string) {
+    setAsRequestedClaims(claim, values.split(" "));
+  },
+);
+
+Given(
   "le fournisseur de service ne requiert pas le claim {string}",
   function (claim: string) {
     removeFromRequestedClaims(claim);


### PR DESCRIPTION
**Problem**
Identity Providers that are not MFA-compliant cannot handle requested ACRs related to MFA, causing authentication failures.

**Proposal**
For Identity Providers flagged as non-MFA-compliant, do not send requested ACRs during authentication.