### PR TITLE
🏗️ Simplify back Dockerfile multi-stage build

### DIFF
--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -94,7 +94,6 @@ jobs:
       matrix:
         instance:
           - core-fca-low
-          - core-fca-low-migrator
           - csmr-rie
           - mock-data-provider
           - mock-identity-provider
@@ -103,9 +102,6 @@ jobs:
         include:
           - instance: core-fca-low
             context: ./back
-          - instance: core-fca-low-migrator
-            context: ./back
-            target: migrator
           - instance: csmr-rie
             context: .
             file: ./csmr-rie/Dockerfile

--- a/back/Dockerfile
+++ b/back/Dockerfile
@@ -1,7 +1,4 @@
-ARG NODE_VERSION=24.16.0
-ARG NODE_IMAGE=node:${NODE_VERSION}-alpine
-
-FROM ${NODE_IMAGE} AS dev_dependencies
+FROM node:24.16.0-alpine AS dev_dependencies
 
 WORKDIR /var/www/app
 
@@ -10,7 +7,7 @@ RUN --mount=type=cache,target=/usr/local/share/.cache,id=back-yarn-cache,sharing
     --mount=type=tmpfs,target=/tmp \
     yarn install --ignore-engines --immutable
 
-FROM ${NODE_IMAGE} AS dependencies
+FROM node:24.16.0-alpine AS dependencies
 
 WORKDIR /var/www/app
 
@@ -19,49 +16,40 @@ RUN --mount=type=cache,target=/usr/local/share/.cache,id=back-yarn-cache,sharing
     --mount=type=tmpfs,target=/tmp \
     yarn install --ignore-engines --immutable --production
 
-FROM ${NODE_IMAGE} AS migrator
-
-WORKDIR /var/www/app
-
-COPY --from=dependencies /var/www/app/node_modules node_modules
-COPY package.json yarn.lock ./
-COPY migrate-mongo-config.js ./migrate-mongo-config.js
-COPY migrations ./migrations
-
-FROM ${NODE_IMAGE} AS dev
+FROM node:24.16.0-alpine AS dev
 
 WORKDIR /var/www/app
 
 RUN apk add --no-cache bash
 
 COPY --from=dev_dependencies /var/www/app/node_modules node_modules
-COPY . ./
+COPY package.json nest-cli.json tsconfig.json tsconfig.build.json global.d.ts migrate-mongo-config.js ./
+COPY apps ./apps
+COPY libs ./libs
+COPY migrations ./migrations
 
-CMD yarn start:dev ${NESTJS_INSTANCE}
+CMD yarn start:dev core-fca-low
 
-FROM ${NODE_IMAGE} AS builder
+FROM dev_dependencies AS builder
 
-ARG INSTANCE
+COPY nest-cli.json tsconfig.json tsconfig.build.json global.d.ts ./
+COPY apps ./apps
+COPY libs ./libs
 
-COPY . /build/back
+RUN yarn run build
 
-WORKDIR /build/back
-
-COPY --from=dev_dependencies /var/www/app/node_modules node_modules
-
-RUN yarn run build ${INSTANCE}
-
-FROM ${NODE_IMAGE} AS production
-
-ARG INSTANCE
+FROM node:24.16.0-alpine AS production
 
 ENV NODE_ENV=production
 
 VOLUME ["/etc/ssl/client_certs"]
 
-COPY --from=dependencies /var/www/app/node_modules /var/www/app/node_modules
-COPY --from=builder /build/back/dist/apps/${INSTANCE} /var/www/app/dist/instances/app
-
 WORKDIR /var/www/app
 
-CMD ["node", "/var/www/app/dist/instances/app/main.js"]
+COPY --from=dependencies /var/www/app/node_modules node_modules
+COPY --from=builder /var/www/app/dist/apps/core-fca-low dist/instances/app
+COPY package.json ./
+COPY migrate-mongo-config.js ./migrate-mongo-config.js
+COPY migrations ./migrations
+
+CMD ["node", "dist/instances/app/main.js"]

--- a/docker/compose/shared/compose.yaml
+++ b/docker/compose/shared/compose.yaml
@@ -20,7 +20,7 @@ services:
   init-core:
     build:
       context: "../../../back"
-      target: migrator
+      target: production
     working_dir: /var/www/app
     user: ${CURRENT_UID}
     depends_on:


### PR DESCRIPTION

**Problem**

- `back/Dockerfile` indirected the base image through an unused `ARG NODE_VERSION`/`NODE_IMAGE` pair
- kept a separate `migrator` stage that duplicated `node_modules`
- rebuilt `node_modules` from scratch in `builder` instead of reusing the cached `dev_dependencies` layer
- threaded an unused `ARG INSTANCE` through `builder`/`production` despite only ever building `core-fca-low`
- copied the whole build context into `dev` via `COPY . ./` instead of naming what `yarn start:dev` actually needs
- the dedicated `migrator` image was still the only way `init-core` (`docker/compose/shared/compose.yaml`) could run `yarn run migrate up`

**Proposal**

- inline the node image tag
- base `builder` on `dev_dependencies` to reuse the cached `node_modules` layer
- hardcode `core-fca-low` as the only instance built from this Dockerfile
- fold `migrator` into `production` instead of dropping it: `migrate-mongo` is already a runtime dependency, so copying `package.json`, `migrate-mongo-config.js`, and `migrations/` lets `production` double as both app server and one-shot migration runner, matching CI's removal of the standalone `core-fca-low-migrator` build target
- point `init-core` at `target: production` accordingly
- replace `dev`'s `COPY . ./` with an explicit list of the files and directories `yarn start:dev core-fca-low` actually reads
