### PR TITLE
✨ feat: add configurable email subject prefix

### DIFF
--- a/back/_doc/env-vars.md
+++ b/back/_doc/env-vars.md
@@ -39,6 +39,7 @@
 | HyyyperbridgeBroker_URLS                        | json          |
 | Logger_THRESHOLD                                | string        |
 | Mailer_BREVO_API_KEY                            | string        |
+| Mailer_EMAIL_SUBJECT_PREFIX                     | string        |
 | Mailer_FROM_EMAIL                               | string        |
 | Mailer_FROM_NAME                                | string        |
 | Mailer_SMTP_URL                                 | string        |

--- a/back/apps/core-fca-low/src/config/mailer.ts
+++ b/back/apps/core-fca-low/src/config/mailer.ts
@@ -10,6 +10,7 @@ const mailerConfig: MailerConfig = {
   fromName: env.string("FROM_NAME"),
   smtpUrl: env.string("SMTP_URL", true),
   brevoApiKey: env.string("BREVO_API_KEY", true),
+  emailSubjectPrefix: env.string("EMAIL_SUBJECT_PREFIX", true),
 };
 
 export default mailerConfig;

--- a/back/libs/mailer/src/adapters/brevo.adapter.ts
+++ b/back/libs/mailer/src/adapters/brevo.adapter.ts
@@ -17,6 +17,7 @@ export class BrevoAdapter implements MailerService {
   }
 
   async sendMail(dto: MailerSendOptions) {
+    const emailSubjectPrefix = this.config.emailSubjectPrefix ?? "";
     const response = await this.fetchFn("https://api.brevo.com/v3/smtp/email", {
       method: "POST",
       headers: {
@@ -27,7 +28,7 @@ export class BrevoAdapter implements MailerService {
       body: JSON.stringify({
         sender: { name: this.config.fromName, email: this.config.fromEmail },
         to: [{ email: dto.to }],
-        subject: dto.subject,
+        subject: `${emailSubjectPrefix}${dto.subject}`,
         htmlContent: dto.htmlContent,
       }),
     });

--- a/back/libs/mailer/src/adapters/smtp.adapter.ts
+++ b/back/libs/mailer/src/adapters/smtp.adapter.ts
@@ -11,10 +11,11 @@ export class SmtpAdapter implements MailerService {
   ) {}
 
   async sendMail(dto: MailerSendOptions) {
+    const emailSubjectPrefix = this.config.emailSubjectPrefix ?? "";
     const result = await this.transporter.sendMail({
       from: { name: this.config.fromName, address: this.config.fromEmail },
       to: dto.to,
-      subject: dto.subject,
+      subject: `${emailSubjectPrefix}${dto.subject}`,
       html: dto.htmlContent,
     });
     return { messageId: result.messageId };

--- a/back/libs/mailer/src/dto/mailer-config.dto.spec.ts
+++ b/back/libs/mailer/src/dto/mailer-config.dto.spec.ts
@@ -10,6 +10,7 @@ describe("MailerConfig (Data Transfer Object)", () => {
   const mailerConfigMock = {
     fromEmail: "no-reply@example.com",
     fromName: "ProConnect",
+    subjectPrefix: "Test - ",
   };
 
   describe("should validate", () => {

--- a/back/libs/mailer/src/dto/mailer-config.dto.ts
+++ b/back/libs/mailer/src/dto/mailer-config.dto.ts
@@ -19,4 +19,8 @@ export class MailerConfig {
   @IsString()
   @ValidateIf(({ transport }) => transport === TransportType.BREVO)
   readonly brevoApiKey?: string;
+
+  @IsString()
+  @IsOptional()
+  readonly emailSubjectPrefix?: string;
 }

--- a/back/libs/mailer/src/mailer.module.ts
+++ b/back/libs/mailer/src/mailer.module.ts
@@ -20,16 +20,17 @@ export class MailerModule {
           inject: [ConfigService],
           useFactory: (config: ConfigService): MailerService => {
             const mailerConfig = config.get<MailerConfig>("Mailer");
-            if (mailerConfig.transport === TransportType.BREVO) {
-              return new BrevoAdapter(mailerConfig, globalThis.fetch);
+            switch (mailerConfig.transport) {
+              case TransportType.BREVO:
+                return new BrevoAdapter(mailerConfig, globalThis.fetch);
+              case TransportType.SMTP:
+                return new SmtpAdapter(
+                  mailerConfig,
+                  nodemailer.createTransport(mailerConfig.smtpUrl),
+                );
+              default:
+                return new NoneAdapter();
             }
-            if (mailerConfig.transport === TransportType.SMTP) {
-              return new SmtpAdapter(
-                mailerConfig,
-                nodemailer.createTransport(mailerConfig.smtpUrl),
-              );
-            }
-            return new NoneAdapter();
           },
         },
       ],

--- a/docker/compose/fca-low/.env/core.env
+++ b/docker/compose/fca-low/.env/core.env
@@ -68,6 +68,7 @@ Mailer_TRANSPORT=smtp
 Mailer_FROM_EMAIL=no-reply@account.proconnect.gouv.fr
 Mailer_FROM_NAME=NE PAS RÉPONDRE
 Mailer_SMTP_URL=smtp://maildev:1025
+Mailer_EMAIL_SUBJECT_PREFIX="Test - "
 ## Bluebird potential memory leak safe guard
 ## @see https://gitlab.dev-franceconnect.fr/france-connect/fc/-/issues/131
 ## @see http://bluebirdjs.com/docs/api/promise.config.html#promise.config

--- a/quality/cypress/support/index.ts
+++ b/quality/cypress/support/index.ts
@@ -49,7 +49,7 @@ Cypress.Commands.add(
 
 function verifyEmailCommand() {
   return cy
-    .maildevGetMessageBySubject("Vérification de votre adresse email")
+    .maildevGetMessageBySubject("Test - Vérification de votre adresse email")
     .then((email) => {
       cy.maildevVisitMessageById(email.id);
       cy.origin(


### PR DESCRIPTION
**Problem**
Emails sent from the integration environment are indistinguishable from those sent from production.

**Proposal**
Add an `EMAIL_SUBJECT_PREFIX` environment variable to automatically prepend a configurable prefix to email subjects in integration environments.