### PR TITLE
🔧 Remove non essential @k8s tags

### DIFF
--- a/quality/cypress/integration/exploitation/connexion-exploitation.feature
+++ b/quality/cypress/integration/exploitation/connexion-exploitation.feature
@@ -1,5 +1,4 @@
 #language: fr
-@k8s
 Fonctionnalité: Connexion Exploitation
 
   @ignoreInteg01

--- a/quality/cypress/integration/exploitation/creation-modification-fi-routing.feature
+++ b/quality/cypress/integration/exploitation/creation-modification-fi-routing.feature
@@ -2,7 +2,6 @@
 @ignoreInteg01
 Fonctionnalité: Création Modification de FI - routing
 
-  @k8s
   Scénario: Création d'un FI avec routage désactivé
     Etant donné que je navigue sur la page login d'exploitation
     Et que je me connecte à exploitation en tant que "exploitant"
@@ -15,19 +14,13 @@ Fonctionnalité: Création Modification de FI - routing
     Quand je valide le formulaire de création de FI
     Alors le message de confirmation de création du FI "bdd-idp-with-routing" est affiché
 
-  @k8s
-  Plan du Scénario: Connexion avec routage désactivé
+  Scénario: Connexion avec routage désactivé
     Etant donné que je navigue sur la page fournisseur de service
     Et je clique sur le bouton ProConnect
-    Et j'entre l'email "<email>"
+    Et j'entre l'email "user@test-routing.fr"
     Quand je clique sur le bouton de connexion
     Alors je suis redirigé vers la page login du fournisseur d'identité "moncomptepro"
 
-    Exemples:
-      | email                |
-      | user@test-routing.fr |
-
-  @k8s
   Scénario: Connexion au FI avec routage désactivé et un mail passe-droit
     Etant donné que je navigue sur la page fournisseur de service
     Et je clique sur le bouton ProConnect
@@ -35,7 +28,6 @@ Fonctionnalité: Création Modification de FI - routing
     Quand je clique sur le bouton de connexion
     Alors je suis redirigé vers la page login du fournisseur d'identité "FI bdd basé sur les URLs de fia1"
 
-  @k8s
   Scénario: Modification d'un FI avec IsRoutingEnabled à true
     Etant donné que je navigue sur la page login d'exploitation
     Et que je me connecte à exploitation en tant que "exploitant"
@@ -45,7 +37,6 @@ Fonctionnalité: Création Modification de FI - routing
     Quand je valide le formulaire de modification de FI
     Alors le message de confirmation de modification du FI "bdd-idp-with-routing" est affiché
 
-  @k8s
   Scénario: Connexion avec routage réactivé
     Etant donné que je navigue sur la page fournisseur de service
     Et je clique sur le bouton ProConnect
@@ -53,7 +44,6 @@ Fonctionnalité: Création Modification de FI - routing
     Quand je clique sur le bouton de connexion
     Alors je suis redirigé vers la page login du fournisseur d'identité "FI bdd basé sur les URLs de fia1"
 
-  @k8s
   Scénario: Connexion avec deux FI au routage activé pour le même fqdn
     Etant donné que je navigue sur la page login d'exploitation
     Et que je me connecte à exploitation en tant que "exploitant"
@@ -73,7 +63,6 @@ Fonctionnalité: Création Modification de FI - routing
     Et le fournisseur d'identité "FI de test 1" est affiché
     Et le fournisseur d'identité "FI de test 2" est affiché
 
-  @k8s
   Scénario: Connexion avec deux FI pour le même fqdn mais dont un routage est désactivé
     Etant donné que je navigue sur la page login d'exploitation
     Et que je me connecte à exploitation en tant que "exploitant"
@@ -88,7 +77,6 @@ Fonctionnalité: Création Modification de FI - routing
     Quand je clique sur le bouton de connexion
     Alors je suis redirigé vers la page login du fournisseur d'identité "FI bdd basé sur les URLs de fia1"
 
-  @k8s
   Scénario: Connexion avec deux FI pour le même fqdn mais dont un routage est désactivé et avec un mail passe-droit
     Etant donné que je navigue sur la page fournisseur de service
     Et je clique sur le bouton ProConnect
