### PR TITLE
✨ feat: enable MFA testing with +mfa email aliases

### DIFF
--- a/back/apps/core-fca-low/src/config/app.ts
+++ b/back/apps/core-fca-low/src/config/app.ts
@@ -32,7 +32,8 @@ const appConfig: AppConfig = {
   maintenanceDuration: env.string("MAINTENANCE_DURATION"),
   defaultRedirectUri: "https://www.proconnect.gouv.fr",
   supportEmail: "support+federation@proconnect.gouv.fr",
-  passeDroitEmailSuffix: "+proconnect",
+  idpRoutingForcingEmailSuffix: "+proconnect",
+  idpMfaComplianceForcingEmailSuffix: "+mfa",
 };
 
 export default appConfig;

--- a/back/apps/core-fca-low/src/dto/app-config.dto.ts
+++ b/back/apps/core-fca-low/src/dto/app-config.dto.ts
@@ -36,7 +36,10 @@ export class AppConfig extends AppGenericConfig {
   readonly supportEmail: string;
 
   @IsString()
-  readonly passeDroitEmailSuffix: string;
+  readonly idpRoutingForcingEmailSuffix: string;
+
+  @IsString()
+  readonly idpMfaComplianceForcingEmailSuffix: string;
 
   @IsBoolean()
   @IsOptional()

--- a/back/apps/core-fca-low/src/services/core-fca.service.spec.ts
+++ b/back/apps/core-fca-low/src/services/core-fca.service.spec.ts
@@ -204,7 +204,7 @@ describe("CoreFcaService", () => {
       configServiceMock.get.mockReturnValue({
         defaultIdpId: "default-idp",
         spAuthorizedFqdnsConfigs: [],
-        passeDroitEmailSuffix: "+proconnect",
+        idpRoutingForcingEmailSuffix: "+proconnect",
       });
 
       identityProviderMock.getFqdnFromEmail.mockReturnValueOnce("hogwarts.uk");
@@ -222,7 +222,7 @@ describe("CoreFcaService", () => {
       // Given
       configServiceMock.get.mockReturnValue({
         defaultIdpId: "",
-        passeDroitEmailSuffix: "+proconnect",
+        idpRoutingForcingEmailSuffix: "+proconnect",
       });
 
       identityProviderMock.getFqdnFromEmail.mockReturnValueOnce("hogwarts.uk");
@@ -239,7 +239,7 @@ describe("CoreFcaService", () => {
       // Given
       configServiceMock.get.mockReturnValueOnce({
         defaultIdpId: "default-idp",
-        passeDroitEmailSuffix: "+proconnect",
+        idpRoutingForcingEmailSuffix: "+proconnect",
       });
 
       const idpsList = [
@@ -267,7 +267,7 @@ describe("CoreFcaService", () => {
       // Given
       configServiceMock.get.mockReturnValueOnce({
         defaultIdpId: "default-idp",
-        passeDroitEmailSuffix: "+proconnect",
+        idpRoutingForcingEmailSuffix: "+proconnect",
       });
 
       const idpsList = [
@@ -295,7 +295,7 @@ describe("CoreFcaService", () => {
       // Given
       configServiceMock.get.mockReturnValueOnce({
         defaultIdpId: "default-idp",
-        passeDroitEmailSuffix: "+proconnect",
+        idpRoutingForcingEmailSuffix: "+proconnect",
       });
 
       const idpsList = [
@@ -325,7 +325,7 @@ describe("CoreFcaService", () => {
       // Given
       configServiceMock.get.mockReturnValueOnce({
         defaultIdpId: "default-idp",
-        passeDroitEmailSuffix: "+proconnect",
+        idpRoutingForcingEmailSuffix: "+proconnect",
       });
 
       const idpsList = [

--- a/back/apps/core-fca-low/src/services/core-fca.service.ts
+++ b/back/apps/core-fca-low/src/services/core-fca.service.ts
@@ -54,10 +54,11 @@ export class CoreFcaService {
     // we get the part before the last @ to check if it's a "passe-droit" email
     const emailPrefix = email.substring(0, email.lastIndexOf("@"));
 
-    const { passeDroitEmailSuffix } = this.config.get<AppConfig>("App");
+    const { idpRoutingForcingEmailSuffix } = this.config.get<AppConfig>("App");
     const idpsWithRoutingEnabled = idpsFromFqdn.filter(
       (idp) =>
-        idp.isRoutingEnabled || emailPrefix.endsWith(passeDroitEmailSuffix),
+        idp.isRoutingEnabled ||
+        emailPrefix.endsWith(idpRoutingForcingEmailSuffix),
     );
 
     // when there is no idp mapped for this fqdn

--- a/back/libs/oidc-client/src/services/oidc-client.service.spec.ts
+++ b/back/libs/oidc-client/src/services/oidc-client.service.spec.ts
@@ -557,6 +557,7 @@ describe("OidcClientService", () => {
   });
 
   describe("getAuthorizationUrl", () => {
+    const authorizationParams = { login_hint: "test@yopmail.com" };
     beforeEach(() => {
       identityProviderMock.getById.mockResolvedValue(idpMock);
       (openidClient.discovery as jest.Mock).mockResolvedValue({});
@@ -578,7 +579,7 @@ describe("OidcClientService", () => {
           acrClaims: { essential: true, values: ["eidas1", "eidas2"] },
           acrValues: undefined,
         },
-        {},
+        authorizationParams,
       );
 
       // Then
@@ -589,6 +590,42 @@ describe("OidcClientService", () => {
         idpName: idpMock.name,
         idpLabel: idpMock.title,
       });
+    });
+
+    it("should not set the id_token acr requested claim to null if the idp is not compliant but the e-mail ends with +mfa", async () => {
+      // Given
+      identityProviderMock.getById.mockResolvedValue({
+        ...idpMock,
+        isMfaCompliant: false,
+      });
+      configServiceMock.get.mockReturnValue({
+        acrValuesForMfa: ["eidas0-mfa", "eidas1-mfa", "eidas2", "eidas3"],
+        redirectUri: "https://rp.test/callback",
+        idpMfaComplianceForcingEmailSuffix: "+mfa",
+      });
+      jest.spyOn(OidcClientService, "objToUrlParams");
+
+      // When
+      await service.getAuthorizationUrl(
+        "idp-id",
+        {
+          acrClaims: { essential: true, values: ["eidas0", "eidas0-mfa"] },
+          acrValues: undefined,
+        },
+        { login_hint: "test+mfa@yopmail.com" },
+      );
+
+      // Then
+      expect(OidcClientService.objToUrlParams).toHaveBeenCalledWith(
+        expect.objectContaining({
+          claims: {
+            id_token: {
+              acr: { essential: true, values: ["eidas0", "eidas0-mfa"] },
+              amr: null,
+            },
+          },
+        }),
+      );
     });
 
     it("should set the id_token acr requested claim to null if the idp is not compliant", async () => {
@@ -625,6 +662,40 @@ describe("OidcClientService", () => {
       );
     });
 
+    it("should remove the id_token acr requested claim if the idp is not compliant and there are no other acr values requested", async () => {
+      // Given
+      identityProviderMock.getById.mockResolvedValue({
+        ...idpMock,
+        isMfaCompliant: false,
+      });
+      configServiceMock.get.mockReturnValue({
+        redirectUri: "https://rp.test/callback",
+      });
+      jest.spyOn(OidcClientService, "objToUrlParams");
+
+      // When
+      await service.getAuthorizationUrl(
+        "idp-id",
+        {
+          acrClaims: { essential: true, value: "eidas0-mfa" },
+          acrValues: undefined,
+        },
+        authorizationParams,
+      );
+
+      // Then
+      expect(OidcClientService.objToUrlParams).toHaveBeenCalledWith(
+        expect.objectContaining({
+          claims: {
+            id_token: {
+              acr: null,
+              amr: null,
+            },
+          },
+        }),
+      );
+    });
+
     it("should handle EntraID specific scope and remove claims", async () => {
       // Given
       identityProviderMock.getById.mockResolvedValue({
@@ -639,7 +710,7 @@ describe("OidcClientService", () => {
           acrClaims: { essential: true, values: ["foo"] },
           acrValues: undefined,
         },
-        {},
+        authorizationParams,
       );
 
       // Then
@@ -651,7 +722,7 @@ describe("OidcClientService", () => {
       await service.getAuthorizationUrl(
         "idp-id",
         { acrClaims: undefined, acrValues: "eidas3" },
-        {},
+        authorizationParams,
       );
 
       // Then

--- a/back/libs/oidc-client/src/services/oidc-client.service.ts
+++ b/back/libs/oidc-client/src/services/oidc-client.service.ts
@@ -29,6 +29,7 @@ import {
 } from "openid-client";
 import { lastValueFrom, timeout } from "rxjs";
 
+import { AppConfig } from "@fc/core/dto";
 import {
   HyyyperbridgeEnveloppeDto,
   HyyyperbridgeErrorDto,
@@ -317,8 +318,12 @@ export class OidcClientService {
       },
       ...customParams,
     };
+    const isIdpConsideredMfaCompliant = this.computeIsConsideredMfaCompliant(
+      idp,
+      customParams.login_hint,
+    );
 
-    if (!isEmpty(acrClaims) && idp.isMfaCompliant) {
+    if (!isEmpty(acrClaims) && isIdpConsideredMfaCompliant) {
       params.claims.id_token.acr = acrClaims;
     } else if (!isEmpty(acrValues)) {
       params.acr_values = acrValues;
@@ -502,6 +507,23 @@ export class OidcClientService {
         error,
       );
     }
+  }
+
+  private computeIsConsideredMfaCompliant(
+    idp: IdentityProviderMetadata,
+    email: string | undefined,
+  ) {
+    if (!email) {
+      return idp.isMfaCompliant;
+    }
+    const { idpMfaComplianceForcingEmailSuffix } =
+      this.config.get<AppConfig>("App");
+    // we get the part before the last @ to check if it's a "passe-droit" email
+    const emailPrefix = email.substring(0, email.lastIndexOf("@"));
+    return (
+      idp.isMfaCompliant ||
+      emailPrefix.endsWith(idpMfaComplianceForcingEmailSuffix)
+    );
   }
 
   async getEndSessionUrl({

--- a/quality/cypress/integration/usager/connexion-acr.feature
+++ b/quality/cypress/integration/usager/connexion-acr.feature
@@ -114,3 +114,11 @@ Fonctionnalité: Connexion Usager - ACR
     Alors je suis redirigé vers la page erreur du fournisseur de service
     Et le titre de l'erreur fournisseur de service est "access_denied"
     Et la description de l'erreur fournisseur de service est "requested%20ACRs%20could%20not%20be%20satisfied"
+
+  Scénario: le FI n'est pas MFA-compliant mais j'utilise un e-mail passe-droit
+    Etant donné que je navigue sur la page fournisseur de service
+    Et que le fournisseur de service requiert le claim "acr" avec les valeurs "eidas0 eidas0-mfa"
+    Et que je clique sur le bouton ProConnect
+    Et que j'entre l'email "test+mfa@fia2.fr"
+    Quand je clique sur le bouton de connexion
+    Alors la page du FI affiche requestedAcrs "eidas0 eidas0-mfa" 

--- a/quality/cypress/support/usager/steps/identity-provider-steps.ts
+++ b/quality/cypress/support/usager/steps/identity-provider-steps.ts
@@ -9,6 +9,15 @@ function getDebugInfo() {
   return cy.get(`details#open-debug-info code`).invoke("text");
 }
 
+function extractRequestedAcrs(content: string): string[] {
+  const { oidcProviderPrompt, oidcProviderParams } = JSON.parse(content);
+  return get(oidcProviderPrompt.details, "acr.value")
+    ? [get(oidcProviderPrompt.details, "acr.value")]
+    : get(oidcProviderPrompt.details, "acr.values") ||
+        oidcProviderParams?.acr_values?.split(" ") ||
+        [];
+}
+
 Then(
   /je suis redirigé vers la page login du fournisseur d'identité "([^"]*)"/,
   function (description: string) {
@@ -121,16 +130,22 @@ Then(
 
 Then(/la page du FI n'affiche pas de requestedAcrs/, function () {
   getDebugInfo().then((content) => {
-    const { oidcProviderPrompt, oidcProviderParams } = JSON.parse(content);
-    const requestedAcrs: string[] = get(oidcProviderPrompt.details, "acr.value")
-      ? [get(oidcProviderPrompt.details, "acr.value")]
-      : get(oidcProviderPrompt.details, "acr.values") ||
-        oidcProviderParams?.acr_values?.split(" ") ||
-        [];
+    const requestedAcrs: string[] = extractRequestedAcrs(content);
 
     expect(requestedAcrs).to.be.empty;
   });
 });
+
+Then(
+  /la page du FI affiche requestedAcrs "([^"]*)"/,
+  function (expectedValue: string) {
+    getDebugInfo().then((content) => {
+      const requestedAcrs: string[] = extractRequestedAcrs(content);
+
+      expect(requestedAcrs).to.deep.equal(expectedValue.split(" "));
+    });
+  },
+);
 
 Then("le champ identifiant correspond à {string}", function (email: string) {
   cy.get('input[name="email"]').should("have.value", email);


### PR DESCRIPTION
**Problem**
Identity Providers need to test MFA flows without impacting regular users.

**Proposal**
Enable MFA-related requests when users authenticate with an email address containing the `+mfa` alias, allowing MFA testing without affecting standard authentication flows.