### PR TITLE
🐛 fix: only resend verification email on explicit request

### DIFF
--- a/back/apps/core-fca-low/src/config/email-verification.ts
+++ b/back/apps/core-fca-low/src/config/email-verification.ts
@@ -6,7 +6,7 @@ const env = new ConfigParser(process.env, "EmailVerification");
 const emailVerificationConfig: EmailVerificationConfig = {
   eligibleEmailsPercentage: env.number("ELIGIBLE_EMAILS_PERCENTAGE"),
   tokenExpirationDurationInMs: 60 * 60 * 1000, // 1 hour
-  verificationEmailWaitingDurationBeforeResendInMs: 10 * 60 * 1000, // 10 minutes
+  verificationEmailCooldownBeforeResendInMs: 10 * 60 * 1000, // 10 minutes
 };
 
 export default emailVerificationConfig;

--- a/back/apps/core-fca-low/src/controllers/email-verification.controller.spec.ts
+++ b/back/apps/core-fca-low/src/controllers/email-verification.controller.spec.ts
@@ -129,4 +129,27 @@ describe("EmailVerificationController", () => {
       );
     });
   });
+
+  describe("postResendVerifyEmail()", () => {
+    it("should resend verification email and render verify-email template", async () => {
+      const res = { redirect: jest.fn() } as unknown as Response;
+      emailVerificationMock.sendEmailVerificationIfNeeded.mockResolvedValue({
+        hasSentVerificationEmail: true,
+      });
+      const userSession = {
+        get: jest.fn().mockReturnValue({
+          spIdentity: { email: "user@example.com" },
+        }),
+        set: jest.fn(),
+        commit: jest.fn(),
+      } as unknown as ISessionService<AfterGetOidcCallbackSessionDto>;
+      configServiceMock.get.mockReturnValue({ urlPrefix: "/prefix" });
+
+      await controller.postResendVerifyEmail(res as Response, userSession);
+
+      expect(
+        emailVerificationMock.sendEmailVerificationIfNeeded,
+      ).toHaveBeenCalledWith("user@example.com", { requestSendEmail: true });
+    });
+  });
 });

--- a/back/apps/core-fca-low/src/controllers/email-verification.controller.ts
+++ b/back/apps/core-fca-low/src/controllers/email-verification.controller.ts
@@ -82,4 +82,28 @@ export class EmailVerificationController {
 
     return res.redirect(url);
   }
+
+  @Post(Routes.VERIFY_EMAIL_RESEND)
+  @Header("cache-control", "no-store")
+  @UseGuards(CsrfTokenGuard)
+  @UseFilters(EmailVerificationExceptionFilter)
+  async postResendVerifyEmail(
+    @Res() res: Response,
+    @UserSessionDecorator(AfterGetOidcCallbackSessionDto)
+    userSession: ISessionService<AfterGetOidcCallbackSessionDto>,
+  ): Promise<void> {
+    const {
+      spIdentity: { email },
+    } = userSession.get();
+
+    const { hasSentVerificationEmail } =
+      await this.emailVerification.sendEmailVerificationIfNeeded(email, {
+        requestSendEmail: true,
+      });
+
+    return this.emailVerification.renderVerificationEmailTemplate(res, {
+      email,
+      hasSentVerificationEmail,
+    });
+  }
 }

--- a/back/apps/core-fca-low/src/enums/routes.enum.ts
+++ b/back/apps/core-fca-low/src/enums/routes.enum.ts
@@ -10,6 +10,7 @@ export enum Routes {
   REDIRECT_TO_IDP = "/redirect-to-idp",
   IDENTITY_PROVIDER_SELECTION = "/identity-provider-selection",
   VERIFY_EMAIL = "/verify-email",
+  VERIFY_EMAIL_RESEND = "/verify-email/resend",
   OIDC_CALLBACK = "/oidc-callback",
   OIDC_LOGOUT_CALLBACK = "/client/logout-callback",
 }

--- a/back/apps/core-fca-low/src/views/verify-email.ejs
+++ b/back/apps/core-fca-low/src/views/verify-email.ejs
@@ -58,9 +58,11 @@
                 </button>
               </form>
               <form
