### PR TITLE
🐛 Derive cypress FEDERATION_DIR from config file location

### DIFF
--- a/admin/cypress.config.js
+++ b/admin/cypress.config.js
@@ -1,5 +1,8 @@
 import { defineConfig } from "cypress";
+import path from "path";
 import pluginConfig from "./cypress/plugins";
+
+const REPOSITORY_ROOT = path.resolve(import.meta.dirname, "..");
 
 export default defineConfig({
   chromeWebSecurity: false,
@@ -25,8 +28,8 @@ export default defineConfig({
     APP_HOME_ROLE_SECURITY:
       "https://exploitation-fca-low.docker.dev-franceconnect.fr/service-provider",
     APP_NAME: "admin",
-    FEDERATION_DIR: `${process.env.PC_ROOT}/federation`,
-    LOG_FILE_PATH: `${process.env.PC_ROOT}/federation/docker/volumes/log/fcexploitation.log`,
+    FEDERATION_DIR: REPOSITORY_ROOT,
+    LOG_FILE_PATH: `${REPOSITORY_ROOT}/docker/volumes/log/fcexploitation.log`,
   },
   pageLoadTimeout: 30000,
   viewportHeight: 1800,

--- a/quality/cypress-base.config.ts
+++ b/quality/cypress-base.config.ts
@@ -1,4 +1,7 @@
-// Disable sort-keys to separate base configuration and access env variables
+import path from "path";
+
+const REPOSITORY_ROOT = path.resolve(__dirname, "..");
+
 const config: Partial<Cypress.ResolvedConfigOptions<never>> = {
   chromeWebSecurity: false,
   video: false,
@@ -42,7 +45,7 @@ const config: Partial<Cypress.ResolvedConfigOptions<never>> = {
       kid: "EC",
       use: "enc",
     },
-    FEDERATION_DIR: `${process.env.PC_ROOT}/federation`,
+    FEDERATION_DIR: REPOSITORY_ROOT,
   },
 };
 


### PR DESCRIPTION
**Problem**

FEDERATION_DIR and LOG_FILE_PATH were built from
`${PC_ROOT}/federation`, hardcoding the repo directory name. Any checkout not literally named `federation` (e.g. a git worktree) silently points Cypress at a sibling directory's log file instead of its own, making `hasBusinessLog` assertions fail against a stale or empty log with no indication why.

**Proposal**

Derive REPO_ROOT from cypress.config.js's own location (`import.meta.dirname`) instead of assuming the checkout name, so the log path always matches the repo actually being run.