@@ -96,14 +84,14 @@ Fonctionnalité: Création Modification de FI - routing
     Quand je clique sur le bouton de connexion
     Alors je suis redirigé vers la page permettant la selection d'un fournisseur d'identité
 
-  Plan du Scénario: Utilisateur bloqué lorsque le domaine n'est pas dans la liste
+  Scénario: Utilisateur bloqué lorsque le domaine n'est pas dans la liste
     Etant donné que je navigue sur la page login d'exploitation
     Et que je me connecte à exploitation en tant que "exploitant"
     Et que je navigue vers la page gestion des fournisseurs d'identité
-    Et que je clique sur le bouton de modification du FI "<idpName>"
+    Et que je clique sur le bouton de modification du FI "fia1-low"
     Et que j'entre "true" dans le champ "isBlockingForUnlistedEmailDomainsEnabled" du formulaire de création de FI
     Et que je valide le formulaire de modification de FI
-    Alors le message de confirmation de modification du FI "<idpName>" est affiché
+    Alors le message de confirmation de modification du FI "fia1-low" est affiché
     Etant donné que je navigue sur la page fournisseur de service
     Et que je clique sur le bouton ProConnect
     Et que j'entre l'email "user@fia1.fr"
@@ -113,23 +101,14 @@ Fonctionnalité: Création Modification de FI - routing
     Alors je suis redirigé vers la page erreur technique
     Et je vois l'erreur "Y500027"
 
-    Exemples:
-      | idpName  |
-      | fia1-low |
-
-    @k8s @ignoreInteg01 @ignoreDocker
-    Exemples:
-      | idpName                  |
-      | Fournisseur d'identité 1 |
-
-  Plan du Scénario: Connexion avec un domaine email accepté mais qui ne sert pas au routage
+  Scénario: Connexion avec un domaine email accepté mais qui ne sert pas au routage
     Etant donné que je navigue sur la page login d'exploitation
     Et que je me connecte à exploitation en tant que "exploitant"
     Et que je navigue vers la page gestion des fournisseurs d'identité
-    Et que je clique sur le bouton de modification du FI "<idpName>"
+    Et que je clique sur le bouton de modification du FI "fia1-low"
     Et que j'ajoute la valeur "test-unblocked.fr" au champ "extraAcceptedEmailDomains" du formulaire de modification de FI
     Et que je valide le formulaire de modification de FI
-    Alors le message de confirmation de modification du FI "<idpName>" est affiché
+    Alors le message de confirmation de modification du FI "fia1-low" est affiché
     Etant donné que je navigue sur la page fournisseur de service
     Et que je clique sur le bouton ProConnect
     Et que j'entre l'email "user@fia1.fr"
@@ -138,37 +117,18 @@ Fonctionnalité: Création Modification de FI - routing
     Et que je m'authentifie
     Alors je suis connecté au fournisseur de service
 
-    Exemples:
-      | idpName  |
-      | fia1-low |
-
-    @k8s @ignoreInteg01 @ignoreDocker
-    Exemples:
-      | idpName                  |
-      | Fournisseur d'identité 1 |
-
-  Plan du Scénario: Nettoyage des deux étapes précédentes
+  Scénario: Nettoyage des deux étapes précédentes
     Etant donné que je navigue sur la page login d'exploitation
     Et que je me connecte à exploitation en tant que "exploitant"
     Et que je navigue vers la page gestion des fournisseurs d'identité
-    Et que je clique sur le bouton de modification du FI "<idpName>"
+    Et que je clique sur le bouton de modification du FI "fia1-low"
     Et que je retire la valeur "test-unblocked.fr" du champ "extraAcceptedEmailDomains" du formulaire de modification de FI
     Et que j'entre "false" dans le champ "isBlockingForUnlistedEmailDomainsEnabled" du formulaire de modification de FI
     Et que je valide le formulaire de modification de FI
-    Alors le message de confirmation de modification du FI "<idpName>" est affiché
+    Alors le message de confirmation de modification du FI "fia1-low" est affiché
 
