### PR TITLE
💬 fix: clarify verification email wording

### DIFF
--- a/back/apps/core-fca-low/src/controllers/email-verification.controller.spec.ts
+++ b/back/apps/core-fca-low/src/controllers/email-verification.controller.spec.ts
@@ -64,9 +64,6 @@ describe("EmailVerificationController", () => {
           .mockReturnValue({ spIdentity: { email: "user@example.com" } }),
       } as unknown as ISessionService<AfterGetOidcCallbackSessionDto>;
 
-      configServiceMock.get.mockReturnValue({
-        fromEmail: "noreply@example.com",
-      });
       csrfServiceMock.getOrCreate.mockReturnValue("csrf-token");
       emailVerificationMock.sendEmailVerificationIfNeeded.mockResolvedValue({
         hasSentVerificationEmail: true,
@@ -90,7 +87,7 @@ describe("EmailVerificationController", () => {
       ).toHaveBeenCalledWith(undefined);
       expect(res.render).toHaveBeenCalledWith("verify-email", {
         csrfToken: "csrf-token",
-        fromEmail: "noreply@example.com",
+        email: "user@example.com",
         hasSentVerificationEmail: true,
         countdownEndDate: "2024-01-01T01:00:00.000Z",
         errorMessage: undefined,
@@ -108,9 +105,6 @@ describe("EmailVerificationController", () => {
           .mockReturnValue({ spIdentity: { email: "user@example.com" } }),
       } as unknown as ISessionService<AfterGetOidcCallbackSessionDto>;
 
-      configServiceMock.get.mockReturnValue({
-        fromEmail: "noreply@example.com",
-      });
       csrfServiceMock.getOrCreate.mockReturnValue("csrf-token");
       emailVerificationMock.sendEmailVerificationIfNeeded.mockResolvedValue({
         hasSentVerificationEmail: false,
@@ -129,7 +123,7 @@ describe("EmailVerificationController", () => {
         "verify-email",
         expect.objectContaining({
           csrfToken: "csrf-token",
-          fromEmail: "noreply@example.com",
+          email: "user@example.com",
           hasSentVerificationEmail: false,
           countdownEndDate: "2024-01-01T00:00:00.000Z",
           errorMessage: "Email invalide",
@@ -146,9 +140,6 @@ describe("EmailVerificationController", () => {
           .mockReturnValue({ spIdentity: { email: "user@example.com" } }),
       } as unknown as ISessionService<AfterGetOidcCallbackSessionDto>;
 
-      configServiceMock.get.mockReturnValue({
-        fromEmail: "noreply@example.com",
-      });
       csrfServiceMock.getOrCreate.mockReturnValue("csrf-token");
       emailVerificationMock.sendEmailVerificationIfNeeded.mockRejectedValue(
         new Error("boom"),

--- a/back/apps/core-fca-low/src/controllers/email-verification.controller.ts
+++ b/back/apps/core-fca-low/src/controllers/email-verification.controller.ts
@@ -3,7 +3,6 @@ import { ConfigService } from "@fc/config";
 import { CsrfService, CsrfTokenGuard } from "@fc/csrf";
 import { EmailVerificationService } from "@fc/email-verification";
 import { LoggerService } from "@fc/logger";
-import { MailerConfig } from "@fc/mailer/dto";
 import { type ISessionService } from "@fc/session";
 import {
   Body,
@@ -44,7 +43,6 @@ export class EmailVerificationController {
       spIdentity: { email },
     } = userSession.get();
     const { error } = req.query;
-    const { fromEmail } = this.config.get<MailerConfig>("Mailer");
     const csrfToken = this.csrfService.getOrCreate();
 
     let emailVerificationResult;
@@ -76,7 +74,7 @@ export class EmailVerificationController {
 
     return res.render("verify-email", {
       csrfToken,
-      fromEmail,
+      email,
       hasSentVerificationEmail:
         emailVerificationResult?.hasSentVerificationEmail,
       countdownEndDate: countdownEndDate.toISOString(),

--- a/back/apps/core-fca-low/src/views/verify-email.ejs
+++ b/back/apps/core-fca-low/src/views/verify-email.ejs
@@ -25,7 +25,7 @@
                 <% if (hasSentVerificationEmail) { %>
                 <div class="fr-alert fr-alert--info fr-mb-4w">
                   <h2 class="fr-h6">Code de vérification envoyé</h2>
-                  <p>Vérifiez les emails envoyés par <b><%= fromEmail; %></b>.</p>
+                  <p>Vérifiez les emails envoyés à <b><%= email; %></b>.</p>
                 </div>
                 <% } %>
                 <% if (errorMessage) { %>


### PR DESCRIPTION
**Problem**
The wording around the verification email caused confusion about whether it referred to the sender's email address or the recipient's email address.

**Proposal**
Update the wording to clearly distinguish the role of the sender and recipient email addresses.