### PR TITLE
🚸 quiet the session-not-found error page

### DIFF
--- a/back/apps/core-fca-low/src/views/error.ejs
+++ b/back/apps/core-fca-low/src/views/error.ejs
@@ -76,7 +76,7 @@
               <% } %>
             </div>
 
-            <% if (locals.exceptionDisplay.displayContact || locals.interactionErrorUrl) { %>
+            <% if (locals.exceptionDisplay.displayContact || locals.interactionErrorUrl || locals.exceptionDisplay.mainAction === 'goBack') { %>
               <section>
                 <div class="fr-mt-4w">
                   <% if (locals.exceptionDisplay.displayContact) { %>
@@ -91,6 +91,11 @@
                     <% if (locals.exceptionDisplay.displayContact) { %>
                       <a class="fr-btn<%= locals.exceptionDisplay.mainAction === 'contact' ? '' : ' fr-btn--tertiary' %> fr-icon-flag-line fr-btn--icon-right fr-mr-1w" href="<%= locals.exceptionDisplay.contactHref %>">
                         Signaler l'erreur
+                      </a>
+                    <% } %>
+                    <% if (!locals.interactionErrorUrl && locals.exceptionDisplay.mainAction === 'goBack') { %>
+                      <a class="fr-btn" href="javascript:history.back()" data-testid="go-back-button">
+                        Revenir à l'étape précédente
                       </a>
                     <% } %>
                     <% if (locals.interactionErrorUrl) { %>

--- a/back/libs/oidc-provider/src/filters/oidc-provider-session-not-found-exception.filter.spec.ts
+++ b/back/libs/oidc-provider/src/filters/oidc-provider-session-not-found-exception.filter.spec.ts
@@ -95,5 +95,21 @@ describe("OidcProviderSessionNotFoundExceptionFilter", () => {
       // Then
       expect(resMock.render).toHaveBeenCalledOnce();
     });
+
+    it("should render the error page without error details and with a go back action", () => {
+      // When
+      filter.catch(exceptionMock, hostMock as unknown as ArgumentsHost);
+
+      // Then
+      expect(resMock.render).toHaveBeenCalledWith("error", {
+        error: {},
+        exceptionDisplay: {
+          description: expect.stringContaining(
+            "Nous n’arrivons pas à vous connecter",
+          ),
+          mainAction: "goBack",
+        },
+      });
+    });
   });
 });

--- a/back/libs/oidc-provider/src/filters/oidc-provider-session-not-found-exception.filter.ts
+++ b/back/libs/oidc-provider/src/filters/oidc-provider-session-not-found-exception.filter.ts
@@ -22,15 +22,12 @@ export class OidcProviderSessionNotFoundExceptionFilter extends BaseExceptionFil
     const statusCode = 400;
 
     const errorPageParams: ErrorPageParams = {
-      error: {
-        code,
-        id,
-        message,
-      },
+      error: {},
       exceptionDisplay: {
         description: `Nous n’arrivons pas à vous connecter à votre service en ligne pour l’instant.
 
 <b>Fermez cette page et essayez de vous reconnecter</b> depuis le site sur lequel vous étiez.`,
+        mainAction: "goBack",
       },
     };
 

--- a/quality/cypress/integration/usager/connexion-fi.feature
+++ b/quality/cypress/integration/usager/connexion-fi.feature
@@ -64,4 +64,5 @@ Fonctionnalité: Connexion à un FI
     Quand je reviens en arrière
     Quand je reviens en arrière
     Alors je suis redirigé vers la page erreur technique
-    Et le code d'erreur est "oidc-provider-error:session-not-found"
+    Et je ne vois pas "code erreur"
+    Et je vois "Revenir à l'étape précédente"

--- a/quality/cypress/integration/usager/connexion-session-absente.feature
+++ b/quality/cypress/integration/usager/connexion-session-absente.feature
@@ -28,7 +28,8 @@ Fonctionnalité: Connexion Usager - session absente
     Quand je supprime les cookies AgentConnect
     Et je rafraîchis la page
     Alors je suis redirigé vers la page erreur technique
-    Et le code d'erreur est "oidc-provider-error:session-not-found"
+    Et je ne vois pas "code erreur"
+    Et je vois "Revenir à l'étape précédente"
 
   Scénario: Erreur lors de la connexion - session absente au retour du FI
     Etant donné que je navigue sur la page fournisseur de service
@@ -40,7 +41,8 @@ Fonctionnalité: Connexion Usager - session absente
     Et que je supprime les cookies AgentConnect
     Quand je m'authentifie
     Alors je suis redirigé vers la page erreur technique
-    Et le code d'erreur est "oidc-provider-error:session-not-found"
+    Et je ne vois pas "code erreur"
+    Et je vois "Revenir à l'étape précédente"
 
   Scénario: Erreur lors de la connexion - session absente sur la page multi FI
     Etant donné que je navigue sur la page fournisseur de service
@@ -50,4 +52,5 @@ Fonctionnalité: Connexion Usager - session absente
     Quand je supprime les cookies AgentConnect
     Et je rafraîchis la page
     Alors je suis redirigé vers la page erreur technique
-    Et le code d'erreur est "oidc-provider-error:session-not-found"
+    Et je ne vois pas "code erreur"
+    Et je vois "Revenir à l'étape précédente"

--- a/quality/cypress/integration/usager/connexion-usager-multi-fi.feature
+++ b/quality/cypress/integration/usager/connexion-usager-multi-fi.feature
@@ -100,7 +100,8 @@ Fonctionnalité: Connexion Usager dont le fqdn est lié à plusieurs fi
     Alors je suis redirigé vers la page permettant la selection d'un fournisseur d'identité
     Quand je reviens en arrière
     Alors je suis redirigé vers la page erreur technique
-    Et le code d'erreur est "oidc-provider-error:session-not-found"
+    Et je ne vois pas "code erreur"
+    Et je vois "Revenir à l'étape précédente"
 
     @ignoreInteg01
     Exemples:

--- a/quality/cypress/support/common/steps/visibility-steps.ts
+++ b/quality/cypress/support/common/steps/visibility-steps.ts
@@ -1,0 +1,9 @@
+import { Then } from "@badeball/cypress-cucumber-preprocessor";
+
+Then("je vois {string}", function (text: string) {
+  cy.contains(text).should("be.visible");
+});
+
+Then("je ne vois pas {string}", function (text: string) {
+  cy.contains(text).should("not.exist");
+});


### PR DESCRIPTION
**Problem**

The oidc-provider-error:session-not-found page shows an error code, id and message for a failure we cannot help with (the interaction id is simply gone from redis), generating noise and user reports.

**Proposal**

Render only the friendly description with a "Revenir à l'étape précédente" (history.back) button; keep the technical details in the logs. Add generic "je vois" / "je ne vois pas" cypress steps and use them in the affected scenarios.


--- 

<img width="1458" height="687" alt="image" src="https://github.com/user-attachments/assets/9604fef3-a4fe-4061-820a-2f651eda4bb2" />
