### PR TITLE
🏗️ Run core migrations via pre_start hook, not init-core

### DIFF
--- a/docker/compose/shared/compose.yaml
+++ b/docker/compose/shared/compose.yaml
@@ -17,41 +17,9 @@ services:
       - data
     init: true
 
-  init-core:
-    build:
-      context: "../../../back"
-      target: production
-    working_dir: /var/www/app
-    user: ${CURRENT_UID}
-    depends_on:
-      mongo:
-        condition: service_healthy
-    volumes:
-      - "../../../back:/build/back:ro"
-      - "../../volumes/app:/opt/scripts"
-      - "../../volumes/log:/var/log/app"
-      - "../../volumes/.home:/home"
-      - "../../volumes/ssl:/etc/ssl/docker_host:ro"
-    env_file:
-      - "../shared/.env/base-app.env"
-      - "../fca-low/.env/core.env"
-    environment:
-      - NODE_OPTIONS=--experimental-strip-types
-      - Mongoose_HOSTS=mongo:27017
-      - Mongoose_TLS=false
-      - Mongoose_TLS_INSECURE=false
-      - Mongoose_TLS_ALLOW_INVALID_HOST_NAME=false
-      - Mongoose_TLS_CA_FILE=
-    tty: true
-    networks:
-      - data
-    command: "yarn run migrate up"
-
   base-core:
     extends: base-nodejs
     depends_on:
-      init-core:
-        condition: service_completed_successfully
       rp-all:
         condition: service_started
       maildev:
@@ -60,6 +28,8 @@ services:
         condition: service_healthy
       redis-pwd:
         condition: service_healthy
+    pre_start:
+      - command: yarn run migrate up
     healthcheck:
       test:
         [


### PR DESCRIPTION
**Problem**

`init-core` was a whole extra service — its own build, volumes,
env overrides, and a `depends_on: condition: service_completed_successfully`
gate — that existed only to run `yarn run migrate up` once before
`base-core` starts. Half of its config (`Mongoose_HOSTS`, TLS
settings) duplicated what `core.env` already sets on `base-core`
itself, since both talk to the same local `mongo`.

**Proposal**

Compose's `pre_start` hook runs inside the target container's own
lifecycle, before its main process starts, and inherits the
service's `environment`/`env_file` — so it doesn't need a
duplicate service or duplicate env wiring at all. Verified directly
(not just by reading docs) that a failing `pre_start` hook blocks
the container from ever reaching `Started`, matching the safety
`depends_on: service_completed_successfully` gave `init-core`, and
that a successful hook's output and env inheritance both work as
expected. Move the migration command onto `base-core` as
`pre_start: [command: yarn run migrate up]` and drop `init-core`
entirely — `core` now migrates itself before serving traffic.