-    Exemples:
-      | idpName  |
-      | fia1-low |
-
-    @k8s @ignoreInteg01 @ignoreDocker
-    Exemples:
-      | idpName                  |
-      | Fournisseur d'identité 1 |
-
-  @k8s
   Scénario: Suppression des FI commençant par "bdd-idp-"
     Etant donné que je navigue sur la page login d'exploitation
-    Et je me connecte à exploitation en tant que "exploitant"
+    Et que je me connecte à exploitation en tant que "exploitant"
     Quand je navigue vers la page gestion des fournisseurs d'identité
     Et je supprime les fournisseurs d'identité commençant par "bdd-idp-"

--- a/quality/cypress/integration/exploitation/creation-modification-fi.feature
+++ b/quality/cypress/integration/exploitation/creation-modification-fi.feature
@@ -1,5 +1,4 @@
 #language: fr
-@k8s
 Fonctionnalité: Création Modification de FI - FCA LOW
 
   Scénario: Création d'un FI sans discovery Url

--- a/quality/cypress/integration/exploitation/creation-modification-fs.feature
+++ b/quality/cypress/integration/exploitation/creation-modification-fs.feature
@@ -1,5 +1,4 @@
 #language: fr
-@k8s
 Fonctionnalité: Création Modification de FS
 
   Scénario: Création d'un FS par defaut fc-exploit

--- a/quality/cypress/integration/usager/404.feature
+++ b/quality/cypress/integration/usager/404.feature
@@ -1,5 +1,5 @@
 #language: fr
-@ignoreInteg01 @k8s
+@ignoreInteg01
 Fonctionnalité: Affichage de l'erreur 404
   Scénario: Je vois une page d'erreur 404
     Etant donné que je navigue sur la page "/api/v2/not-found"

--- a/quality/cypress/integration/usager/connexion-acr.feature
+++ b/quality/cypress/integration/usager/connexion-acr.feature
@@ -1,5 +1,5 @@
 #language: fr
-@ignoreInteg01 @k8s
+@ignoreInteg01
 Fonctionnalité: Connexion Usager - ACR
 
   Plan du Scénario: Authentification avec acr "<acr>" exigé

--- a/quality/cypress/integration/usager/connexion-claims.feature
+++ b/quality/cypress/integration/usager/connexion-claims.feature
@@ -1,6 +1,6 @@
 #language: fr
 Fonctionnalité: Connexion avec Claims
-  @k8s
+
   Scénario: demande claim amr essential
     Etant donné que je navigue sur la page fournisseur de service
     Et que le fournisseur de service requiert le claim "amr"
@@ -10,7 +10,6 @@ Fonctionnalité: Connexion avec Claims
     Quand je m'authentifie
     Alors la cinématique a renvoyé l'amr "pwd"
 
-  @k8s
   Scénario: pas de demande du claim amr
     Etant donné que je navigue sur la page fournisseur de service
     Et que le fournisseur de service ne requiert pas le claim "amr"
@@ -20,7 +19,6 @@ Fonctionnalité: Connexion avec Claims
     Quand je m'authentifie
     Alors la cinématique n'a pas renvoyé d'amr
 
-  @k8s
   Scénario: demande de claim amr mais FI qui n'en renvoie pas
     Etant donné que je navigue sur la page fournisseur de service
     Et que le fournisseur de service demande le claim "amr"
@@ -42,7 +40,6 @@ Fonctionnalité: Connexion avec Claims
     # Currently, the default amr: ["pwd"] is returned
     Alors la cinématique n'a pas renvoyé d'amr
 
-  @k8s
   Scénario: demande du claim given_name essential
     Etant donné que je navigue sur la page fournisseur de service
     Et que le fournisseur de service requiert le claim "given_name"

--- a/quality/cypress/integration/usager/connexion-email-authorise.feature
+++ b/quality/cypress/integration/usager/connexion-email-authorise.feature
@@ -1,5 +1,5 @@
 #language: fr
-@ignoreInteg01 @k8s
+@ignoreInteg01
 Fonctionnalité: Connexion Usager - Email autorisé
   Scénario: Connexion à un FS qui limite les emails avec un email authorisé
     Etant donné que je navigue sur la page fournisseur de service "avec une restriction de fqdn"

