### PR TITLE
🩺 Add livez/readyz healthcheck to admin

### DIFF
--- a/admin/src/app.module.ts
+++ b/admin/src/app.module.ts
@@ -26,6 +26,7 @@ import { ConfigurationController } from "./configuration/configuration.controlle
 import { ConfigurationModule } from "./configuration/configuration.module";
 import { FederationUserController } from "./federation-user/federation-user.controller";
 import { FederationUserModule } from "./federation-user/federation-user.module";
+import { HealthController } from "./health.controller";
 import { IdentityProviderController } from "./identity-provider/identity-provider.controller";
 import { IdentityProviderModule } from "./identity-provider/identity-provider.module";
 import { LoggerModule } from "./logger/logger.module";
@@ -59,7 +60,7 @@ import { ServiceProviderModule } from "./service-provider/service-provider.modul
     }),
   ],
   providers: [LocalsInterceptor, TotpService],
-  controllers: [AppController],
+  controllers: [AppController, HealthController],
 })
 export class AppModule implements NestModule {
   configure(consumer: MiddlewareConsumer): MiddlewareConsumer | void {

--- a/admin/src/health.controller.spec.ts
+++ b/admin/src/health.controller.spec.ts
@@ -1,0 +1,145 @@
+import { HttpStatus } from "@nestjs/common";
+import { Test, TestingModule } from "@nestjs/testing";
+import { getDataSourceToken } from "@nestjs/typeorm";
+import { HealthController } from "./health.controller";
+
+describe("HealthController", () => {
+  let controller: HealthController;
+
+  const databaseMock = {
+    isInitialized: true,
+    query: jest.fn(),
+  };
+  const mongoRepositoryMock = {
+    count: jest.fn(),
+  };
+  const mongoDatabaseMock = {
+    isInitialized: true,
+    manager: {
+      getMongoRepository: jest.fn(() => mongoRepositoryMock),
+    },
+  };
+
+  const resMock = {
+    status: jest.fn().mockReturnThis(),
+  };
+
+  beforeEach(async () => {
+    jest.resetAllMocks();
+    databaseMock.isInitialized = true;
+    databaseMock.query.mockResolvedValue([{ "?column?": 1 }]);
+    mongoDatabaseMock.isInitialized = true;
+    mongoDatabaseMock.manager.getMongoRepository.mockReturnValue(
+      mongoRepositoryMock,
+    );
+    mongoRepositoryMock.count.mockResolvedValue(0);
+
+    const app: TestingModule = await Test.createTestingModule({
+      controllers: [HealthController],
+      providers: [
+        { provide: getDataSourceToken(), useValue: databaseMock },
+        {
+          provide: getDataSourceToken("fc-mongo"),
+          useValue: mongoDatabaseMock,
+        },
+      ],
+    }).compile();
+
+    controller = app.get<HealthController>(HealthController);
+  });
+
+  describe("livez()", () => {
+    it("should return 'ok'", () => {
+      expect(controller.livez()).toBe("ok");
+    });
+  });
+
+  describe("readyz()", () => {
+    it("should return 'ok' when both connections are initialized and reachable", async () => {
+      const result = await controller.readyz(resMock as any);
+      expect(databaseMock.query).toHaveBeenCalledWith("SELECT 1");
+      expect(mongoRepositoryMock.count).toHaveBeenCalled();
+      expect(resMock.status).not.toHaveBeenCalled();
+      expect(result).toBe("ok");
+    });
+
+    // [label, setup, verboseMessage]
+    const failureScenarios: [string, () => void, string][] = [
+      [
+        "database not initialized",
+        () => {
+          databaseMock.isInitialized = false;
+        },
+        "[-]postgresDatabase failed (PostgreSQL default database connection not initialized)\n[+]mongoDatabase ok\nreadyz check failed",
+      ],
+      [
+        "database query rejects with Error",
+        () => {
+          databaseMock.query.mockRejectedValue(
+            new Error("connection terminated"),
+          );
+        },
+        "[-]postgresDatabase failed (connection terminated)\n[+]mongoDatabase ok\nreadyz check failed",
+      ],
+      [
+        "database query rejects with non-Error value",
+        () => {
+          databaseMock.query.mockRejectedValue("connection reset");
+        },
+        '[-]postgresDatabase failed ("connection reset")\n[+]mongoDatabase ok\nreadyz check failed',
+      ],
+      [
+        "fc-mongo not initialized",
+        () => {
+          mongoDatabaseMock.isInitialized = false;
+        },
+        "[+]postgresDatabase ok\n[-]mongoDatabase failed (MongoDB fc-mongo connection not initialized)\nreadyz check failed",
+      ],
+      [
+        "fc-mongo query rejects",
+        () => {
+          mongoRepositoryMock.count.mockRejectedValue(
+            new Error("topology was destroyed"),
+          );
+        },
+        "[+]postgresDatabase ok\n[-]mongoDatabase failed (topology was destroyed)\nreadyz check failed",
+      ],
+    ];
+
+    describe("plain mode", () => {
+      it.each(failureScenarios)(
+        "should return 'error' when %s",
+        async (_, setup) => {
+          setup();
+          const result = await controller.readyz(resMock as any);
+          expect(resMock.status).toHaveBeenCalledWith(
+            HttpStatus.SERVICE_UNAVAILABLE,
+          );
+          expect(result).toBe("error");
+        },
+      );
+    });
+
+    describe("verbose", () => {
+      it("should return verbose output when both connections are initialized and reachable", async () => {
+        const result = await controller.readyz(resMock as any, "");
+        expect(resMock.status).not.toHaveBeenCalled();
+        expect(result).toBe(
+          "[+]postgresDatabase ok\n[+]mongoDatabase ok\nreadyz check passed",
+        );
+      });
+
+      it.each(failureScenarios)(
+        "should return verbose output when %s",
+        async (_, setup, expectedMessage) => {
+          setup();
+          const result = await controller.readyz(resMock as any, "");
+          expect(resMock.status).toHaveBeenCalledWith(
+            HttpStatus.SERVICE_UNAVAILABLE,
+          );
+          expect(result).toBe(expectedMessage);
+        },
+      );
+    });
+  });
+});

--- a/admin/src/health.controller.ts
+++ b/admin/src/health.controller.ts
@@ -1,0 +1,83 @@
+import {
+  Controller,
+  Get,
+  Header,
+  HttpStatus,
+  Query,
+  Res,
+} from "@nestjs/common";
+import { InjectDataSource } from "@nestjs/typeorm";
+import { type Response } from "express";
+import { DataSource } from "typeorm";
+import { Configuration } from "./configuration/entity/configuration.mongodb.entity";
+
+@Controller()
+export class HealthController {
+  constructor(
+    @InjectDataSource() private readonly postgresDatabase: DataSource,
+    @InjectDataSource("fc-mongo") private readonly mongoDatabase: DataSource,
+  ) {}
+
+  checks = {
+    postgresDatabase: async () => {
+      if (!this.postgresDatabase.isInitialized) {
+        throw new Error(
+          "PostgreSQL default database connection not initialized",
+        );
+      }
+      await this.postgresDatabase.query("SELECT 1");
+    },
+    mongoDatabase: async () => {
+      if (!this.mongoDatabase.isInitialized) {
+        throw new Error("MongoDB fc-mongo connection not initialized");
+      }
+      await this.mongoDatabase.manager
+        .getMongoRepository(Configuration)
+        .count();
+    },
+  };
+
+  @Get("/livez")
+  livez(): string {
+    return "ok";
+  }
+
+  @Get("/readyz")
+  @Header("Content-Type", "text/plain")
+  async readyz(
+    @Res({ passthrough: true }) res: Response,
+    @Query("verbose") verbose?: string,
+  ): Promise<string> {
+    const results = await Promise.all(
+      Object.entries(this.checks).map(async ([name, check]) => {
+        try {
+          await check();
+          return { name, status: "success" as const };
+        } catch (error) {
+          const message =
+            error instanceof Error ? error.message : JSON.stringify(error);
+          return { name, status: "error" as const, message };
+        }
+      }),
+    );
+    const allHealthy = results.every((r) => r.status === "success");
+
+    if (!allHealthy) {
+      res.status(HttpStatus.SERVICE_UNAVAILABLE);
+    }
+
+    if (verbose !== undefined) {
+      const lines = results.map((r) =>
+        r.status === "success"
+          ? `[+]${r.name} ok`
+          : `[-]${r.name} failed (${r.message})`,
+      );
+      return [
+        ...lines,
+        `readyz check ${allHealthy ? "passed" : "failed"}`,
+      ].join("\n");
+    }
+
+    return allHealthy ? "ok" : "error";
+  }
+}

--- a/docker/compose/fca-low/admin.yml
+++ b/docker/compose/fca-low/admin.yml
@@ -24,6 +24,12 @@ services:
       - "../../volumes/.home:/home"
       - "../../volumes/ssl:/etc/ssl/docker_host:ro"
       - "../../volumes/log:/var/log/app"
+    healthcheck:
+      test: ["CMD", "wget", "-qO", "/dev/null", "http://localhost:3000/readyz"]
+      interval: 10s
+      timeout: 5s
+      retries: 3
+      start_period: 60s
     tmpfs:
       - /var/www/app/dist:mode=777
       - /var/www/app/.parcel-cache:mode=777


### PR DESCRIPTION
**Problem**

admin has no /livez or /readyz endpoints, unlike core-fca-low and csmr-rie, so Kubernetes has no way to probe its readiness before routing traffic to it.

**Proposal**

Add a HealthController modeled on the existing core-fca-low/csmr-rie pattern: /livez always returns ok, /readyz checks both TypeORM connections (postgresDatabase and mongoDatabase) and returns 503 with a verbose per-check breakdown when either is not initialized.