### PR TITLE
🦺 pcdbapi: reject empty collaborators list

### DIFF
--- a/pcdbapi/main.py
+++ b/pcdbapi/main.py
@@ -8,7 +8,7 @@ from typing import List, Literal
 from bson import ObjectId
 from fastapi import FastAPI, HTTPException, Request
 from motor.motor_asyncio import AsyncIOMotorClient
-from pydantic import BaseModel, ConfigDict, constr
+from pydantic import BaseModel, ConfigDict, conlist, constr
 
 from crypt import decrypt_symetric, encrypt_symetric
 from middleware import encode_response, verify_signature
@@ -36,7 +36,9 @@ class OidcClient(BaseModel):
     post_logout_redirect_uris: List[str] | None = None
     id_token_signed_response_alg: Literal["RS256", "ES256", "HS256"] | None = None
     userinfo_signed_response_alg: Literal["RS256", "ES256", "HS256"] | None = None
-    collaborators: List[str] | None = None
+    # Never empty: collaborators is the only access path, an empty list
+    # would lock everyone out of the app permanently
+    collaborators: conlist(str, min_length=1) | None = None
     active: bool | None = None
 
 

--- a/pcdbapi/test_api.py
+++ b/pcdbapi/test_api.py
@@ -165,6 +165,29 @@ async def test_invalid_timestamp(client):
 
 
 @pytest.mark.asyncio
+async def test_patch_empty_collaborators_is_rejected(client):
+    create_response = await api_call(
+        client, "POST", "/api/oidc_clients?email=test@example.com", json_data={"name": "Test App"}
+    )
+    assert create_response.status_code == 200
+    app_id = create_response.json()["_id"]
+
+    # Emptying collaborators would permanently lock everyone out
+    response = await api_call(
+        client,
+        "PATCH",
+        f"/api/oidc_clients/{app_id}?email=test@example.com",
+        json_data={"collaborators": []},
+    )
+    assert response.status_code == 422
+
+    # Owner still has access
+    list_response = await api_call(client, "GET", "/api/oidc_clients?email=test@example.com")
+    assert list_response.status_code == 200
+    assert len(list_response.json()) == 1
+
+
+@pytest.mark.asyncio
 async def test_list_oidc_clients(client):
     response = await api_call(client, "GET", "/api/oidc_clients?email=test@example.com")
     assert response.status_code == 200


### PR DESCRIPTION
**Problem**

PATCH accepts collaborators: [] even though collaborators is the only access path since dcb796b0e. Emptying it permanently locks everyone out of the app, with no recovery short of manual DB surgery.

**Proposal**

Require at least one entry in collaborators through the pydantic model, answering 422 on an empty list.