### PR TITLE
🗃️ chore: backfill app owners as collaborators

### DIFF
--- a/back/migrations/20260706134953-move_client.email_to_collaborators.ts
+++ b/back/migrations/20260706134953-move_client.email_to_collaborators.ts
@@ -1,0 +1,15 @@
+import type { Db } from "mongodb";
+
+export const up = async (db: Db) => {
+  const clients = await db.collection("client").find({}).toArray();
+  for (const client of clients) {
+    const emails = client.email?.split("\n").filter(Boolean) || [];
+    await db
+      .collection("client")
+      .updateOne({ _id: client._id }, { $set: { collaborators: emails } });
+  }
+};
+
+export const down = async (db: Db) => {
+  await db.collection("client").updateMany({}, { $set: { collaborators: [] } });
+};

--- a/pcdbapi/main.py
+++ b/pcdbapi/main.py
@@ -104,14 +104,7 @@ async def readyz():
 @app.get("/api/oidc_clients")
 @encode_response
 async def list_oidc_clients(request: Request):
-    cursor = app.collection.find(
-        {
-            "$or": [
-                {"email": request.state.email},
-                {"collaborators": request.state.email},
-            ]
-        }
-    )
+    cursor = app.collection.find({"collaborators": request.state.email})
     elts = await cursor.to_list(None)
     for elt in elts:
         format_oidc_client(elt)
@@ -125,6 +118,7 @@ async def create_oidc_client(data: OidcClient, request: Request):
     d.update(
         {
             "email": request.state.email,
+            "collaborators": [request.state.email],
             "createdAt": datetime.now(),
             "updatedAt": datetime.now(),
             "secretUpdatedAt": datetime.now(),
@@ -162,17 +156,7 @@ async def create_oidc_client(data: OidcClient, request: Request):
 @encode_response
 async def get_oidc_client(id: str, request: Request):
     oid = validate_objectid(id)
-    if not (
-        elt := await app.collection.find_one(
-            {
-                "_id": oid,
-                "$or": [
-                    {"email": request.state.email},
-                    {"collaborators": request.state.email},
-                ],
-            }
-        )
-    ):
+    if not (elt := await app.collection.find_one({"collaborators": request.state.email})):
         raise HTTPException(status_code=404)
     format_oidc_client(elt)
     return elt
@@ -190,13 +174,7 @@ async def update_oidc_client(id: str, updates: OidcClient, request: Request):
         }
     )
     result = await app.collection.update_one(
-        {
-            "_id": oid,
-            "$or": [
-                {"email": request.state.email},
-                {"collaborators": request.state.email},
-            ],
-        },
+        {"_id": oid, "collaborators": request.state.email},
         {"$set": d},
     )
     if not result.matched_count:

--- a/pcdbapi/test_api.py
+++ b/pcdbapi/test_api.py
@@ -185,7 +185,6 @@ async def test_create_oidc_client(client):
     app_data = {
         "name": "Test App",
         "redirect_uris": ["https://example.com/callback"],
-        "collaborators": ["collaborator@example.com"],
     }
     response = await api_call(
         client, "POST", "/api/oidc_clients?email=test@example.com", json_data=app_data
@@ -193,7 +192,7 @@ async def test_create_oidc_client(client):
     assert response.status_code == 200
     data = response.json()
     assert data["name"] == app_data["name"]
-    assert data["collaborators"] == app_data["collaborators"]
+    assert data["collaborators"] == ["test@example.com"]
     assert data["email"] == "test@example.com"
     assert "_id" in data
     assert len(data["client_secret"]) == 64
@@ -232,7 +231,6 @@ async def test_update_fields_whitelist(client):
     valid_data = {
         "name": "Test App",
         "redirect_uris": ["https://example.com/callback"],
-        "collaborators": ["collaborator@example.com"],
     }
     create_response = await api_call(
         client, "POST", "/api/oidc_clients?email=test@example.com", json_data=valid_data
@@ -241,7 +239,6 @@ async def test_update_fields_whitelist(client):
     created = create_response.json()
     assert created["name"] == valid_data["name"]
     assert created["redirect_uris"] == valid_data["redirect_uris"]
-    assert created["collaborators"] == valid_data["collaborators"]
     app_id = created["_id"]
 
     for k, v in {
@@ -283,7 +280,7 @@ async def test_update_fields_whitelist(client):
     valid_updates = {
         "name": "Updated App",
         "redirect_uris": ["https://updated.com/callback"],
-        "collaborators": ["collaborator-updated@example.com"],
+        "collaborators": ["test@example.com", "collaborator@example.com"],
     }
     response = await api_call(
         client,
@@ -343,7 +340,6 @@ async def test_oidc_client_lifecycle(client):
         "name": "Test App",
         "redirect_uris": ["https://example.com/callback"],
         "id_token_signed_response_alg": "ES256",
-        "collaborators": ["collaborator@example.com"],
     }
     create_response = await api_call(
         client, "POST", "/api/oidc_clients?email=test@example.com", json_data=app_data
@@ -353,7 +349,6 @@ async def test_oidc_client_lifecycle(client):
     assert created_app["name"] == app_data["name"]
     assert created_app["redirect_uris"] == app_data["redirect_uris"]
     assert created_app["email"] == "test@example.com"
-    assert created_app["collaborators"] == app_data["collaborators"]
     assert created_app["createdAt"] is not None
     assert created_app["updatedAt"] is not None
     assert created_app["updatedBy"] == "espace-partenaires"
@@ -366,6 +361,15 @@ async def test_oidc_client_lifecycle(client):
     assert list_response.status_code == 200
     apps = list_response.json()
     assert len(apps) == 0
+
+    # Adds a collaborator to the app
+    updates = {"collaborators": ["test@example.com", "collaborator@example.com"]}
+    patch_response = await api_call(
+        client, "PATCH", f"/api/oidc_clients/{app_id}?email=test@example.com", json_data=updates
+    )
+    assert patch_response.status_code == 200
+    updated_app = patch_response.json()
+    assert updated_app["collaborators"] == updates["collaborators"]
 
     # Try to list apps directly with collaborator email
     list_response = await api_call(


### PR DESCRIPTION
**Problem**
The application owner's email should be included by default in the `collaborators` field, but existing applications do not have it.

**Proposal**
Add a migration to populate the `collaborators` field with the application owner's email for existing records.