### PR TITLE
🩹 fix: handle invalid client email values gracefully

### DIFF
--- a/back/migrations/20260706134953-move_client.email_to_collaborators.ts
+++ b/back/migrations/20260706134953-move_client.email_to_collaborators.ts
@@ -3,10 +3,19 @@ import type { Db } from "mongodb";
 export const up = async (db: Db) => {
   const clients = await db.collection("client").find({}).toArray();
   for (const client of clients) {
-    const emails = client.email?.split("\n").filter(Boolean) || [];
-    await db
-      .collection("client")
-      .updateOne({ _id: client._id }, { $set: { collaborators: emails } });
+    let emails: string[] = [];
+    try {
+      emails = client.email?.split("\n").filter(Boolean) || [];
+    } catch (error) {
+      console.warn(
+        `Error processing client with _id: ${client._id} (email: ${client.email})`,
+        error,
+      );
+    } finally {
+      await db
+        .collection("client")
+        .updateOne({ _id: client._id }, { $set: { collaborators: emails } });
+    }
   }
 };
 


### PR DESCRIPTION
**Problem**
A runtime error occurred in the sandbox: `client.email?.split is not a function`, causing the operation to fail when `client.email` is not a string.

**Proposal**
Wrap the `split` call in a `try...catch` block to handle unexpected values gracefully and prevent the application from crashing.