### PR TITLE
remove unused baseurl email template parameter

### DIFF
--- a/back/libs/email-verification/src/email-verification.service.ts
+++ b/back/libs/email-verification/src/email-verification.service.ts
@@ -1,4 +1,3 @@
-import { AppConfig } from "@fc/app";
 import { ConfigService } from "@fc/config";
 import { CsrfService } from "@fc/csrf";
 import { LoggerService } from "@fc/logger";
@@ -89,7 +88,6 @@ export class EmailVerificationService {
   }
 
   async sendVerificationMail(email: string, token: string) {
-    const { fqdn } = this.config.get<AppConfig>("App");
     this.logger.info({
       code: "send-verification-mail",
       email,
@@ -100,7 +98,6 @@ export class EmailVerificationService {
         to: email,
         subject: "Vérification de votre adresse email",
         htmlContent: VerifyEmail({
-          baseurl: fqdn || "",
           token,
         }).toString(),
       });

--- a/back/package.json
+++ b/back/package.json
@@ -41,7 +41,7 @@
     "@proconnect-gouv/proconnect.annuaire_entreprises": "^2.0.2",
     "@proconnect-gouv/proconnect.api_entreprise": "^2.2.0",
     "@proconnect-gouv/proconnect.core": "^1.0.0",
-    "@proconnect-gouv/proconnect.email": "^1.0.2",
+    "@proconnect-gouv/proconnect.email": "^1.1.0",
     "@proconnect-gouv/proconnect.identite": "^9.1.3",
     "@proconnect-gouv/proconnect.insee": "^2.0.0",
     "@proconnect-gouv/proconnect.registre_national_entreprises": "^4.0.0",

--- a/back/tsconfig.json
+++ b/back/tsconfig.json
@@ -2,6 +2,7 @@
   "compilerOptions": {
     "module": "NodeNext",
     "moduleResolution": "NodeNext",
+    "jsxImportSource": "@kitajs/html",
     "target": "es2023",
     "esModuleInterop": true,
     "outDir": "./dist",

--- a/back/yarn.lock
+++ b/back/yarn.lock
@@ -1368,10 +1368,10 @@
     nanoid "^5.1.5"
     tld-extract "^2.1.0"
 
-"@proconnect-gouv/proconnect.email@^1.0.2":
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/@proconnect-gouv/proconnect.email/-/proconnect.email-1.0.2.tgz#15e100dbe6a090cde4d271dbdf3f90352abed68c"
-  integrity sha512-GNPxQ229pu4Oq/VgGWFxqeAcOYo82ccZ8fq+Q/fvXKubNA1dUOtJyg9zlbo9SFVaFPMWMxRGIdyNVIzKeNAEuA==
+"@proconnect-gouv/proconnect.email@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@proconnect-gouv/proconnect.email/-/proconnect.email-1.1.0.tgz#9e9a82cc791f272c2d8a26d36b4c5315362ef364"
+  integrity sha512-T4p2fveNSPySf8gkNVruqya86+rRFimGBUKpSR+pNDQV5YbPaAo+7H3lzfoGus7ewNLUw/MvRqzwGWlovNg4QQ==
   dependencies:
     "@kitajs/html" "^4.2.9"
 


### PR DESCRIPTION
**Problem**
The `baseurl` parameter was required for every email template, even though it was no longer used.

**Proposal**
Remove the unused `baseurl` parameter from the email template API.