--- a/quality/cypress/integration/usager/connexion-fi-non-signé.feature
+++ b/quality/cypress/integration/usager/connexion-fi-non-signé.feature
@@ -1,5 +1,4 @@
 #language: fr
-@k8s
 Fonctionnalité: Connexion Usager avec FI (user info non signé)
   Scénario: Connexion OK
     Etant donné que je navigue sur la page fournisseur de service "par défaut"

--- a/quality/cypress/integration/usager/connexion-identite-personnalisee.feature
+++ b/quality/cypress/integration/usager/connexion-identite-personnalisee.feature
@@ -1,5 +1,4 @@
 #language: fr
-@k8s
 Fonctionnalité: Connexion Usager personnalisé
   @ignoreInteg01
   Scénario: Connexion d'un usager - claim phone_number non renvoyé si mauvais format

--- a/quality/cypress/integration/usager/connexion-idp_hint.feature
+++ b/quality/cypress/integration/usager/connexion-idp_hint.feature
@@ -1,5 +1,4 @@
 #language: fr
-@k8s
 Fonctionnalité: Connexion Usager - idp_hint
 
   @ignoreInteg01

--- a/quality/cypress/integration/usager/connexion-local-storage.feature
+++ b/quality/cypress/integration/usager/connexion-local-storage.feature
@@ -1,5 +1,4 @@
 #language: fr
-@k8s
 Fonctionnalité: Connexion avec LocalStorage
 
   @ignoreInteg01

--- a/quality/cypress/integration/usager/connexion-login-hint.feature
+++ b/quality/cypress/integration/usager/connexion-login-hint.feature
@@ -1,5 +1,5 @@
 #language: fr
-@ignoreInteg01 @k8s
+@ignoreInteg01
 Fonctionnalité: Connexion Usager - login_hint
 
   Scénario: ProConnect fournit le login_hint au FI

--- a/quality/cypress/integration/usager/connexion-pkce.feature
+++ b/quality/cypress/integration/usager/connexion-pkce.feature
@@ -1,5 +1,4 @@
 #language: fr
-@k8s
 Fonctionnalité: Connexion Usager - PKCE
 
   Scénario: Authentification nominale avec PKCE

--- a/quality/cypress/integration/usager/connexion-prompt.feature
+++ b/quality/cypress/integration/usager/connexion-prompt.feature
@@ -1,5 +1,5 @@
 #language: fr
-@k8s
+
 Fonctionnalité: Connexion avec manipulation du paramêtre prompt
   Scénario: Prompt=none pour un utilisateur déjà connecté
     Etant donné que je navigue sur la page fournisseur de service "premier FS"

--- a/quality/cypress/integration/usager/connexion-redirect-uri.feature
+++ b/quality/cypress/integration/usager/connexion-redirect-uri.feature
@@ -1,5 +1,5 @@
 #language: fr
-@ignoreInteg01 @k8s
+@ignoreInteg01
 Fonctionnalité: Erreur redirect uri invalide
 
   Plan du Scénario: Erreur <error> redirect_uri=<redirectUri>

--- a/quality/cypress/integration/usager/connexion-scope.feature
+++ b/quality/cypress/integration/usager/connexion-scope.feature
@@ -1,5 +1,5 @@
 #language: fr
-@k8s
+
 Fonctionnalité: Connexion Usager - Scope
 
   Plan du Scénario: Connexion d'un usager - scope <scopeType>

--- a/quality/cypress/integration/usager/connexion-secteur-prive.feature
+++ b/quality/cypress/integration/usager/connexion-secteur-prive.feature
@@ -17,8 +17,3 @@ Fonctionnalité: Connexion Partenaires
     Exemples:
       | spName         | idpName      |
       | FSA - FSA1-LOW | moncomptepro |
-
-    @k8s @ignoreInteg01 @ignoreDocker
-    Exemples:
-      | spName                   | idpName             |
-      | Fournisseur de service 1 | ProConnect Identité |

--- a/quality/cypress/integration/usager/connexion-session-absente.feature
+++ b/quality/cypress/integration/usager/connexion-session-absente.feature
@@ -1,5 +1,5 @@
 #language: fr
