### PR TITLE
🐛 Replace admin e2e pg-db clone with TRUNCATE + reseed

### DIFF
--- a/admin/cypress/support/apply-db-backup.sh
+++ b/admin/cypress/support/apply-db-backup.sh
@@ -1,6 +1,4 @@
 #!/bin/bash
 
-psql postgres -U pg-user -c 'REVOKE CONNECT ON DATABASE "pg-db" FROM public'
-psql postgres -U pg-user -c "SELECT \"pid\", pg_terminate_backend(pid) FROM \"pg_stat_activity\" WHERE datname='pg-db' AND pid <> pg_backend_pid();"
-psql postgres -U pg-user -c 'DROP DATABASE  IF EXISTS "pg-db"'
-psql postgres -U pg-user -c 'CREATE DATABASE "pg-db" WITH TEMPLATE "pg-backup"'
+psql -U pg-user -d pg-db -c 'TRUNCATE TABLE "user", "password", "authentication_failures"'
+psql -U pg-user -d pg-db -f /tmp/admin-e2e-seed.sql

--- a/admin/cypress/support/create-db-backup.sh
+++ b/admin/cypress/support/create-db-backup.sh
@@ -1,7 +1,9 @@
 #!/bin/bash
 
 ## backup is used by db.sh
-psql postgres -U pg-user -c 'REVOKE CONNECT ON DATABASE "pg-backup" FROM public'
-psql postgres -U pg-user -c "SELECT \"pid\", pg_terminate_backend(pid) FROM \"pg_stat_activity\" WHERE datname='pg-backup' AND pid <> pg_backend_pid();"
-psql postgres -U pg-user -c 'DROP DATABASE  IF EXISTS "pg-backup"'
-psql postgres -U pg-user -c 'CREATE DATABASE "pg-backup" WITH TEMPLATE "pg-db"'
+## Dump lives in the pg-admin container's writable layer — same lifetime as
+## the old pg-backup database (gone if the container is recreated without
+## re-running docker-stack up's pg-admin hook).
+pg_dump -U pg-user -d pg-db --data-only --column-inserts \
+  --table='"user"' --table='password' --table='authentication_failures' \
+  -f /tmp/admin-e2e-seed.sql

--- a/docker/bash/commands/up.sh
+++ b/docker/bash/commands/up.sh
@@ -31,7 +31,6 @@ _up() {
       ${DOCKER_COMPOSE} exec ${NO_TTY} "admin" yarn migrations:run
       ${DOCKER_COMPOSE} exec ${NO_TTY} "admin" yarn fixtures:load
 
-      sleep 10 # wait for the database to be ready before creating a backup
       (cd ${FEDERATION_DIR}/admin/cypress/support/ && docker exec pc-pg-"admin"-1 bash -c "$(cat create-db-backup.sh)")
       ;;
     *)


### PR DESCRIPTION
**Problem**

Cypress e2e resets recreated pg-db from a pg-backup template DB via CREATE DATABASE ... WITH TEMPLATE, which requires zero connections on the source. The scripts only terminated connections on the target, causing an intermittent CI failure ("source database is being accessed by other users") when a leftover session (fixtures loader) was still attached to pg-db.

Terminating connections on the source fixes that race, but it also kills the admin app's own live pooled connections on every single test reset, forcing a silent reconnect each time - a second, structural source of flakiness that no amount of
pg_terminate_backend closes off, since dropping/recreating a database inherently requires zero connections to it.

**Proposal**

Stop cloning the whole database. Capture a data-only pg_dump of the three e2e-relevant tables once fixtures are loaded, then reset by TRUNCATE + replay instead of DROP/CREATE DATABASE. TRUNCATE takes a table-level lock that existing pooled connections simply wait on rather than getting killed, so the app's connections are never disrupted. Mirrors the project's existing Mongo reset convention (wipe in place + replay seed scripts) instead of a whole-DB clone.

Also drops the sleep 10 in up.sh that used to paper over the race - no longer needed since the reset is now deterministic.