### PR TITLE
📝 Standardize cinematic diagram in back documentation

### DIFF
--- a/back/README.md
+++ b/back/README.md
@@ -1,37 +1,38 @@
-# FC Documentation
+# Documentation ProConnect Fédération
 
-D'un point de vue technique. La cinématique FC est divisée en deux parties principales distinctes:
+D'un point de vue technique. La cinématique ProConnect Fédération (PCF) est divisée en deux parties principales distinctes:
 
-1. Un échange openid entre le FI et FC
-2. Un échange openid entre FC et le FS
+1. Un échange openid entre le FI et PCF
+2. Un échange openid entre PCF et le FS
 
 Ces deux échanges ne sont cependant pas linéaires:
 
-1. Le FS effectue une [demande d'autorisation openid](https://openid.net/specs/openid-connect-core-1_0.html#AuthorizationEndpoint) au endpoint FC dédié. **# Début de l'échange entre le FC et le FS**
-2. FC valide que la requête est acceptable et affiche une mire où l'user doit entrer son email.
-3. Le FI est automatiquement choisi selon l'email de l'user puis FC effectue une [demande d'autorisation openid](https://openid.net/specs/openid-connect-core-1_0.html#AuthorizationEndpoint) à l'endpoint dédié de ce FI. **# Début de l'échange entre le FI et FC**
+1. Le FS effectue une [demande d'autorisation openid](https://openid.net/specs/openid-connect-core-1_0.html#AuthorizationEndpoint) au endpoint PCF dédié. **# Début de l'échange entre le FC et le FS**
+2. PCF valide que la requête est acceptable et affiche une mire où l'user doit entrer son email.
+3. Le FI est automatiquement choisi selon l'email de l'user puis FC effectue une [demande d'autorisation openid](https://openid.net/specs/openid-connect-core-1_0.html#AuthorizationEndpoint) à l'endpoint dédié de ce FI. **# Début de l'échange entre le FI et PCF**
 4. L'utilisateur s'authentifie sur le FI.
-5. Le FI donne accès aux données de l'utilisateur à FC. **# Fin de l'échange entre le FI et FC**
-6. FC donne accès aux données de l'utilisateur au FS. **# fin de l'échange entre FC et FS**
+5. Le FI donne accès aux données de l'utilisateur à PCF. **# Fin de l'échange entre le FI et PCF**
+6. PCF donne accès aux données de l'utilisateur au FS. **# fin de l'échange entre PCF et FS**
 
 ```mermaid
-graph TB
-  subgraph "ECHANGE OPENID FI / FC"
-  FiFcFlow(Demande d'autorisation openid)
-  --> Node1.1[L'utilisateur s'authentifie sur le FI]
-  --> Node1.2[Le FI donne accès aux données de l'utilisateur à FC]
-  end
+sequenceDiagram
+  actor User
+  participant FS as Service Provider
+  participant PCF as Fédération (PCF)
+  participant FI as Identity Provider
 
-  subgraph "ECHANGE OPENID FC / FS"
-  Node1[Demande d'autorisation openid]
-  --> Node2[FC valide la requête]
-  --> Node3[L'utilisateur choisit son FI]
-  Node3 --> FiFcFlow
-  Node1.2 --> LastNode[FC donne accès aux données de l'utilisateur au FS]
-  end
+  FS->>PCF: Demande d'autorisation openid
+  PCF->>PCF: Valide la requête
+  PCF->>User: Affiche mire (email)
+  User->>PCF: Saisit email
+  PCF->>FI: Demande d'autorisation openid
+  FI->>User: Demande authentification
+  User->>FI: S'authentifie
+  FI->>PCF: Donne accès aux données utilisateur
+  PCF->>FS: Donne accès aux données utilisateur
 ```
 
-L'échange entre le FI et FC est encapsulé dans l'échange entre FC et le FS. Il faut garder en tête que cette représentation reste simplifiée car il existe en vérité d'autres étapes qui s'insèrent entre ces étapes. On garde cependant une bonne vision globale de ce qu'il se passe.
+L'échange entre le FI et PCF est encapsulé dans l'échange entre PCF et le FS. Il faut garder en tête que cette représentation reste simplifiée car il existe en vérité d'autres étapes qui s'insèrent entre ces étapes. On garde cependant une bonne vision globale de ce qu'il se passe.
 
 # Dépendances
 


### PR DESCRIPTION
- Replace FC terminology with PCF for consistency
- Standardize the login flow representation using a formal OIDC sequence diagram format for better readability
- Resolve text truncation issues in previous diagram

PS: I would like to include some diagrams and documentation to support the writing of the Technical Architecture Document (DAT)."

before on github :arrow_down: 

<img width="1371" height="1320" alt="image" src="https://github.com/user-attachments/assets/35d6ddbb-830e-41cd-9314-ebaf58641d69" />

before on my local vscode :arrow_down: 
<img width="1426" height="1382" alt="image" src="https://github.com/user-attachments/assets/357dd7f2-848c-420c-ba84-ee5068c67a9d" />



after on my local vs_code :arrow_down: 
<img width="1610" height="951" alt="image" src="https://github.com/user-attachments/assets/6e0e6e1b-d94f-479a-9701-f150ad76cf69" />
