### PR TITLE
 ✨ feat: use dedicated OTP email template and shorten OTP length

### DIFF
--- a/back/apps/core-fca-low/src/controllers/email-verification.controller.spec.ts
+++ b/back/apps/core-fca-low/src/controllers/email-verification.controller.spec.ts
@@ -109,7 +109,7 @@ describe("EmailVerificationController", () => {
     it("should redirect to interaction verify after a valid token", async () => {
       const res = { redirect: jest.fn() } as unknown as Response;
       const body: VerifyEmailDto = {
-        verify_email_token: "0123456789",
+        verify_email_token: "01234567",
         csrfToken: "",
       };
       const userSession = {

--- a/back/apps/core-fca-low/src/dto/verify-email.dto.ts
+++ b/back/apps/core-fca-low/src/dto/verify-email.dto.ts
@@ -1,6 +1,6 @@
 import { Transform } from "class-transformer";
 import { IsAscii, IsString, Matches } from "class-validator";
-const VERIFY_EMAIL_TOKEN_REGEX = /^\d{10}$/;
+const VERIFY_EMAIL_TOKEN_REGEX = /^\d{8}$/;
 export class VerifyEmailDto {
   @IsString()
   @Transform(({ value }) =>

--- a/back/apps/core-fca-low/src/views/verify-email.ejs
+++ b/back/apps/core-fca-low/src/views/verify-email.ejs
@@ -40,16 +40,16 @@
                   <label class="fr-label" for="verify_email_token">
                     Code de confirmation
                     <span class="fr-hint-text">
-                      Insérer le code à 10 chiffres reçu par email
+                      Insérer le code à 8 chiffres reçu par email
                     </span>
                   </label>
                   <input
                     class="fr-input"
                     required
-                    pattern="^\s*(\d\s*){10}$"
+                    pattern="^\s*(\d\s*){8}$"
                     type="text"
                     id="verify_email_token"
-                    title="10 chiffres"
+                    title="8 chiffres"
                     name="verify_email_token"
                   />
                 </div>

--- a/back/libs/email-verification/src/email-verification.service.spec.ts
+++ b/back/libs/email-verification/src/email-verification.service.spec.ts
@@ -401,4 +401,32 @@ describe(EmailVerificationService.name, () => {
       );
     });
   });
+  describe("getValidityDuration", () => {
+    it("should return the validity duration in minutes if < 60 minutes", () => {
+      configServiceMock.get.mockReturnValue({
+        tokenExpirationDurationInMs: 30 * 60 * 1000,
+      });
+      const result = service.getValidityDuration();
+
+      expect(result).toBe("30 minutes");
+    });
+
+    it("should return the validity duration in hours if >= 60 minutes", () => {
+      configServiceMock.get.mockReturnValue({
+        tokenExpirationDurationInMs: 90 * 60 * 1000,
+      });
+      const result = service.getValidityDuration();
+
+      expect(result).toBe("1 heure 30");
+    });
+
+    it("should return the validity duration in hours with plural if >= 2 hours", () => {
+      configServiceMock.get.mockReturnValue({
+        tokenExpirationDurationInMs: 2 * 60 * 60 * 1000,
+      });
+      const result = service.getValidityDuration();
+
+      expect(result).toBe("2 heures");
+    });
+  });
 });

--- a/back/libs/email-verification/src/email-verification.service.ts
+++ b/back/libs/email-verification/src/email-verification.service.ts
@@ -5,7 +5,7 @@ import { MailerService } from "@fc/mailer";
 import { RateLimiterService } from "@fc/rate-limiter";
 import { RateLimiterKeyPrefix } from "@fc/rate-limiter/enum";
 import { Injectable } from "@nestjs/common";
-import { VerifyEmail } from "@proconnect-gouv/proconnect.email";
+import { OtpEmail } from "@proconnect-gouv/proconnect.email";
 import { Response } from "express";
 import { customAlphabet } from "nanoid";
 import { EmailVerificationConfig } from "./dto";
@@ -85,15 +85,17 @@ export class EmailVerificationService {
   async sendVerificationMail(email: string, token: string) {
     this.logger.info({
       code: "send-verification-mail",
-      email,
     });
+
+    const validityDuration = this.getValidityDuration();
 
     try {
       await this.mailer.sendMail({
         to: email,
         subject: "Vérification de votre adresse email",
-        htmlContent: VerifyEmail({
+        htmlContent: OtpEmail({
           token,
+          validityDuration,
         }).toString(),
       });
     } catch (error) {
@@ -101,6 +103,22 @@ export class EmailVerificationService {
     }
 
     return;
+  }
+
+  getValidityDuration(): string {
+    const { tokenExpirationDurationInMs } =
+      this.config.get<EmailVerificationConfig>("EmailVerification");
+    const minutes = Math.floor(tokenExpirationDurationInMs / 1000 / 60);
+    if (minutes < 60) {
+      return `${minutes} minutes`;
+    }
+    const hours = Math.floor(minutes / 60);
+    const remainingMinutes = minutes % 60;
+    const hoursString = `${hours} heure${hours > 1 ? "s" : ""}`;
+    if (remainingMinutes === 0) {
+      return hoursString;
+    }
+    return `${hoursString} ${remainingMinutes}`;
   }
 
   async renderVerificationEmailTemplate(
@@ -191,6 +209,6 @@ export class EmailVerificationService {
   }
 
   private generateToken(): string {
-    return customAlphabet("0123456789", 10)();
+    return customAlphabet("0123456789", 8)();
   }
 }

--- a/back/package.json
+++ b/back/package.json
@@ -41,7 +41,7 @@
     "@proconnect-gouv/proconnect.annuaire_entreprises": "^2.0.2",
     "@proconnect-gouv/proconnect.api_entreprise": "^2.2.0",
     "@proconnect-gouv/proconnect.core": "^1.0.0",
-    "@proconnect-gouv/proconnect.email": "^1.1.0",
+    "@proconnect-gouv/proconnect.email": "^1.1.1",
     "@proconnect-gouv/proconnect.identite": "^9.1.3",
     "@proconnect-gouv/proconnect.insee": "^2.0.0",
     "@proconnect-gouv/proconnect.registre_national_entreprises": "^4.0.0",

--- a/back/yarn.lock
+++ b/back/yarn.lock
@@ -1368,10 +1368,10 @@
     nanoid "^5.1.5"
     tld-extract "^2.1.0"
 
-"@proconnect-gouv/proconnect.email@^1.1.0":
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/@proconnect-gouv/proconnect.email/-/proconnect.email-1.1.0.tgz#9e9a82cc791f272c2d8a26d36b4c5315362ef364"
-  integrity sha512-T4p2fveNSPySf8gkNVruqya86+rRFimGBUKpSR+pNDQV5YbPaAo+7H3lzfoGus7ewNLUw/MvRqzwGWlovNg4QQ==
+"@proconnect-gouv/proconnect.email@^1.1.1":
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/@proconnect-gouv/proconnect.email/-/proconnect.email-1.1.1.tgz#f6d88d702b1f7c8f919e8f7a834a2944b5138bb0"
+  integrity sha512-BqnRPZxShTf60pI2XGRW8WENkxR8ebxhbv21eScImBVT7pgf8Tbn8DsuP/7D/3paL95qypelQpwXV/hwU+KzTQ==
   dependencies:
     "@kitajs/html" "^4.2.9"
 

--- a/quality/cypress/integration/usager/connexion-email-verification.feature
+++ b/quality/cypress/integration/usager/connexion-email-verification.feature
@@ -51,7 +51,7 @@ Fonctionnalité: Connexion Usager - Email verification
     Et que je m'authentifie
     Et que je suis redirigé vers la page de vérification de l'email
     Et qu'un e-mail a été envoyé à "pc@fia2.fr"
-    Et que je rentre le code de confirmation " 0000000000 "
+    Et que je rentre le code de confirmation " 00000000 "
     Alors je vois le message d'erreur "Le code rentré est invalide ou expiré."
 
 
@@ -103,8 +103,8 @@ Fonctionnalité: Connexion Usager - Email verification
     Et que je m'authentifie
     Et que je suis redirigé vers la page de vérification de l'email
     Et qu'un e-mail a été envoyé à "pc+aaaaaaaaa@fia2.fr"
-    Et que je rentre le code de confirmation "0000000000" 10 fois
+    Et que je rentre le code de confirmation "00000000" 10 fois
     Et que je vois le message d'erreur "Le code rentré est invalide ou expiré."
-    Et que je rentre le code de confirmation "0000000000"
+    Et que je rentre le code de confirmation "00000000"
     Alors je vois le message d'erreur "Vous avez dépassé le nombre de tentatives autorisées. Veuillez réessayer plus tard."
 

--- a/quality/cypress/support/index.ts
+++ b/quality/cypress/support/index.ts
@@ -55,14 +55,12 @@ function verifyEmailCommand() {
       cy.origin(
         `${Cypress.expose("MAILDEV_PROTOCOL")}://${Cypress.expose("MAILDEV_HOST")}`,
         () => {
-          cy.contains(
-            "Pour vérifier votre adresse e-mail, merci de copier-coller ou de renseigner ce code dans l’interface de connexion ProConnect.",
-          );
+          cy.contains("Voici votre code de connexion à usage unique.");
         },
       );
       cy.go("back");
       cy.maildevDeleteMessageById(email.id);
-      return cy.maildevGetOTPCode(email.html, 10);
+      return cy.maildevGetOTPCode(email.html, 8);
     })
     .then((code) => {
       if (!code)


### PR DESCRIPTION
**Problem**
The support team needs OTP emails to be clearly distinguishable from email verification messages.

**Proposal**
Use the dedicated OTP email template and reduce the OTP length to 8 characters.