-                action="/api/v2/verify-email"
-                method="get"
+                action="/api/v2/verify-email/resend"
+                method="post"
               >
+                <input type="hidden" name="csrfToken" value="<%= locals.csrfToken %>" />
+
                 <button
                   disabled
                   data-countdown-end-date="<%= locals.countdownEndDate %>"

--- a/back/libs/email-verification/src/dto/email-verification-config.dto.ts
+++ b/back/libs/email-verification/src/dto/email-verification-config.dto.ts
@@ -8,9 +8,9 @@ export class EmailVerificationConfig {
 
   @IsNumber()
   @IsPositive()
-  readonly tokenExpirationDurationInMs = 60 * 60 * 1000; // 1 hour in milliseconds
+  readonly tokenExpirationDurationInMs: number;
 
   @IsNumber()
   @IsPositive()
-  readonly verificationEmailWaitingDurationBeforeResendInMs = 10 * 60 * 1000; // 10 minutes in milliseconds
+  readonly verificationEmailCooldownBeforeResendInMs: number;
 }

--- a/back/libs/email-verification/src/email-verification.service.spec.ts
+++ b/back/libs/email-verification/src/email-verification.service.spec.ts
@@ -51,7 +51,7 @@ describe(EmailVerificationService.name, () => {
           return {
             eligibleEmailsPercentage: 100,
             tokenExpirationDurationInMs: 60 * 60 * 1000,
-            verificationEmailWaitingDurationBeforeResendInMs: 10 * 60 * 1000,
+            verificationEmailCooldownBeforeResendInMs: 10 * 60 * 1000,
           };
         default:
           return {};
@@ -303,7 +303,7 @@ describe(EmailVerificationService.name, () => {
       jest.useRealTimers();
     });
 
-    it("should return false when token is still within threshold", async () => {
+    it("should return false when token is still before cooldown", async () => {
       jest.useFakeTimers().setSystemTime(new Date("2024-01-01T00:05:00.000Z"));
       const lastEmailVerificationToken = {
         sentAt: new Date("2024-01-01T00:00:00.000Z"),
@@ -319,7 +319,7 @@ describe(EmailVerificationService.name, () => {
       jest.useRealTimers();
     });
 
-    it("should return true when token is past threshold", async () => {
+    it("should return false when token is past cooldown but user did not request", async () => {
       jest.useFakeTimers().setSystemTime(new Date("2024-01-01T00:11:00.000Z"));
       const lastEmailVerificationToken = {
         sentAt: new Date("2024-01-01T00:00:00.000Z"),
@@ -330,6 +330,60 @@ describe(EmailVerificationService.name, () => {
 
       const result =
         await service.sendEmailVerificationIfNeeded("user@example.com");
+
+      expect(result.hasSentVerificationEmail).toBe(false);
+      jest.useRealTimers();
+    });
+
+    it("should return false when token is not past cooldown but user requested", async () => {
+      jest.useFakeTimers().setSystemTime(new Date("2024-01-01T00:05:00.000Z"));
+      const lastEmailVerificationToken = {
+        sentAt: new Date("2024-01-01T00:00:00.000Z"),
+      } as EmailVerificationToken;
+      emailVerificationRepositoryMock.findOne.mockResolvedValue(
+        lastEmailVerificationToken,
+      );
+
+      const result = await service.sendEmailVerificationIfNeeded(
+        "user@example.com",
+        { requestSendEmail: true },
+      );
+
+      expect(result.hasSentVerificationEmail).toBe(false);
+      jest.useRealTimers();
+    });
+
+    it("should return false when token is not past cooldown but user requested", async () => {
+      jest.useFakeTimers().setSystemTime(new Date("2024-01-01T00:05:00.000Z"));
+      const lastEmailVerificationToken = {
+        sentAt: new Date("2024-01-01T00:00:00.000Z"),
+      } as EmailVerificationToken;
+      emailVerificationRepositoryMock.findOne.mockResolvedValue(
+        lastEmailVerificationToken,
+      );
+
+      const result = await service.sendEmailVerificationIfNeeded(
+        "user@example.com",
+        { requestSendEmail: true },
+      );
+
+      expect(result.hasSentVerificationEmail).toBe(false);
+      jest.useRealTimers();
+    });
+
+    it("should return true when token is past cooldown and user requested", async () => {
+      jest.useFakeTimers().setSystemTime(new Date("2024-01-01T00:11:00.000Z"));
+      const lastEmailVerificationToken = {
+        sentAt: new Date("2024-01-01T00:00:00.000Z"),
+      } as EmailVerificationToken;
+      emailVerificationRepositoryMock.findOne.mockResolvedValue(
+        lastEmailVerificationToken,
+      );
+
+      const result = await service.sendEmailVerificationIfNeeded(
+        "user@example.com",
+        { requestSendEmail: true },
+      );
 
       expect(result.hasSentVerificationEmail).toBe(true);
       jest.useRealTimers();

--- a/back/libs/email-verification/src/email-verification.service.ts
+++ b/back/libs/email-verification/src/email-verification.service.ts
@@ -36,26 +36,30 @@ export class EmailVerificationService {
   computeCountdownEndDate(
     lastEmailVerificationTokenSentAt: Date | undefined,
   ): Date {
-    const { verificationEmailWaitingDurationBeforeResendInMs } =
+    const { verificationEmailCooldownBeforeResendInMs } =
       this.config.get<EmailVerificationConfig>("EmailVerification");
     if (!lastEmailVerificationTokenSentAt) {
       const now = new Date();
       return new Date(
-        now.getTime() + verificationEmailWaitingDurationBeforeResendInMs,
+        now.getTime() + verificationEmailCooldownBeforeResendInMs,
       );
     }
     return new Date(
       lastEmailVerificationTokenSentAt.getTime() +
-        verificationEmailWaitingDurationBeforeResendInMs,
+        verificationEmailCooldownBeforeResendInMs,
     );
   }
 
-  async sendEmailVerificationIfNeeded(email: string) {
+  async sendEmailVerificationIfNeeded(
+    email: string,
+    options?: { requestSendEmail?: boolean },
+  ): Promise<{ hasSentVerificationEmail: boolean }> {
     const lastEmailVerificationToken =
       await this.emailVerificationTokenRepository.findOne(email);
 
     const shouldSendEmail = await this.computeShouldSendEmail(
       lastEmailVerificationToken?.sentAt,
+      options?.requestSendEmail,
     );
 
     if (!shouldSendEmail) {
@@ -126,7 +130,8 @@ export class EmailVerificationService {
   }
 
   private async computeShouldSendEmail(
-    lastEmailVerificationTokenSentAt?: Date,
+    lastEmailVerificationTokenSentAt: Date | undefined,
+    requestSendEmail?: boolean,
   ): Promise<boolean> {
     if (!lastEmailVerificationTokenSentAt) {
       return true;
@@ -134,7 +139,7 @@ export class EmailVerificationService {
     const now = new Date();
     const {
       tokenExpirationDurationInMs,
-      verificationEmailWaitingDurationBeforeResendInMs,
+      verificationEmailCooldownBeforeResendInMs,
     } = this.config.get<EmailVerificationConfig>("EmailVerification");
 
     const isTokenExpired =
@@ -144,14 +149,15 @@ export class EmailVerificationService {
       return true;
     }
 
-    const hasResendCooldownExpired =
-      now.getTime() - lastEmailVerificationTokenSentAt.getTime() >
-      verificationEmailWaitingDurationBeforeResendInMs;
-    if (hasResendCooldownExpired) {
-      return true;
+    if (!requestSendEmail) {
+      return false;
     }
 
-    return false;
+    const hasResendCooldownExpired =
+      now.getTime() - lastEmailVerificationTokenSentAt.getTime() >
+      verificationEmailCooldownBeforeResendInMs;
+
+    return hasResendCooldownExpired;
   }
 
   async verifyEmailToken(email: string, token: string) {


### PR DESCRIPTION
**Problem**
The verification email was automatically resent whenever the user refreshed the page after the cooldown period had expired, resulting in unnecessary emails.

**Proposal**
Only resend the verification email when the user explicitly clicks the "Request a new code" button.

**Girl scout**
Rename variable to verificationEmailCooldownBeforeResendInMs