-@k8s
+
 Fonctionnalité: Connexion Usager - session absente
   Scénario: Connexion OK - session inconnue lors de l'appel authorize
     Etant donné que je force un sessionId inexistant dans le cookie de session AgentConnect

--- a/quality/cypress/integration/usager/connexion-session.feature
+++ b/quality/cypress/integration/usager/connexion-session.feature
@@ -1,5 +1,5 @@
 #language: fr
-@ignoreInteg01 @k8s
+@ignoreInteg01
 Fonctionnalité: Connexion Usager - session fca-low (avec SSO)
 
   Scénario: Session avec SSO activé - Nouvelle session créée lors de l'appel à authorize (1ère connexion)

--- a/quality/cypress/integration/usager/connexion-siret-hint.feature
+++ b/quality/cypress/integration/usager/connexion-siret-hint.feature
@@ -1,5 +1,5 @@
 #language: fr
-@ignoreInteg01 @k8s
+@ignoreInteg01
 Fonctionnalité: Connexion Usager - siret_hint
   Scénario: Le FS fournit le siret_hint à ProConnect
     Etant donné que je navigue sur la page fournisseur de service

--- a/quality/cypress/integration/usager/connexion-sso.feature
+++ b/quality/cypress/integration/usager/connexion-sso.feature
@@ -1,5 +1,5 @@
 #language: fr
-@k8s
+
 Fonctionnalité: Connexion Usager - SSO
 
   Plan du Scénario: Deux FS avec accès au même FI

--- a/quality/cypress/integration/usager/connexion-sub.feature
+++ b/quality/cypress/integration/usager/connexion-sub.feature
@@ -1,5 +1,5 @@
 #language: fr
-@k8s
+
 Fonctionnalité: Connexion Usager - Sub
 
   Scénario: retourne le même sub à deux FS différents quand j'utilise la même identité

--- a/quality/cypress/integration/usager/connexion-usager-multi-fi.feature
+++ b/quality/cypress/integration/usager/connexion-usager-multi-fi.feature
@@ -32,13 +32,6 @@ Fonctionnalité: Connexion Usager dont le fqdn est lié à plusieurs fi
       | Identity Provider 1 - HS256 | par défaut | tous les scopes |
       | Identity Provider 2 - ES256 | second FI  | tous les scopes |
 
-    @k8s @ignoreDocker @ignoreInteg01
-    Exemples:
-      | idpLabel                 | idpName    | scope           |
-      | Fournisseur d'identité 1 | par défaut | tous les scopes |
-      | Fournisseur d'identité 2 | second FI  | tous les scopes |
-
-  @k8s
   Scénario: Fournisseur d'identité autre
     Etant donné que je navigue sur la page fournisseur de service
     Et que je clique sur le bouton ProConnect
@@ -66,12 +59,7 @@ Fonctionnalité: Connexion Usager dont le fqdn est lié à plusieurs fi
       | idpLabel                                   |
       | Identity Provider 1 - eIDAS faible - ES256 |
 
-    @k8s @ignoreDocker @ignoreInteg01
-    Exemples:
-      | idpLabel                 |
-      | Fournisseur d'identité 1 |
-
-  @ignoreInteg01 @k8s
+  @ignoreInteg01
   Scénario: FI par défaut est accepté par tous les fqdnToIdp
     Etant donné que je navigue sur la page fournisseur de service
     Et que je clique sur le bouton ProConnect
@@ -80,7 +68,7 @@ Fonctionnalité: Connexion Usager dont le fqdn est lié à plusieurs fi
     Et je suis redirigé vers la page permettant la selection d'un fournisseur d'identité
     Alors le fournisseur d'identité "Autre (via ProConnect Identité)" est affiché
 
-  @ignoreInteg01 @k8s
+  @ignoreInteg01
   Scénario: FI par défaut n'est pas accepté par l'un des fqdnToIdp
     Etant donné que je navigue sur la page fournisseur de service "par défaut"
     Et que je clique sur le bouton ProConnect
