### PR TITLE
🎨 style: apply project Prettier formatting

### DIFF
--- a/admin/src/pagination/interface/pagination-options.interface.ts
+++ b/admin/src/pagination/interface/pagination-options.interface.ts
@@ -8,8 +8,7 @@ export interface PaginationOptions {
 export type PaginationFieldSearchType = {
   name: string;
 } & (
-  | { searchKind: "exactMatch"; pattern: RegExp }
-  | { searchKind: "contains" }
+  { searchKind: "exactMatch"; pattern: RegExp } | { searchKind: "contains" }
 );
 
 export type PaginationSortDirectionType = "asc" | "desc";


### PR DESCRIPTION
**Problem**
The developer's local linter configuration differs from the project's Prettier settings, resulting in inconsistent formatting.

**Proposal**
Run `npm run format` to apply the project's standard Prettier formatting across the modified files.