### PR TITLE
🚚 Extract logout confirm script to external file

### DIFF
--- a/back/apps/core-fca-low/src/public/js/end-session-confirm.js
+++ b/back/apps/core-fca-low/src/public/js/end-session-confirm.js
@@ -1,0 +1,7 @@
+var form = document.forms[0];
+var input = document.createElement("input");
+input.type = "hidden";
+input.name = "logout";
+input.value = "yes";
+form.appendChild(input);
+form.submit();

--- a/back/libs/oidc-provider/src/services/oidc-provider-config.service.ts
+++ b/back/libs/oidc-provider/src/services/oidc-provider-config.service.ts
@@ -249,15 +249,7 @@ export class OidcProviderConfigService {
         </head>
         <body>
           ${form}
-          <script>
-            var form = document.forms[0];
-            var input = document.createElement('input');
-            input.type = 'hidden';
-            input.name = 'logout';
-            input.value = 'yes';
-            form.appendChild(input);
-            form.submit();
-          </script>
+          <script src="/js/end-session-confirm.js"></script>
         </body>
       </html>`;
     };


### PR DESCRIPTION
**Problem**

The logout confirmation page rendered by OidcProviderConfigService inlines a <script> block directly in the HTML template. The app's CSP scriptSrc policy has no 'unsafe-inline' allowance, and every other page-level script in core-fca-low already lives under public/js/ and is loaded via <script src=...>.

**Proposal**

Move the auto-submit logic into public/js/end-session-confirm.js, served as a static asset, and reference it with a src attribute instead of inlining it.