### PR TITLE
🐛 Guard email-to-collaborators migration against clobbering seeded collaborators

### DIFF
--- a/back/migrations/20260706134953-move_client.email_to_collaborators.ts
+++ b/back/migrations/20260706134953-move_client.email_to_collaborators.ts
@@ -1,12 +1,19 @@
 import type { Db } from "mongodb";
 
 export const up = async (db: Db) => {
-  const clients = await db.collection("client").find({}).toArray();
+  const clients = await db
+    .collection("client")
+    .find({ email: { $exists: true }, collaborators: { $exists: false } })
+    .toArray();
   for (const client of clients) {
     const emails = client.email?.split("\n").filter(Boolean) || [];
+    if (emails.length === 0) continue;
     await db
       .collection("client")
-      .updateOne({ _id: client._id }, { $set: { collaborators: emails } });
+      .updateOne(
+        { _id: client._id },
+        { $addToSet: { collaborators: { $each: emails } } },
+      );
   }
 };
 


### PR DESCRIPTION


**Problem**
`20260706134953-move_client.email_to_collaborators.ts` runs `find({})` over every client and unconditionally `$set`s `collaborators`, defaulting to `[]` when `client.email` is absent. On environments where `collaborators` is seeded another way (k8s-proconnect fixtures, #1312 collaborators feature), the migration wipes it back to `[]` the first time it fires — same root cause as the #1344/dcb796b0e incident, resurfacing via fresh-cluster CI on helm-fca-low.

**Proposal**
Scope the migration to `find({ email: { $exists: true } })` and merge into `collaborators` with `$addToSet` instead of overwriting, making it a no-op for documents without `client.email`. `down` is left as-is (blind `$set: { collaborators: [] }`) since a precise inverse isn't feasible with `$addToSet`.