### PR TITLE
🐛 pcdbapi: get client by id ignores requested id

### DIFF
--- a/pcdbapi/main.py
+++ b/pcdbapi/main.py
@@ -156,7 +156,9 @@ async def create_oidc_client(data: OidcClient, request: Request):
 @encode_response
 async def get_oidc_client(id: str, request: Request):
     oid = validate_objectid(id)
-    if not (elt := await app.collection.find_one({"collaborators": request.state.email})):
+    if not (
+        elt := await app.collection.find_one({"_id": oid, "collaborators": request.state.email})
+    ):
         raise HTTPException(status_code=404)
     format_oidc_client(elt)
     return elt

--- a/pcdbapi/test_api.py
+++ b/pcdbapi/test_api.py
@@ -334,6 +334,33 @@ async def test_update_fields_type_validation(client, field, invalid_value):
 
 
 @pytest.mark.asyncio
+async def test_get_oidc_client_returns_requested_id(client):
+    # Create two apps for the same user
+    first_response = await api_call(
+        client, "POST", "/api/oidc_clients?email=test@example.com", json_data={"name": "First App"}
+    )
+    assert first_response.status_code == 200
+
+    second_response = await api_call(
+        client,
+        "POST",
+        "/api/oidc_clients?email=test@example.com",
+        json_data={"name": "Second App"},
+    )
+    assert second_response.status_code == 200
+    second_id = second_response.json()["_id"]
+
+    # Fetching the second app by id must not return the first app's data
+    get_response = await api_call(
+        client, "GET", f"/api/oidc_clients/{second_id}?email=test@example.com"
+    )
+    assert get_response.status_code == 200
+    retrieved = get_response.json()
+    assert retrieved["_id"] == second_id
+    assert retrieved["name"] == "Second App"
+
+
+@pytest.mark.asyncio
 async def test_oidc_client_lifecycle(client):
     # Create an app
     app_data = {


### PR DESCRIPTION
**Problem**

GET /api/oidc_clients/{id} dropped the _id filter in dcb796b0e, returning the first client where the user is a collaborator instead of the requested one — users with several apps see another app's data, including its decrypted client_secret.

**Proposal**

Restore the _id constraint in the find_one filter and add a regression test creating two apps and fetching the second by id.