### PR TITLE
🥅 pcdbapi: reject non-numeric timestamp with 401

### DIFF
--- a/pcdbapi/middleware.py
+++ b/pcdbapi/middleware.py
@@ -41,7 +41,10 @@ async def verify_signature(request: Request, call_next, config: Dict):
         return JSONResponse(status_code=422, content={"detail": "Invalid email"})
 
     # Verify timestamp freshness
-    ts = int(timestamp)
+    try:
+        ts = int(timestamp)
+    except ValueError:
+        return JSONResponse(status_code=401, content={"detail": "Invalid timestamp"})
     now = int(time.time())
     if abs(now - ts) > config["max_timestamp_diff"]:
         return JSONResponse(status_code=401, content={"detail": "Timestamp expired"})

--- a/pcdbapi/test_api.py
+++ b/pcdbapi/test_api.py
@@ -163,6 +163,16 @@ async def test_invalid_timestamp(client):
     assert response.status_code == 401
     assert response.json()["detail"] == "Timestamp expired"
 
+    # Test non-numeric timestamp
+    response = await api_call(
+        client,
+        "GET",
+        "/api/oidc_clients?email=test@example.com",
+        override_timestamp="not-a-number",
+    )
+    assert response.status_code == 401
+    assert response.json()["detail"] == "Invalid timestamp"
+
 
 @pytest.mark.asyncio
 async def test_list_oidc_clients(client):


### PR DESCRIPTION
**Problem**

int(timestamp) in the signature middleware raises an unhandled ValueError when X-Timestamp is not numeric, turning a malformed unauthenticated request into a 500 and a traceback in the logs.

**Proposal**

Catch the ValueError and answer 401 "Invalid timestamp", like the other authentication failures.