### PR TITLE
🔒 security: reuse MFA sessions when ACR requirements are satisfied

### DIFF
--- a/back/apps/core-fca-low/src/config/oidc-provider.ts
+++ b/back/apps/core-fca-low/src/config/oidc-provider.ts
@@ -59,6 +59,7 @@ const oidcProviderConfig: OidcProviderConfig = {
     "eidas3",
     "https://proconnect.gouv.fr/assurance/certification-dirigeant",
   ],
+  acrValuesThatRequireNewSession: ["eidas2", "eidas3"],
   // Global request timeout used for any outgoing app requests.
   timeout: parseInt(process.env.REQUEST_TIMEOUT, 10),
 };

--- a/back/apps/core-fca-low/src/controllers/interaction.controller.spec.ts
+++ b/back/apps/core-fca-low/src/controllers/interaction.controller.spec.ts
@@ -63,6 +63,7 @@ describe("InteractionController", () => {
     oidcAcrMock = {
       getFilteredAcrParamsFromInteraction: jest.fn(),
       getInteractionAcr: jest.fn(),
+      areThereEssentialAcrRequested: jest.fn(),
       isEssentialAcrSatisfied: jest.fn(),
       computeCanAcrBeSatisfiedByPcf: jest.fn(),
     };
@@ -168,7 +169,6 @@ describe("InteractionController", () => {
       oidcAcrMock.getFilteredAcrParamsFromInteraction.mockReturnValue({
         acr_values: "high",
       });
-      oidcAcrMock.isEssentialAcrSatisfied.mockReturnValue(true);
       configServiceMock.get.mockReturnValue({ urlPrefix: "/prefix" });
     });
 
@@ -251,6 +251,7 @@ describe("InteractionController", () => {
         uid: "interaction123",
         params: { client_id: "sp123" },
       });
+      oidcAcrMock.isEssentialAcrSatisfied.mockReturnValue(true);
 
       await controller.getInteraction(
         req,

--- a/back/apps/core-fca-low/src/controllers/interaction.controller.ts
+++ b/back/apps/core-fca-low/src/controllers/interaction.controller.ts
@@ -109,8 +109,15 @@ export class InteractionController {
     const isSessionOpenedWithHintedIdp =
       !idpHint || userSession.get("idpId") === hintedIdp.uid;
 
-    const isEssentialAcrSatisfied =
-      this.oidcAcr.isEssentialAcrSatisfied(interaction);
+    const { acrClaims } =
+      this.oidcAcr.getFilteredAcrParamsFromInteraction(interaction);
+    const spEssentialAcr =
+      acrClaims?.value || acrClaims?.values?.join(" ") || undefined;
+
+    const isEssentialAcrSatisfied = this.oidcAcr.isEssentialAcrSatisfied(
+      interaction,
+      activeUserSession,
+    );
 
     const canReuseActiveSession =
       isUserConnectedAlready &&
@@ -119,10 +126,6 @@ export class InteractionController {
       isSessionOpenedWithHintedLogin;
 
     const { name: spName } = await this.serviceProvider.getById(spId);
-    const { acrClaims } =
-      this.oidcAcr.getFilteredAcrParamsFromInteraction(interaction);
-    const spEssentialAcr =
-      acrClaims?.value || acrClaims?.values.join(" ") || null;
 
     if (!canReuseActiveSession) {
       userSession.clear();

--- a/back/libs/oidc-acr/src/oidc-acr.service.spec.ts
+++ b/back/libs/oidc-acr/src/oidc-acr.service.spec.ts
@@ -42,6 +42,7 @@ describe("OidcAcrService", () => {
         "eidas0-mfa",
         "eidas1-mfa",
       ],
+      acrValuesThatRequireNewSession: ["eidas2", "eidas3"],
       defaultIdpId: "defaultIdpId",
     });
   });
@@ -207,7 +208,136 @@ describe("OidcAcrService", () => {
   });
 
   describe("isEssentialAcrSatisfied()", () => {
-    it("should return false when prompt contains essential_acr reason", () => {
+    it("should return true when no essential ACR is requested", () => {
+      // Given
+      const interactionMock = {
+        uid: "123",
+        params: {},
+        prompt: {
+          name: "consent",
+          reasons: [],
+          details: {},
+        },
+      } as unknown as ExtendedInteraction;
+
+      const userSessionMock = {
+        idpAcr: "eidas1",
+        isEmailVerifiedByPcf: false,
+        amr: ["pwd"],
+      } as Pick<UserSession, "idpAcr" | "isEmailVerifiedByPcf" | "amr">;
+
+      // When
+      const result = service.isEssentialAcrSatisfied(
+        interactionMock,
+        userSessionMock,
+      );
+
+      // Then
+      expect(result).toBe(true);
+    });
+
+    it("should return false when essential ACR is requested but not satisfied", () => {
+      // Given
+      const interactionMock = {
+        uid: "123",
+        params: {},
+        prompt: {
+          name: "login",
+          reasons: ["essential_acr"],
+          details: {
+            acr: {
+              essential: true,
+              value: "eidas2",
+            },
+          },
+        },
+      } as unknown as ExtendedInteraction;
+
+      const userSessionMock = {
+        idpAcr: "eidas1",
+        isEmailVerifiedByPcf: true,
+        amr: ["pwd"],
+      } as Pick<UserSession, "idpAcr" | "isEmailVerifiedByPcf" | "amr">;
+
+      // When
+      const result = service.isEssentialAcrSatisfied(
+        interactionMock,
+        userSessionMock,
+      );
+
+      // Then
+      expect(result).toBe(false);
+    });
+
+    it("should return false when satisfied ACR requires a new session", () => {
+      // Given
+      const interactionMock = {
+        uid: "123",
+        params: {},
+        prompt: {
+          name: "login",
+          reasons: ["essential_acr"],
+          details: {
+            acr: {
+              essential: true,
+              values: ["eidas2"],
+            },
+          },
+        },
+      } as unknown as ExtendedInteraction;
+
+      const userSessionMock = {
+        idpAcr: "eidas2",
+        isEmailVerifiedByPcf: true,
+        amr: ["pwd"],
+      } as Pick<UserSession, "idpAcr" | "isEmailVerifiedByPcf" | "amr">;
+
+      // When
+      const result = service.isEssentialAcrSatisfied(
+        interactionMock,
+        userSessionMock,
+      );
+
+      // Then
+      expect(result).toBe(false);
+    });
+
+    it("should return true when essential ACR is satisfied and does not require a new session", () => {
+      // Given
+      const interactionMock = {
+        uid: "123",
+        params: {},
+        prompt: {
+          name: "login",
+          reasons: ["essential_acr"],
+          details: {
+            acr: {
+              essential: true,
+              value: "eidas1",
+            },
+          },
+        },
+      } as unknown as ExtendedInteraction;
+
+      const userSessionMock = {
+        idpAcr: "eidas1",
+        isEmailVerifiedByPcf: true,
+        amr: ["pwd"],
+      } as Pick<UserSession, "idpAcr" | "isEmailVerifiedByPcf" | "amr">;
+
+      // When
+      const result = service.isEssentialAcrSatisfied(
+        interactionMock,
+        userSessionMock,
+      );
+
+      // Then
+      expect(result).toBe(true);
+    });
+  });
+
+  describe("computeAreThereEssentialAcrRequested()", () => {
+    it("should return true when prompt contains essential_acr reason", () => {
       // Given
       const interactionMock = {
         prompt: {
@@ -217,13 +347,14 @@ describe("OidcAcrService", () => {
       } as undefined as ExtendedInteraction;
 
       // When
-      const result = service["isEssentialAcrSatisfied"](interactionMock);
+      const result =
+        service["computeAreThereEssentialAcrRequested"](interactionMock);
 
       // Then
-      expect(result).toBe(false);
+      expect(result).toBe(true);
     });
 
-    it("should return false when prompt contains essential_acrs reason", () => {
+    it("should return true when prompt contains essential_acrs reason", () => {
       // Given
       const interactionMock = {
         prompt: {
@@ -233,13 +364,31 @@ describe("OidcAcrService", () => {
       } as undefined as ExtendedInteraction;
 
       // When
-      const result = service["isEssentialAcrSatisfied"](interactionMock);
+      const result =
+        service["computeAreThereEssentialAcrRequested"](interactionMock);
+
+      // Then
+      expect(result).toBe(true);
+    });
+
+    it("should return false when prompt does not contain essential ACR reasons", () => {
+      // Given
+      const interactionMock = {
+        prompt: {
+          name: "login",
+          reasons: ["other_reasons"],
+        },
+      } as undefined as ExtendedInteraction;
+
+      // When
+      const result =
+        service["computeAreThereEssentialAcrRequested"](interactionMock);
 
       // Then
       expect(result).toBe(false);
     });
 
-    it("should return true when prompt does not contain essential ACR reasons", () => {
+    it("should return false when prompt is not a login", () => {
       // Given
       const interactionMock = {
         prompt: {
@@ -249,10 +398,11 @@ describe("OidcAcrService", () => {
       } as undefined as ExtendedInteraction;
 
       // When
-      const result = service["isEssentialAcrSatisfied"](interactionMock);
+      const result =
+        service["computeAreThereEssentialAcrRequested"](interactionMock);
 
       // Then
-      expect(result).toBe(true);
+      expect(result).toBe(false);
     });
   });
 

--- a/back/libs/oidc-acr/src/oidc-acr.service.ts
+++ b/back/libs/oidc-acr/src/oidc-acr.service.ts
@@ -107,16 +107,35 @@ export class OidcAcrService {
     return intersection(acrValuesAsArray, Array.from(supportedAcrValues));
   }
 
-  isEssentialAcrSatisfied({
-    prompt,
-  }: {
-    prompt: ExtendedInteraction["prompt"];
-  }): boolean {
-    if (prompt.name === "login" && prompt.reasons.includes("essential_acr")) {
+  isEssentialAcrSatisfied(
+    interaction: ExtendedInteraction,
+    userSession: Pick<UserSession, "idpAcr" | "isEmailVerifiedByPcf" | "amr">,
+  ) {
+    const areThereEssentialAcrRequested =
+      this.computeAreThereEssentialAcrRequested(interaction);
+
+    if (!areThereEssentialAcrRequested) {
+      return true;
+    }
+
+    const { acrClaims } = this.getFilteredAcrParamsFromInteraction(interaction);
+    const spEssentialAcr =
+      acrClaims?.value || acrClaims?.values?.join(" ") || undefined;
+
+    const interactionAcr = this.getInteractionAcr({
+      idpAcr: userSession.idpAcr,
+      spEssentialAcr,
+      isEmailVerifiedByPcf: userSession.isEmailVerifiedByPcf,
+      amr: userSession.amr,
+    });
+
+    if (!interactionAcr) {
       return false;
     }
 
-    if (prompt.name === "login" && prompt.reasons.includes("essential_acrs")) {
+    const { acrValuesThatRequireNewSession } =
+      this.config.get<OidcProviderConfig>("OidcProvider");
+    if (acrValuesThatRequireNewSession.includes(interactionAcr)) {
       return false;
     }
 
@@ -165,5 +184,24 @@ export class OidcAcrService {
     }
 
     return {};
+  }
+
+  private computeAreThereEssentialAcrRequested(interaction: {
+    prompt: ExtendedInteraction["prompt"];
+  }): boolean {
+    const { prompt } = interaction;
+    if (prompt.name !== "login") {
+      return false;
+    }
+
+    const containsEssentialAcrs =
+      prompt.reasons.includes("essential_acr") ||
+      prompt.reasons.includes("essential_acrs");
+
+    if (!containsEssentialAcrs) {
+      return false;
+    }
+
+    return true;
   }
 }

--- a/back/libs/oidc-provider/src/dto/oidc-provider-config.dto.ts
+++ b/back/libs/oidc-provider/src/dto/oidc-provider-config.dto.ts
@@ -47,4 +47,8 @@ export class OidcProviderConfig {
 
   @IsUrl()
   readonly errorUriBase?: string;
+
+  @IsArray()
+  @IsString({ each: true })
+  readonly acrValuesThatRequireNewSession: string[];
 }

--- a/quality/cypress/integration/usager/connexion-email-verification.feature
+++ b/quality/cypress/integration/usager/connexion-email-verification.feature
@@ -71,6 +71,26 @@ Fonctionnalité: Connexion Usager - Email verification
     Et que je rentre le code de confirmation reçu par e-mail
     Alors la cinématique a utilisé le niveau de sécurité "eidas1-mfa"
 
+  Scénario: la session est ré-utilisée si un autre fournisseur de service demande le même ACR
+    Etant donné que je navigue sur la page fournisseur de service "premier FS"
+    Et que le fournisseur de service requiert le claim "acr" avec la valeur "eidas1-mfa"
+    Et que je clique sur le bouton ProConnect
+    Et que j'entre l'email "pc@fia2.fr"
+    Et que je clique sur le bouton de connexion
+    Et que le fournisseur d'identité garantit un niveau de sécurité "eidas1"
+    Et que je m'authentifie
+    Et que je suis redirigé vers la page de vérification de l'email
+    Et qu'un e-mail a été envoyé à "pc@fia2.fr"
+    Et que je vois un bouton "Recevoir un nouveau code" désactivé
+    Et que je rentre le code de confirmation reçu par e-mail
+    Et que je suis redirigé vers la page fournisseur de service "premier FS"
+    Et que la cinématique a utilisé le niveau de sécurité "eidas1-mfa"
+    Et que je navigue sur la page fournisseur de service "second FS"
+    Et que le fournisseur de service requiert le claim "acr" avec la valeur "eidas1-mfa"
+    Et que je clique sur le bouton ProConnect
+    Alors je suis redirigé vers la page fournisseur de service "second FS"
+    Et je suis connecté au fournisseur de service
+
   Scénario: on vérifie mon e-mail, je fais trop de tentatives
     Etant donné que je navigue sur la page fournisseur de service
     Et que la base de données est réinitialisée

--- a/quality/cypress/integration/usager/connexion-sso.feature
+++ b/quality/cypress/integration/usager/connexion-sso.feature
@@ -87,3 +87,20 @@ Fonctionnalité: Connexion Usager - SSO
     Quand je navigue sur la page fournisseur de service "second FS"
     Et que je clique sur le bouton ProConnect deux facteurs
     Alors je suis redirigé vers la page interaction
+
+  Scénario: La session est ré-utilisée lorsque le niveau ACR est satisfait
+    Etant donné que je navigue sur la page fournisseur de service "premier FS"
+    Et que le fournisseur de service requiert le claim "acr" avec la valeur "eidas1-mfa"
+    Et que je clique sur le bouton ProConnect
+    Et que j'entre l'email "test@fia1.fr"
+    Et que je clique sur le bouton de connexion
+    Et que le fournisseur d'identité garantit un niveau de sécurité "eidas1-mfa"
+    Et que je m'authentifie
+    Et que je suis redirigé vers la page fournisseur de service "premier FS"
+    Et que la cinématique a utilisé le niveau de sécurité "eidas1-mfa"
+    Et que je navigue sur la page fournisseur de service "second FS"
+    Et que le fournisseur de service requiert le claim "acr" avec la valeur "eidas1-mfa"
+    Et que je clique sur le bouton ProConnect
+    Alors je suis redirigé vers la page fournisseur de service "second FS"
+    Et je suis connecté au fournisseur de service
+


### PR DESCRIPTION
**Problem**
Users receive a new MFA email every time they authenticate to another Service Provider requiring MFA, even when their existing session already satisfies the requested assurance level.

**Proposal**
Allow session reuse when the ACR values present in the existing session satisfy the requirements of the new Service Provider, except for sensitive ACR values (`eidas2` and `eidas3`) which require a fresh authentication session.