### PR TITLE
🔒 security: remove unsafe-inline from Content Security Policy

### DIFF
--- a/back/apps/core-fca-low/src/config/app.ts
+++ b/back/apps/core-fca-low/src/config/app.ts
@@ -20,8 +20,8 @@ const appConfig: AppConfig = {
   defaultEmailRenater: env.string("DEFAULT_EMAIL_RENATER"),
   contentSecurityPolicy: {
     defaultSrc: ["'self'"],
-    styleSrc: ["'self'", "'unsafe-inline'"],
-    scriptSrc: ["'self'", "stats.data.gouv.fr", "'unsafe-inline'", "blob:"],
+    styleSrc: ["'self'"],
+    scriptSrc: ["'self'", "stats.data.gouv.fr", "blob:"],
     connectSrc: ["'self'", "stats.data.gouv.fr"],
     frameAncestors: [],
     imgSrc: ["'self'", "data:", "stats.data.gouv.fr"],


### PR DESCRIPTION
**Problem**
The current Content Security Policy includes the `unsafe-inline` directive, which weakens the application's security by allowing inline scripts.

**Proposal**
Remove the `unsafe-inline` directive from the Content Security Policy.