@@ -89,7 +77,7 @@ Fonctionnalité: Connexion Usager dont le fqdn est lié à plusieurs fi
     Et je suis redirigé vers la page permettant la selection d'un fournisseur d'identité
     Alors le fournisseur d'identité "Autre (via ProConnect Identité)" n'est pas affiché
 
-  @ignoreInteg01 @k8s
+  @ignoreInteg01
   Scénario: Le FI "Autre (via ProConnect Identité)" est toujours positionné en dernier
     Etant donné que je navigue sur la page fournisseur de service
     Et que je clique sur le bouton ProConnect
@@ -118,8 +106,3 @@ Fonctionnalité: Connexion Usager dont le fqdn est lié à plusieurs fi
     Exemples:
       | idpLabel                                   |
       | Identity Provider 1 - eIDAS faible - ES256 |
-
-    @k8s @ignoreDocker @ignoreInteg01
-    Exemples:
-      | idpLabel                 |
-      | Fournisseur d'identité 1 |

--- a/quality/cypress/integration/usager/connexion-usager.feature
+++ b/quality/cypress/integration/usager/connexion-usager.feature
@@ -10,7 +10,6 @@ Fonctionnalité: Connexion Usager - Redirection vers FI avec email
     Et je m'authentifie
     Alors je suis connecté au fournisseur de service
 
-    @k8s
     Exemples:
       | email                  | idpDescription |
       | iknowthisemail@fia1.fr | par défaut     |
@@ -35,7 +34,7 @@ Fonctionnalité: Connexion Usager - Redirection vers FI avec email
       | albus.dumbledore@example.com        | moncomptepro   |
       | hades@developpement-durable.gouv.fr | cerbere        |
 
-  @ignoreInteg01 @k8s
+  @ignoreInteg01
   Scénario: Connexion d'un usager - fqdn non reconnu et non service public
     Etant donné que je navigue sur la page fournisseur de service
     Et que je clique sur le bouton ProConnect
@@ -47,7 +46,7 @@ Fonctionnalité: Connexion Usager - Redirection vers FI avec email
     Alors je suis redirigé vers la page erreur technique
     Et le code d'erreur est "Y500015"
 
-  @ignoreInteg01 @k8s
+  @ignoreInteg01
   Scénario: Connexion d'un usager - fqdn non reconnu et non service public mais FS acceptant le privé
     Etant donné que je navigue sur la page fournisseur de service "acceptant le privé"
     Et que je clique sur le bouton ProConnect
@@ -57,7 +56,7 @@ Fonctionnalité: Connexion Usager - Redirection vers FI avec email
     Et je m'authentifie
     Alors je suis redirigé vers la page fournisseur de service "acceptant le privé"
 
-  @ignoreInteg01 @k8s
+  @ignoreInteg01
   Scénario: Connexion d'un usager - retour en arrière après redirection vers FI
     Etant donné que je navigue sur la page fournisseur de service "par défaut"
     Et que je clique sur le bouton ProConnect
@@ -66,7 +65,6 @@ Fonctionnalité: Connexion Usager - Redirection vers FI avec email
     Quand je reviens en arrière
     Alors je suis redirigé vers la page interaction
 
-  @k8s
   Scénario: Connexion d'un usager - mauvaise orthographe d'une adresse e-mail avec suggestion
     Etant donné que je navigue sur la page fournisseur de service "par défaut"
     Et que je clique sur le bouton ProConnect
@@ -76,7 +74,6 @@ Fonctionnalité: Connexion Usager - Redirection vers FI avec email
     Et que je clique sur la suggestion d'email corrigé
     Alors le champ email correspond à "test@gendarmerie.interieur.gouv.fr"
 
-  @k8s
   Scénario: Connexion d'un usager - mauvaise orthographe d'une adresse e-mail sans suggestion
     Etant donné que je navigue sur la page fournisseur de service "par défaut"
     Et que je clique sur le bouton ProConnect
@@ -85,7 +82,6 @@ Fonctionnalité: Connexion Usager - Redirection vers FI avec email
     Et que je suis redirigé vers la page interaction
     Alors je vois l'erreur "Adresse e-mail invalide."
 
