### PR TITLE
💄 Domain emails  are blocked by default in admin

### DIFF
--- a/admin/cypress/integration/identity-provider/identity-provider-create.spec.js
+++ b/admin/cypress/integration/identity-provider/identity-provider-create.spec.js
@@ -296,7 +296,7 @@ describe("Identity provider creation", () => {
       cy.url().should("eq", `${BASE_URL}/identity-provider/create`);
     });
 
-    it("if the totp is invalid", () => {
+    it("if the totp is invalid and form values are preserved", () => {
       const idp = {
         name: "MonSuperFI-3",
         title: "Mon Super FI 3 mais mieux écrit",
@@ -312,6 +312,8 @@ describe("Identity provider creation", () => {
         token_endpoint_auth_method: "client_secret_post",
         siret: "34047343800034",
         isMfaCompliant: true,
+        isRoutingEnabled: true,
+        isBlockingForUnlistedEmailDomainsEnabled: true,
       };
 
       basicConfiguration.totp = false;
@@ -319,6 +321,7 @@ describe("Identity provider creation", () => {
       createIdentityProvider(idp, basicConfiguration);
       cy.url().should("eq", `${BASE_URL}/identity-provider/create`);
       cy.contains(`Le TOTP saisi n'est pas valide`).should("exist");
+
       assertFormValues(idp);
     });
   });

--- a/admin/src/identity-provider/identity-provider.service.ts
+++ b/admin/src/identity-provider/identity-provider.service.ts
@@ -37,7 +37,7 @@ export class IdentityProviderService {
     }
   }
 
-  async countIdentityProviders() {
+  async countIdentityProviders(): Promise<number> {
     return this.identityProviderRepository.count();
   }
 

--- a/admin/views/identity-provider/creation.ejs
+++ b/admin/views/identity-provider/creation.ejs
@@ -143,11 +143,11 @@
             </div>
 
             <%
-              let isBlockingForUnlistedEmailDomainsEnabledChecked = false
+              let isBlockingForUnlistedEmailDomainsEnabledChecked = true
               if (locals.messages.values && messages.values[0].isBlockingForUnlistedEmailDomainsEnabled !== undefined) {
                 isBlockingForUnlistedEmailDomainsEnabledChecked = messages.values[0].isBlockingForUnlistedEmailDomainsEnabled
               } else {
-                isBlockingForUnlistedEmailDomainsEnabledChecked = false
+                isBlockingForUnlistedEmailDomainsEnabledChecked = true
               }
             %>
             <div class="mb-3 row">


### PR DESCRIPTION
Previously, email domains were not blocked by default when creating an IdP in the admin panel. We have decided to block them by default, so we need to update the IdP creation interface to reflect this.

When looking at the code, I realize `countIdentityProviders` return was not typed so I add a return type.

<img width="1307" height="1030" alt="Screenshot from 2026-08-06 19-50-09" src="https://github.com/user-attachments/assets/09265bca-a37f-43d6-92cf-1035568c09b9" />
