### PR TITLE
🔍 chore: add logs for duplicate OTP emails

### DIFF
--- a/back/libs/email-verification/src/email-verification.service.ts
+++ b/back/libs/email-verification/src/email-verification.service.ts
@@ -62,6 +62,14 @@ export class EmailVerificationService {
       options?.requestSendEmail,
     );
 
+    this.logger.info({
+      code: "send-email-verification-if-needed",
+      lastEmailVerificationTokenSentAt:
+        lastEmailVerificationToken?.sentAt?.toISOString(),
+      requestSendEmail: options?.requestSendEmail,
+      shouldSendEmail,
+    });
+
     if (!shouldSendEmail) {
       return {
         hasSentVerificationEmail: false,


### PR DESCRIPTION
**Problem**
Some users receive multiple one-time password emails, even though the algorithm should prevent this from happening within a 10-minute interval.

**Proposal**
Add logs around the OTP email generation and sending logic to investigate the cause of duplicate emails.