### PR TITLE
♻️ refactor: rename exception filters

### DIFF
--- a/back/apps/core-fca-low/src/app.module.ts
+++ b/back/apps/core-fca-low/src/app.module.ts
@@ -7,10 +7,10 @@ import { CsrfModule, CsrfService } from "@fc/csrf";
 import { EmailValidatorModule } from "@fc/email-validator/email-validator.module";
 import { EmailVerificationModule } from "@fc/email-verification";
 import {
+  BaseExceptionFilter,
   ExceptionsModule,
-  FcWebHtmlExceptionFilter,
   HttpExceptionFilter,
-  UnknownHtmlExceptionFilter,
+  UnknownExceptionFilter,
 } from "@fc/exceptions";
 import {
   IdentityProviderAdapterMongoModule,
@@ -110,11 +110,11 @@ export class AppModule {
         IdentitySanitizer,
         {
           provide: APP_FILTER,
-          useClass: UnknownHtmlExceptionFilter,
+          useClass: UnknownExceptionFilter,
         },
         {
           provide: APP_FILTER,
-          useClass: FcWebHtmlExceptionFilter,
+          useClass: BaseExceptionFilter,
         },
         {
           provide: APP_FILTER,

--- a/back/libs/email-verification/src/exception-filters/email-verification-exception.filter.ts
+++ b/back/libs/email-verification/src/exception-filters/email-verification-exception.filter.ts
@@ -1,5 +1,5 @@
 import { ConfigService } from "@fc/config";
-import { FcWebHtmlExceptionFilter } from "@fc/exceptions/filters";
+import { BaseExceptionFilter } from "@fc/exceptions/filters";
 import { LoggerService } from "@fc/logger";
 import { SessionService } from "@fc/session";
 import { Catch, Injectable } from "@nestjs/common";
@@ -9,7 +9,7 @@ import { EmailVerificationBaseException } from "../exceptions";
 
 @Catch(EmailVerificationBaseException)
 @Injectable()
-export class EmailVerificationExceptionFilter extends FcWebHtmlExceptionFilter {
+export class EmailVerificationExceptionFilter extends BaseExceptionFilter {
   constructor(
     protected readonly config: ConfigService,
     protected readonly session: SessionService,

--- a/back/libs/exceptions/src/exceptions.module.ts
+++ b/back/libs/exceptions/src/exceptions.module.ts
@@ -3,17 +3,13 @@ import { LoggerModule } from "@fc/logger";
 import { SessionModule } from "@fc/session";
 import { Module } from "@nestjs/common";
 import {
-  FcWebHtmlExceptionFilter,
+  BaseExceptionFilter,
   HttpExceptionFilter,
-  UnknownHtmlExceptionFilter,
+  UnknownExceptionFilter,
 } from "./filters";
 
 @Module({
   imports: [SessionModule, ConfigModule, LoggerModule],
-  providers: [
-    UnknownHtmlExceptionFilter,
-    FcWebHtmlExceptionFilter,
-    HttpExceptionFilter,
-  ],
+  providers: [UnknownExceptionFilter, BaseExceptionFilter, HttpExceptionFilter],
 })
 export class ExceptionsModule {}

--- a/back/libs/exceptions/src/filters/base-exception.filter.spec.ts
+++ b/back/libs/exceptions/src/filters/base-exception.filter.spec.ts
@@ -14,15 +14,15 @@ import { ArgumentsHost } from "@nestjs/common";
 import { Test, TestingModule } from "@nestjs/testing";
 import { BaseException } from "../exceptions/base.exception";
 import { generateErrorId } from "../helpers";
-import { FcWebHtmlExceptionFilter } from "./fc-web-html-exception.filter";
+import { BaseExceptionFilter } from "./base-exception.filter";
 
 jest.mock("../helpers/", () => ({
   ...jest.requireActual("../helpers/"),
   generateErrorId: jest.fn(),
 }));
 
-describe("FcWebHtmlExceptionFilter", () => {
-  let filter: FcWebHtmlExceptionFilter;
+describe("BaseExceptionFilter", () => {
+  let filter: BaseExceptionFilter;
 
   const generateErrorIdMock = jest.mocked(generateErrorId);
 
@@ -61,7 +61,7 @@ describe("FcWebHtmlExceptionFilter", () => {
 
     const module: TestingModule = await Test.createTestingModule({
       providers: [
-        FcWebHtmlExceptionFilter,
+        BaseExceptionFilter,
         ConfigService,
         SessionService,
         LoggerService,
@@ -75,7 +75,7 @@ describe("FcWebHtmlExceptionFilter", () => {
       .useValue(configMock)
       .compile();
 
-    filter = module.get<FcWebHtmlExceptionFilter>(FcWebHtmlExceptionFilter);
+    filter = module.get<BaseExceptionFilter>(BaseExceptionFilter);
 
     hostMock.switchToHttp.mockReturnThis();
     hostMock.getResponse.mockReturnValue(resMock);

--- a/back/libs/exceptions/src/filters/base-exception.filter.ts
+++ b/back/libs/exceptions/src/filters/base-exception.filter.ts
@@ -5,7 +5,7 @@ import { Routes } from "@fc/core/enums/routes.enum";
 import { LoggerService } from "@fc/logger";
 import { SessionService } from "@fc/session";
 import { ArgumentsHost, Catch, Injectable } from "@nestjs/common";
-import { BaseExceptionFilter } from "@nestjs/core";
+import { BaseExceptionFilter as NestBaseExceptionFilter } from "@nestjs/core";
 import { Response } from "express";
 import { ExceptionsConfig } from "../dto";
 import { BaseException, EnrichedDisplayBaseException } from "../exceptions";
@@ -20,7 +20,7 @@ import { ErrorPageParams } from "../types";
 
 @Catch(BaseException)
 @Injectable()
-export class FcWebHtmlExceptionFilter extends BaseExceptionFilter<BaseException> {
+export class BaseExceptionFilter extends NestBaseExceptionFilter<BaseException> {
   constructor(
     protected readonly config: ConfigService,
     protected readonly session: SessionService,

--- a/back/libs/exceptions/src/filters/index.ts
+++ b/back/libs/exceptions/src/filters/index.ts
@@ -1,3 +1,3 @@
-export * from "./fc-web-html-exception.filter";
+export * from "./base-exception.filter";
 export * from "./http-exception.filter";
-export * from "./unknown-html-exception.filter";
+export * from "./unknown-exception.filter";

--- a/back/libs/exceptions/src/filters/unknown-exception.filter.spec.ts
+++ b/back/libs/exceptions/src/filters/unknown-exception.filter.spec.ts
@@ -7,7 +7,7 @@ import { getSessionServiceMock } from "@mocks/session";
 import { ArgumentsHost } from "@nestjs/common";
 import { Test, TestingModule } from "@nestjs/testing";
 import { HttpExceptionFilter } from "./http-exception.filter";
-import { UnknownHtmlExceptionFilter } from "./unknown-html-exception.filter";
+import { UnknownExceptionFilter } from "./unknown-exception.filter";
 
 // Avoid importing the real HttpExceptionFilter (which pulls heavy deps) during this spec
 jest.mock("./http-exception.filter", () => ({
@@ -16,8 +16,8 @@ jest.mock("./http-exception.filter", () => ({
   },
 }));
 
-describe("UnknownHtmlExceptionFilter", () => {
-  let filter: UnknownHtmlExceptionFilter;
+describe("UnknownExceptionFilter", () => {
+  let filter: UnknownExceptionFilter;
 
   const configMock = getConfigMock();
   const loggerMock = getLoggerMock();
@@ -37,7 +37,7 @@ describe("UnknownHtmlExceptionFilter", () => {
 
     const module: TestingModule = await Test.createTestingModule({
       providers: [
-        UnknownHtmlExceptionFilter,
+        UnknownExceptionFilter,
         ConfigService,
         SessionService,
         LoggerService,
@@ -50,7 +50,7 @@ describe("UnknownHtmlExceptionFilter", () => {
       .overrideProvider(ConfigService)
       .useValue(configMock)
       .compile();
-    filter = module.get<UnknownHtmlExceptionFilter>(UnknownHtmlExceptionFilter);
+    filter = module.get<UnknownExceptionFilter>(UnknownExceptionFilter);
 
     spyParent = jest
       .spyOn(HttpExceptionFilter.prototype, "catch")

--- a/back/libs/exceptions/src/filters/unknown-exception.filter.ts
+++ b/back/libs/exceptions/src/filters/unknown-exception.filter.ts
@@ -9,7 +9,7 @@ import { HttpExceptionFilter } from "./http-exception.filter";
 
 @Catch()
 @Injectable()
-export class UnknownHtmlExceptionFilter extends HttpExceptionFilter {
+export class UnknownExceptionFilter extends HttpExceptionFilter {
   catch(exception: Error, host: ArgumentsHost) {
     const wrapped = new InternalServerErrorException(exception);
 

--- a/back/libs/oidc-provider/src/oidc-provider.module.ts
+++ b/back/libs/oidc-provider/src/oidc-provider.module.ts
@@ -1,5 +1,5 @@
 import { ConfigModule } from "@fc/config";
-import { ExceptionsModule, FcWebHtmlExceptionFilter } from "@fc/exceptions";
+import { BaseExceptionFilter, ExceptionsModule } from "@fc/exceptions";
 import { LoggerModule } from "@fc/logger";
 import { IServiceProviderAdapter } from "@fc/oidc";
 import { OidcAcrModule } from "@fc/oidc-acr";
@@ -46,7 +46,7 @@ export class OidcProviderModule {
         LoggerModule,
       ],
       providers: [
-        FcWebHtmlExceptionFilter,
+        BaseExceptionFilter,
         {
           provide: IDENTITY_PROVIDER_SERVICE,
           useExisting: IdentityProviderAdapterMongoService,


### PR DESCRIPTION
**Problem**
The `FcWebHtmlExceptionFilter` and `UnknownHtmlExceptionFilter` classes have legacy and unclear names.

**Proposal**
Rename them to `BaseExceptionFilter` and `UnknownExceptionFilter` to use clearer, more generic names.