### PR TITLE
♻️ refactor: enforce a single email verification token per user

### DIFF
--- a/back/apps/core-fca-low/src/controllers/email-verification.controller.spec.ts
+++ b/back/apps/core-fca-low/src/controllers/email-verification.controller.spec.ts
@@ -22,7 +22,7 @@ describe("EmailVerificationController", () => {
     emailVerificationMock = {
       sendEmailVerificationIfNeeded: jest.fn(),
       verifyEmailToken: jest.fn(),
-      deleteEmailTokens: jest.fn(),
+      deleteEmailToken: jest.fn(),
       findLastEmailVerificationToken: jest.fn(),
       renderVerificationEmailTemplate: jest.fn(),
     };

--- a/back/apps/core-fca-low/src/controllers/email-verification.controller.ts
+++ b/back/apps/core-fca-low/src/controllers/email-verification.controller.ts
@@ -76,7 +76,7 @@ export class EmailVerificationController {
 
     userSession.set({ isEmailVerifiedByPcf: true });
     await userSession.commit();
-    await this.emailVerification.deleteEmailTokens(email);
+    await this.emailVerification.deleteEmailToken(email);
 
     const url = `${urlPrefix}/interaction/${interactionId}/verify`;
 

--- a/back/libs/email-verification/src/email-verification.service.spec.ts
+++ b/back/libs/email-verification/src/email-verification.service.spec.ts
@@ -24,7 +24,8 @@ describe(EmailVerificationService.name, () => {
   const modelMock = {
     create: jest.fn(),
     findOne: jest.fn(),
-    deleteMany: jest.fn(),
+    deleteOne: jest.fn(),
+    findOneAndUpdate: jest.fn(),
   };
   const csrfServiceMock = {
     getOrCreate: jest.fn(),
@@ -153,10 +154,6 @@ describe(EmailVerificationService.name, () => {
       const now = new Date("2024-01-01T12:00:00.000Z");
       jest.useFakeTimers().setSystemTime(now);
 
-      modelMock.findOne.mockReturnValue({
-        sort: jest.fn().mockResolvedValue(null),
-      });
-
       const result =
         await service.sendEmailVerificationIfNeeded("user@example.com");
 
@@ -170,11 +167,7 @@ describe(EmailVerificationService.name, () => {
           htmlContent: expect.any(String),
         }),
       );
-      expect(modelMock.create).toHaveBeenCalledWith({
-        email: "user@example.com",
-        token: expect.any(String),
-        sentAt: now,
-      });
+      expect(modelMock.findOneAndUpdate).toHaveBeenCalled();
       jest.useRealTimers();
     });
 
@@ -240,16 +233,21 @@ describe(EmailVerificationService.name, () => {
       ).rejects.toThrow(InvalidEmailVerificationTokenException);
     });
 
-    it("should return true when token is valid", async () => {
+    it("should not throw when token is valid", async () => {
+      const now = new Date("2024-01-01T00:01:00.000Z");
+      jest.useFakeTimers().setSystemTime(now);
+
       rateLimiterServiceMock.consume.mockResolvedValue(undefined);
       modelMock.findOne.mockResolvedValue({
         email: "user@example.com",
         token: "1234567890",
+        sentAt: new Date("2024-01-01T00:00:00.000Z"),
       });
 
-      expect(
+      await expect(
         service.verifyEmailToken("user@example.com", "1234567890"),
       ).resolves.not.toThrow();
+      jest.useRealTimers();
     });
   });
 
@@ -341,6 +339,16 @@ describe(EmailVerificationService.name, () => {
 
       expect(result.hasSentVerificationEmail).toBe(true);
       jest.useRealTimers();
+    });
+  });
+
+  describe("deleteEmailToken", () => {
+    it("should call deleteOne", async () => {
+      const email = "user@example.com";
+
+      await service.deleteEmailToken(email);
+
+      expect(modelMock.deleteOne).toHaveBeenCalledWith({ email });
     });
   });
 });

--- a/back/libs/email-verification/src/email-verification.service.ts
+++ b/back/libs/email-verification/src/email-verification.service.ts
@@ -72,16 +72,21 @@ export class EmailVerificationService {
       };
     }
 
-    await this.deleteEmailTokens(email);
     const token = this.generateToken();
 
     await this.sendVerificationMail(email, token);
 
-    await this.model.create({
-      email,
-      token,
-      sentAt: new Date(),
-    });
+    await this.model.findOneAndUpdate(
+      {
+        email,
+      },
+      {
+        email,
+        token,
+        sentAt: new Date(),
+      },
+      { upsert: true },
+    );
 
     return {
       hasSentVerificationEmail: true,
@@ -177,21 +182,24 @@ export class EmailVerificationService {
     }
     const { tokenExpirationDurationInMs } =
       this.config.get<EmailVerificationConfig>("EmailVerification");
-    const expirationTimeThreshold = new Date(
-      Date.now() - tokenExpirationDurationInMs,
-    );
+    const now = new Date();
+
     const emailVerificationToken = await this.model.findOne({
       email,
-      token,
-      sentAt: { $gte: expirationTimeThreshold },
     });
-    if (!emailVerificationToken) {
+
+    if (
+      !emailVerificationToken ||
+      emailVerificationToken.token !== token ||
+      now.getTime() - emailVerificationToken.sentAt.getTime() >
+        tokenExpirationDurationInMs
+    ) {
       throw new InvalidEmailVerificationTokenException();
     }
   }
 
-  deleteEmailTokens(email: string) {
-    return this.model.deleteMany({ email });
+  async deleteEmailToken(email: string) {
+    return this.model.deleteOne({ email });
   }
 
   private generateToken(): string {

--- a/back/libs/email-verification/src/schemas/email-verification-token.schema.ts
+++ b/back/libs/email-verification/src/schemas/email-verification-token.schema.ts
@@ -3,7 +3,7 @@ import { Document } from "mongoose";
 
 @Schema({ collection: "emailVerificationToken", strict: true })
 export class EmailVerificationToken extends Document {
-  @Prop({ type: String, index: true })
+  @Prop({ type: String, index: true, unique: true })
   email: string;
 
   @Prop({ type: String })

--- a/back/migrations/20260731082824-delete_multiple_tokens_per_email.ts
+++ b/back/migrations/20260731082824-delete_multiple_tokens_per_email.ts
@@ -1,0 +1,26 @@
+import type { Db } from "mongodb";
+export const up = async (db: Db) => {
+  const collection = db.collection("emailVerificationToken");
+  const emailVerificationTokens = await collection
+    .find({})
+    .sort({ sentAt: -1 })
+    .toArray();
+  const emailToTokenMap = new Map();
+
+  for (const emailVerificationToken of emailVerificationTokens) {
+    if (!emailToTokenMap.has(emailVerificationToken.email)) {
+      emailToTokenMap.set(emailVerificationToken.email, true);
+    } else {
+      await collection.deleteOne({ _id: emailVerificationToken._id });
+    }
+  }
+
+  await collection.createIndex(
+    { email: 1 },
+    { unique: true, name: "unique_email" },
+  );
+};
+
+export const down = async (db: Db) => {
+  await db.collection("emailVerificationToken").dropIndex("unique_email");
+};


### PR DESCRIPTION
**Problem**
The MongoDB database can store multiple email verification tokens for the same user, requiring periodic cleanup.

**Proposal**
Enforce a single email verification token per user by upserting the token each time an email verification is requested.