### PR TITLE
🔧 make the local mongo watcher faster

### DIFF
--- a/docker/compose/fca-low/.env/core-rie.env
+++ b/docker/compose/fca-low/.env/core-rie.env
@@ -48,6 +48,8 @@ Mongoose_HOSTS=mongo:27017
 Mongoose_DATABASE=core-fca-low
 Mongoose_USER=fc
 Mongoose_PASSWORD=pass
+Mongoose_WATCHER_DEBOUNCE_WAIT_DURATION=11
+
 FC_DB_SYNCHRONIZE=false
 FC_DB_CONNECT_OPTIONS=?replicaSet=rs0
 # Crypto

--- a/docker/compose/fca-low/.env/core.env
+++ b/docker/compose/fca-low/.env/core.env
@@ -49,6 +49,8 @@ Mongoose_HOSTS=mongo:27017
 Mongoose_DATABASE=core-fca-low
 Mongoose_USER=fc
 Mongoose_PASSWORD=pass
+Mongoose_WATCHER_DEBOUNCE_WAIT_DURATION=11
+
 FC_DB_SYNCHRONIZE=false
 FC_DB_CONNECT_OPTIONS=?replicaSet=rs0
 # Crypto


### PR DESCRIPTION
**Problem**

Fast e2e tests can fail because the watcher wait for 1s before applying changes in memory in the core-fca-low. 

**Proposal**

Boost of **98,9%** from 1_000 to 11 to reduce edge cases