-  @k8s
   Scénario: Connexion d'un usager - mauvaise orthographe d'une adresse email sans option "Mémoriser mon adresse sur cet appareil"
     Etant donné que je navigue sur la page fournisseur de service "par défaut"
     Et que je clique sur le bouton ProConnect

--- a/quality/cypress/integration/usager/deconnexion-usager.feature
+++ b/quality/cypress/integration/usager/deconnexion-usager.feature
@@ -1,5 +1,5 @@
 #language: fr
-@ignoreInteg01 @k8s
+@ignoreInteg01
 Fonctionnalité: Déconnexion Usager
   Scénario: Déconnexion d'un usager avec log métier
     Etant donné que je navigue sur la page fournisseur de service

--- a/quality/cypress/integration/usager/reconciliation-pci.feature
+++ b/quality/cypress/integration/usager/reconciliation-pci.feature
@@ -1,7 +1,7 @@
 #language: fr
 @ignoreInteg01
 Fonctionnalité: Réconciliation d'identité d'un usager PCI dont le domaine est préempté
-  Plan du Scénario: Chapitre 1: création d'un compte ProConnect Identité (ex MonComptePro)
+  Scénario: Chapitre 1: création d'un compte ProConnect Identité (ex MonComptePro)
     Etant donné que je navigue sur la page fournisseur de service
     Et que je clique sur le bouton ProConnect
     Et que j'entre l'email "albus@example.com"
@@ -17,10 +17,10 @@ Fonctionnalité: Réconciliation d'identité d'un usager PCI dont le domaine est
     Etant donné que je navigue sur la page login d'exploitation
     Et que je me connecte à exploitation en tant que "exploitant"
     Et que je navigue vers la page gestion des fournisseurs d'identité
-    Et que je clique sur le bouton de modification du FI "<idpName>"
+    Et que je clique sur le bouton de modification du FI "fia2-low"
     Et que j'ajoute la valeur "example.com" au champ "fqdns" du formulaire de modification de FI
     Quand je valide le formulaire de modification de FI
-    Alors le message de confirmation de modification du FI "<idpName>" est affiché
+    Alors le message de confirmation de modification du FI "fia2-low" est affiché
 
     # Chapitre 3: connexion avec le nouveau FI, mais sub identique
     Etant donné que je navigue sur la page fournisseur de service
@@ -33,34 +33,15 @@ Fonctionnalité: Réconciliation d'identité d'un usager PCI dont le domaine est
     Alors je suis connecté au fournisseur de service
     Et le sub transmis au fournisseur de service est identique au sub mémorisé
 
-    Exemples:
-      | idpName  |
-      | fia2-low |
-
-    @k8s @ignoreInteg01 @ignoreDocker
-    Exemples:
-      | idpName                  |
-      | Fournisseur d'identité 2 |
-
-  Plan du Scénario: Epilogue - nettoyage
+  Scénario: Epilogue - nettoyage
     Etant donné que je navigue sur la page login d'exploitation
     Et que je me connecte à exploitation en tant que "exploitant"
     Et que je navigue vers la page gestion des fournisseurs d'identité
-    Et que je clique sur le bouton de modification du FI "<idpName>"
+    Et que je clique sur le bouton de modification du FI "fia2-low"
     Et que je retire la valeur "example.com" du champ "fqdns" du formulaire de modification de FI
     Quand je valide le formulaire de modification de FI
-    Alors le message de confirmation de modification du FI "<idpName>" est affiché
+    Alors le message de confirmation de modification du FI "fia2-low" est affiché
 
-    Exemples:
-      | idpName  |
-      | fia2-low |
-
-    @k8s @ignoreInteg01 @ignoreDocker
-    Exemples:
-      | idpName                  |
-      | Fournisseur d'identité 2 |
-
-  @k8s
   Scénario: La réconciliation ignore la casse de l'adresse email
     Etant donné que je navigue sur la page fournisseur de service
     Et que je clique sur le bouton ProConnect


### PR DESCRIPTION
We only start minimal tests in k8s-proconnect CI, so there's no need to keep these tags on all test scenarios. 

This cleanup removes unnecessary "k8s" tags from quality test files to reduce clutter and maintain only the essential markers for CI orchestration.