### PR TITLE
💬 fix: clarify OTP email subject

### DIFF
--- a/back/libs/email-verification/src/email-verification.service.spec.ts
+++ b/back/libs/email-verification/src/email-verification.service.spec.ts
@@ -159,7 +159,7 @@ describe(EmailVerificationService.name, () => {
       expect(mailerServiceMock.sendMail).toHaveBeenCalledWith(
         expect.objectContaining({
           to: "user@example.com",
-          subject: "Vérification de votre adresse email",
+          subject: "Code à usage unique",
           htmlContent: expect.any(String),
         }),
       );
@@ -188,7 +188,7 @@ describe(EmailVerificationService.name, () => {
       expect(mailerServiceMock.sendMail).toHaveBeenCalledWith(
         expect.objectContaining({
           to: "user@example.com",
-          subject: "Vérification de votre adresse email",
+          subject: "Code à usage unique",
         }),
       );
     });
@@ -203,7 +203,7 @@ describe(EmailVerificationService.name, () => {
       expect(mailerServiceMock.sendMail).toHaveBeenCalledWith(
         expect.objectContaining({
           to: "user@example.com",
-          subject: "Vérification de votre adresse email",
+          subject: "Code à usage unique",
         }),
       );
     });

--- a/back/libs/email-verification/src/email-verification.service.ts
+++ b/back/libs/email-verification/src/email-verification.service.ts
@@ -92,7 +92,7 @@ export class EmailVerificationService {
     try {
       await this.mailer.sendMail({
         to: email,
-        subject: "Vérification de votre adresse email",
+        subject: "Code à usage unique",
         htmlContent: OtpEmail({
           token,
           validityDuration,

--- a/quality/cypress/support/index.ts
+++ b/quality/cypress/support/index.ts
@@ -49,7 +49,7 @@ Cypress.Commands.add(
 
 function verifyEmailCommand() {
   return cy
-    .maildevGetMessageBySubject("Test - Vérification de votre adresse email")
+    .maildevGetMessageBySubject("Test - Code à usage unique")
     .then((email) => {
       cy.maildevVisitMessageById(email.id);
       cy.origin(


### PR DESCRIPTION
**Problem**
The OTP email subject still referred to "email address verification", which is misleading because the email is used to authenticate the user with an OTP.

**Proposal**
Replace the subject with a clearer and more explicit one that reflects the purpose of the OTP email.