### PR TITLE
⚡ perf: use exact string matching for MongoDB queries

### DIFF
--- a/admin/cypress/integration/federation-user/federation-user-list.spec.js
+++ b/admin/cypress/integration/federation-user/federation-user-list.spec.js
@@ -48,6 +48,15 @@ describe("Federation user list", () => {
       cy.get("table").should("contain.text", "user-multiple-idp@fia1.fr");
     });
 
+    it("I cannot search a federation user with a string that is neither a sub nor an email", () => {
+      cy.visit(`/federation-user`);
+
+      cy.get("#searchInput").clear().type("not-a-sub-or-email");
+      cy.contains("Rechercher").click();
+
+      cy.get("table tbody tr").should("have.length", 2);
+    });
+
     it("I cannot activate a federation user if totp not filled", () => {
       cy.visit(`/federation-user`);
 

--- a/admin/src/federation-user/federation-user.controller.ts
+++ b/admin/src/federation-user/federation-user.controller.ts
@@ -12,8 +12,8 @@ import {
 } from "@nestjs/common";
 import { Roles } from "../authentication/decorator/roles.decorator";
 import { FormErrorsInterceptor } from "../form/interceptor/form-errors.interceptor";
-import { type PaginationSortDirectionType } from "../pagination";
 import { UserRole } from "../user/roles.enum";
+import { VALID_EMAIL_REGEX_STRING } from "../utils/regex/valid-email-regex";
 import { FederationUserService } from "./federation-user.service";
 
 @Controller("federation-user")
@@ -29,12 +29,12 @@ export class FederationUserController {
   async list(
     @Req() req,
     @Query("search") querySearch?: string,
-    @Query("sortField") querySortField?: string,
-    @Query("sortDirection")
-    querySortDirection: PaginationSortDirectionType = "asc",
     @Query("page") queryPage: string = "1",
     @Query("limit") queryLimit: string = "10",
   ) {
+    const UUID_REGEX_STRING =
+      "[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}";
+    const searchPattern = `^(${UUID_REGEX_STRING}|${VALID_EMAIL_REGEX_STRING})$`;
     const page = parseInt(queryPage, 10);
     const limit = parseInt(queryLimit, 10);
     const csrfToken = req.csrfToken();
@@ -43,15 +43,22 @@ export class FederationUserController {
         page,
         limit,
         search: querySearch
-          ? { fields: ["sub", "idpIdentityKeys.idpMail"], value: querySearch }
+          ? {
+              fields: [
+                {
+                  name: "sub",
+                  searchKind: "exactMatch",
+                  pattern: new RegExp(UUID_REGEX_STRING),
+                },
+                {
+                  name: "idpIdentityKeys.idpMail",
+                  searchKind: "exactMatch",
+                  pattern: new RegExp(VALID_EMAIL_REGEX_STRING),
+                },
+              ],
+              value: querySearch,
+            }
           : undefined,
-        sort: querySortField
-          ? { field: querySortField, direction: querySortDirection }
-          : undefined,
-        defaultSort: {
-          field: "createdAt",
-          direction: "desc",
-        },
       });
 
     return {
@@ -60,9 +67,8 @@ export class FederationUserController {
       csrfToken,
       page,
       limit,
-      querySortField,
-      querySortDirection,
       querySearch,
+      searchPattern,
     };
   }
 

--- a/admin/src/identity-provider/identity-provider.controller.ts
+++ b/admin/src/identity-provider/identity-provider.controller.ts
@@ -50,15 +50,21 @@ export class IdentityProviderController {
         page,
         limit,
         search: querySearch
-          ? { fields: ["name", "title", "clientID"], value: querySearch }
+          ? {
+              fields: [
+                { name: "name", searchKind: "contains" },
+                { name: "title", searchKind: "contains" },
+                { name: "clientID", searchKind: "contains" },
+              ],
+              value: querySearch,
+            }
           : undefined,
         sort: querySortField
           ? { field: querySortField, direction: querySortDirection }
-          : undefined,
-        defaultSort: {
-          field: "createdAt",
-          direction: "desc",
-        },
+          : {
+              field: "createdAt",
+              direction: "desc",
+            },
       });
 
     return {

--- a/admin/src/pagination/interface/pagination-options.interface.ts
+++ b/admin/src/pagination/interface/pagination-options.interface.ts
@@ -1,9 +1,15 @@
 export interface PaginationOptions {
   page: number;
   limit: number;
-  search?: { fields: string[]; value: string };
+  search?: { fields: PaginationFieldSearchType[]; value: string };
   sort?: { field: string; direction: PaginationSortDirectionType };
-  defaultSort: { field: string; direction: PaginationSortDirectionType };
 }
+
+export type PaginationFieldSearchType = {
+  name: string;
+} & (
+  | { searchKind: "exactMatch"; pattern: RegExp }
+  | { searchKind: "contains" }
+);
 
 export type PaginationSortDirectionType = "asc" | "desc";

--- a/admin/src/pagination/pagination.service.ts
+++ b/admin/src/pagination/pagination.service.ts
@@ -1,4 +1,5 @@
-import { PaginationOptions } from "./interface";
+import { escapeRegExp } from "lodash";
+import { PaginationFieldSearchType, PaginationOptions } from "./interface";
 
 export class PaginationService {
   buildPaginationParams(options: PaginationOptions) {
@@ -6,16 +7,24 @@ export class PaginationService {
     const skip = (page - 1) * limit;
     const take = limit;
 
-    let where;
+    let where = {};
     if (options.search) {
-      where = { $or: [] };
+      const orSearch = [];
       for (const field of options.search.fields) {
-        where.$or.push({
-          [field]: new RegExp(
-            options.search.value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&"),
-            "i",
-          ),
-        });
+        const searchCriteria = this.computeSearchCriteria(
+          field,
+          options.search.value,
+        );
+        if (!!searchCriteria) {
+          orSearch.push({
+            ...searchCriteria,
+          });
+        }
+      }
+      if (orSearch.length === 1) {
+        where = orSearch[0];
+      } else if (orSearch.length > 1) {
+        where = { $or: orSearch };
       }
     }
 
@@ -25,15 +34,22 @@ export class PaginationService {
       order = {
         [field]: direction === "asc" ? "ASC" : "DESC",
       };
-    } else {
-      order = {
-        [options.defaultSort.field]:
-          options.defaultSort.direction === "asc" ? "ASC" : "DESC",
-      };
     }
 
     const params = { skip, take, where, order };
 
     return params;
+  }
+
+  computeSearchCriteria(field: PaginationFieldSearchType, value: string) {
+    switch (field.searchKind) {
+      case "contains":
+        return { [field.name]: new RegExp(escapeRegExp(value), "i") };
+      case "exactMatch":
+        if (!field.pattern.test(value)) {
+          return null;
+        }
+        return { [field.name]: value };
+    }
   }
 }

--- a/admin/src/service-provider/service-provider.controller.spec.ts
+++ b/admin/src/service-provider/service-provider.controller.spec.ts
@@ -855,9 +855,14 @@ describe("ServiceProviderController", () => {
       expect(serviceProviderServiceMock.paginate).toHaveBeenCalledWith({
         page: 0,
         limit: 10,
-        search: { fields: ["name", "key"], value: search },
+        search: {
+          fields: [
+            { name: "name", searchKind: "contains" },
+            { name: "key", searchKind: "contains" },
+          ],
+          value: search,
+        },
         sort: { field: sortField, direction: sortDirection },
-        defaultSort: { field: "createdAt", direction: "desc" },
       });
     });
   });

--- a/admin/src/service-provider/service-provider.controller.ts
+++ b/admin/src/service-provider/service-provider.controller.ts
@@ -76,15 +76,20 @@ export class ServiceProviderController {
       page,
       limit,
       search: querySearch
-        ? { fields: ["name", "key"], value: querySearch }
+        ? {
+            fields: [
+              { name: "name", searchKind: "contains" },
+              { name: "key", searchKind: "contains" },
+            ],
+            value: querySearch,
+          }
         : undefined,
       sort: querySortField
         ? { field: querySortField, direction: querySortDirection }
-        : undefined,
-      defaultSort: {
-        field: "createdAt",
-        direction: "desc",
-      },
+        : {
+            field: "createdAt",
+            direction: "desc",
+          },
     });
     return {
       serviceProviders: items,

--- a/admin/src/utils/regex/valid-email-regex.ts
+++ b/admin/src/utils/regex/valid-email-regex.ts
@@ -5,8 +5,8 @@
  * \u0026 => &
  * \u002f => /
  */
-const VALID_EMAIL_REGEX_STRING =
-  "([a-zA-Z0-9_\\.-]+)@([\\da-z\\.-]+)\\.([a-z\\.]{2,10})";
+export const VALID_EMAIL_REGEX_STRING =
+  "([a-zA-Z0-9_\\.\\-]+)@([\\da-z\\.\\-]+)\\.([a-z\\.]{2,10})";
 
 const VALID_EMAILS_REGEX_STRING = `${VALID_EMAIL_REGEX_STRING}(\n${VALID_EMAIL_REGEX_STRING})*`;
 export const VALID_EMAILS_REGEX = new RegExp(`^${VALID_EMAILS_REGEX_STRING}$`);

--- a/admin/views/federation-user/list.ejs
+++ b/admin/views/federation-user/list.ejs
@@ -16,7 +16,7 @@
             <%- include('partials/choose-items-number-to-show.ejs') -%>
           </form>
           <%- include('partials/global-errors-handler.ejs') -%>
-          <%- include('partials/search', {userSearch: querySearch, placeholder: "Rechercher par sub ou e-mail" }); %>
+          <%- include('partials/search', {userSearch: querySearch, placeholder: "Rechercher par sub ou e-mail entier", pattern: searchPattern }); %>
 
           <table class="table table-hover table-light shadow-sm">
             <thead class="thead-light">

--- a/admin/views/partials/search.ejs
+++ b/admin/views/partials/search.ejs
@@ -9,6 +9,7 @@
     <div class="mb-3 mx-sm-2">
       <label for="search" class="visually-hidden">Search</label>
       <input
+        pattern="<%= locals.pattern || '*' %>"
         type="text"
         value="<%= userSearch %>"
         name="search"


### PR DESCRIPTION
**Problem**
MongoDB queries were using regular expressions instead of exact string matching, preventing indexes from being used efficiently.

**Proposal**
Replace regular expression queries with exact string matching to enable index usage and improve query performance.