### PR TITLE
🚚 Rename `Fournisseur de données` into `Serveur de ressources`

### DIFF
--- a/admin/cypress/integration/service-provider/service-provider-create.utils.js
+++ b/admin/cypress/integration/service-provider/service-provider-create.utils.js
@@ -3,7 +3,7 @@ const BASE_URL = Cypress.config("baseUrl");
 export function createServiceProvider(serviceProviderInfo, configuration) {
   cy.url().should("eq", `${BASE_URL}/service-provider`);
   cy.contains("Créer un fournisseur de service").click();
-  cy.contains("Section Fournisseur de données").click();
+  cy.contains("Section Serveur de ressources").click();
 
   const {
     name,

--- a/admin/cypress/integration/service-provider/service-provider-update.spec.js
+++ b/admin/cypress/integration/service-provider/service-provider-update.spec.js
@@ -423,7 +423,7 @@ describe("update a service-provider", () => {
       cy.contains(`MyFirstFSCypress`).should("be.visible");
       cy.get("a.btn-action-update").last().click();
 
-      cy.contains("Section Fournisseur de données").click();
+      cy.contains("Section Serveur de ressources").click();
 
       cy.formFill(resourceServerData, mockConfig);
       cy.get('form[name="fs-form"] button[type="submit"]').click();

--- a/admin/views/partials/resource-server.ejs
+++ b/admin/views/partials/resource-server.ejs
@@ -1,6 +1,6 @@
 <div class="mb-3">
     <details>
-        <summary id="open-custom-configuration">Section Fournisseur de données</summary>
+        <summary id="open-custom-configuration">Section Serveur de ressources</summary>
 
         <div class="mb-3 row">
             <label class="col-2 col-form-label" for="introspection_signed_response_alg">introspection_signed_response_alg : </label>

--- a/docker/volumes/mongo-fca-low/scripts/db-states/_default/identity-providers.js
+++ b/docker/volumes/mongo-fca-low/scripts/db-states/_default/identity-providers.js
@@ -1,4 +1,4 @@
-const fia = {
+const identityProviders = {
   // -- FIA - FIA1-LOW - Activated
   "FIA1-LOW": {
     uid: "9c716f61-b8a1-435c-a407-ef4d677ec270",
@@ -259,7 +259,7 @@ const fia = {
 };
 
 // -- Idps ----------
-Object.values(fia).forEach((idp) => {
-  print(`${idp.name} > Initializing provider: ${idp.name}`);
-  db.provider.replaceOne({ name: idp.name }, idp, { upsert: true });
+Object.values(identityProviders).forEach((identityProvider) => {
+  print(`${identityProvider.name} > Initializing provider: ${identityProvider.name}`);
+  db.provider.replaceOne({ name: identityProvider.name }, identityProvider, { upsert: true });
 });

--- a/docker/volumes/mongo-fca-low/scripts/db-states/_default/index.js
+++ b/docker/volumes/mongo-fca-low/scripts/db-states/_default/index.js
@@ -1,10 +1,10 @@
-print("Initializing SPs...");
-load("/opt/scripts/db-states/_default/sp.js");
+print("Initializing Service Providers...");
+load("/opt/scripts/db-states/_default/service-providers.js");
 
 /* ------------------------------------------------------------------------------- */
 
-print("Initializing IDPs...");
-load("/opt/scripts/db-states/_default/idp.js");
+print("Initializing Identity Providers...");
+load("/opt/scripts/db-states/_default/identity-providers.js");
 
 /* ------------------------------------------------------------------------------- */
 
@@ -18,5 +18,5 @@ load("/opt/scripts/db-states/_default/scopes.js");
 
 /* ------------------------------------------------------------------------------- */
 
-print("Initializing Data providers...");
-load("/opt/scripts/db-states/_default/dp.js");
+print("Initializing Resource Servers...");
+load("/opt/scripts/db-states/_default/resource-servers.js");

--- a/docker/volumes/mongo-fca-low/scripts/db-states/_default/resource-servers.js
+++ b/docker/volumes/mongo-fca-low/scripts/db-states/_default/resource-servers.js
@@ -1,7 +1,7 @@
-const dps = {
+const resourceServers = {
   "DPA1-LOW": {
-    name: "Fournisseur de données Mock - 1",
-    title: "Fournisseur de données Mock - 1",
+    name: "Serveur de ressources Mock - 1",
+    title: "Serveur de ressources Mock - 1",
     active: true,
     scopes: ["groups"],
     key: "423dcbdc5a15ece61ed00ff5989d72379c26d9ed4c8e4e05a87cffae019586e0",
@@ -21,8 +21,8 @@ const dps = {
     type: "private",
   },
   "DPA2-LOW": {
-    name: "Fournisseur de données Mock - 2",
-    title: "Fournisseur de données Mock - 2",
+    name: "Serveur de ressources Mock - 2",
+    title: "Serveur de ressources Mock - 2",
     active: true,
     scopes: ["groups"],
     key: "71c27fec9540e5aa30b34f8c012154f88f8416530b25f31ba4873a2e58e3d3fe",
@@ -43,7 +43,7 @@ const dps = {
   },
 };
 /* ------------------------------------------------------------------------------- */
-Object.values(dps).forEach((dp) => {
-  print(`${dp.name} > Initializing data provider: ${dp.name}`);
-  db.client.replaceOne({ name: dp.name }, dp, { upsert: true });
+Object.values(resourceServers).forEach((resourceServer) => {
+  print(`${resourceServer.name} > Initializing data provider: ${resourceServer.name}`);
+  db.client.replaceOne({ name: resourceServer.name }, resourceServer, { upsert: true });
 });

--- a/docker/volumes/mongo-fca-low/scripts/db-states/_default/service-providers.js
+++ b/docker/volumes/mongo-fca-low/scripts/db-states/_default/service-providers.js
@@ -1,4 +1,4 @@
-const fsa = {
+const serviceProviders = {
   // -- FSA - FSA1-LOW - Activated - HS256 - no encrypted response
   "FSA1-LOW": {
     name: "FSA - FSA1-LOW",
@@ -134,7 +134,7 @@ const fsa = {
 };
 
 // -- SPs ----------
-Object.values(fsa).forEach((fs) => {
-  print(`${fs.name} > Initializing client: ${fs.name}`);
-  db.client.replaceOne({ name: fs.name }, fs, { upsert: true });
+Object.values(serviceProviders).forEach((serviceProvider) => {
+  print(`${serviceProvider.name} > Initializing client: ${serviceProvider.name}`);
+  db.client.replaceOne({ name: serviceProvider.name }, serviceProvider, { upsert: true });
 });

--- a/docker/volumes/mongo/initdb.d/02-seed.js
+++ b/docker/volumes/mongo/initdb.d/02-seed.js
@@ -1,6 +1,6 @@
 print("Seeding default state...");
-load("/opt/scripts/db-states/_default/sp.js");
-load("/opt/scripts/db-states/_default/idp.js");
+load("/opt/scripts/db-states/_default/service-providers.js");
+load("/opt/scripts/db-states/_default/identity-providers.js");
 load("/opt/scripts/db-states/_default/account-fca.js");
 load("/opt/scripts/db-states/_default/scopes.js");
-load("/opt/scripts/db-states/_default/dp.js");
+load("/opt/scripts/db-states/_default/resource-servers.js");


### PR DESCRIPTION
Fournisseur de données" is the legacy name used by FranceConnect, which has since been updated to "Serveur de ressources" (Resource Server) to align with OIDC standards. While renaming the resource servers, I also made minor naming adjustments to the SP and IdP configurations for consistency.