### PR TITLE
🐛 Improve unexpected error handling

### DIFF
--- a/back/apps/core-fca-low/src/views/verify-email.ejs
+++ b/back/apps/core-fca-low/src/views/verify-email.ejs
@@ -25,17 +25,17 @@
                 <% if (hasSentVerificationEmail) { %>
                 <div class="fr-alert fr-alert--info fr-mb-4w">
                   <h2 class="fr-h6">Code de vérification envoyé</h2>
-                  <p>Vérifiez les emails envoyés à <b><%= email; %></b>.</p>
+                  <p>Vérifiez les emails envoyés à <b><%= locals.email %></b>.</p>
                 </div>
                 <% } %>
                 <% if (errorMessage) { %>
                   <div class="fr-alert fr-alert--error fr-mb-4w">
                     <h2 class="fr-h6">Erreur</h2>
-                    <p><%= errorMessage %></p>
+                    <p><%= locals.errorMessage %></p>
                   </div>
                 <% } %>
 
-                <input type="hidden" name="csrfToken" value="<%= locals.csrfToken; %>" />
+                <input type="hidden" name="csrfToken" value="<%= locals.csrfToken %>" />
                 <div class="fr-input-group fr-mb-2w">
                   <label class="fr-label" for="verify_email_token">
                     Code de confirmation
@@ -63,7 +63,7 @@
               >
                 <button
                   disabled
-                  data-countdown-end-date="<%= countdownEndDate %>"
+                  data-countdown-end-date="<%= locals.countdownEndDate %>"
                   class="fr-btn fr-btn--tertiary fr-mb-2w disabled-with-countdown btn--fullwidth"
                 >
                   Recevoir un nouveau code


### PR DESCRIPTION
**Problem**

In the email verification service, all errors are caught in the controller and the email verification page is rendered to display the error.

However, if an unexpected error occurs, `countdownEndDate` may be undefined, causing the template rendering to crash. This results in an incomprehensible error message for users and makes debugging more difficult.

**Proposal**

Use the EJS `locals` variable, which is more resilient when optional values are missing, to avoid rendering errors.

Proper error handling will be implemented in a future PR.