### PR TITLE
🧹 chore: remove unused computeTokenErrorMessage function

### DIFF
--- a/back/libs/email-verification/src/email-verification.service.spec.ts
+++ b/back/libs/email-verification/src/email-verification.service.spec.ts
@@ -253,30 +253,6 @@ describe(EmailVerificationService.name, () => {
     });
   });
 
-  describe("computeTokenErrorMessage", () => {
-    it("should return undefined when no error code is provided", () => {
-      expect(service.computeTokenErrorMessage(undefined)).toBeUndefined();
-    });
-
-    it("should return a message for invalid_verify_email_code", () => {
-      expect(
-        service.computeTokenErrorMessage("invalid_verify_email_code"),
-      ).toBe("Le code rentré est invalide ou expiré.");
-    });
-
-    it("should return a message for too_many_attempts", () => {
-      expect(service.computeTokenErrorMessage("too_many_attempts")).toBe(
-        "Vous avez fait trop de tentatives, veuillez réessayer plus tard.",
-      );
-    });
-
-    it("should return default message for unknown error code", () => {
-      expect(service.computeTokenErrorMessage("unknown")).toBe(
-        "Une erreur est survenue, veuillez réessayer.",
-      );
-    });
-  });
-
   describe("renderVerificationEmailTemplate", () => {
     it("should render verify-email template with csrf token and computed countdown date", async () => {
       const lastEmailVerificationTokenSentAt = new Date(

--- a/back/libs/email-verification/src/email-verification.service.ts
+++ b/back/libs/email-verification/src/email-verification.service.ts
@@ -190,20 +190,6 @@ export class EmailVerificationService {
     }
   }
 
-  computeTokenErrorMessage(errorCode: string | undefined) {
-    if (!errorCode) {
-      return undefined;
-    }
-    switch (errorCode) {
-      case "invalid_verify_email_code":
-        return "Le code rentré est invalide ou expiré.";
-      case "too_many_attempts":
-        return "Vous avez fait trop de tentatives, veuillez réessayer plus tard.";
-      default:
-        return "Une erreur est survenue, veuillez réessayer.";
-    }
-  }
-
   deleteEmailTokens(email: string) {
     return this.model.deleteMany({ email });
   }


### PR DESCRIPTION
**Problem**
The `computeTokenErrorMessage` function is no longer used but was accidentally left in the codebase.

**Proposal**
Remove the unused `computeTokenErrorMessage` function.