### PR TITLE
✨ feat: include email verification in AMR

### DIFF
--- a/back/apps/core-fca-low/src/controllers/email-verification.controller.spec.ts
+++ b/back/apps/core-fca-low/src/controllers/email-verification.controller.spec.ts
@@ -106,7 +106,7 @@ describe("EmailVerificationController", () => {
   });
 
   describe("postVerifyEmail()", () => {
-    it("should redirect to interaction verify after a valid token", async () => {
+    it("should redirect to interaction verify after a valid token and update amr", async () => {
       const res = { redirect: jest.fn() } as unknown as Response;
       const body: VerifyEmailDto = {
         verify_email_token: "01234567",
@@ -116,6 +116,35 @@ describe("EmailVerificationController", () => {
         get: jest.fn().mockReturnValue({
           spIdentity: { email: "user@example.com" },
           interactionId: "interaction123",
+          spAmr: ["pwd"],
+        }),
+        set: jest.fn(),
+        commit: jest.fn(),
+      } as unknown as ISessionService<AfterGetOidcCallbackSessionDto>;
+      configServiceMock.get.mockReturnValue({ urlPrefix: "/prefix" });
+
+      await controller.postVerifyEmail(res as Response, body, userSession);
+
+      expect(userSession.set).toHaveBeenCalledWith({
+        isEmailVerifiedByPcf: true,
+        spAmr: ["pwd", "mail"],
+      });
+      expect(res.redirect).toHaveBeenCalledWith(
+        "/prefix/interaction/interaction123/verify",
+      );
+    });
+
+    it("should redirect to interaction verify after a valid token and set amr if not present", async () => {
+      const res = { redirect: jest.fn() } as unknown as Response;
+      const body: VerifyEmailDto = {
+        verify_email_token: "01234567",
+        csrfToken: "",
+      };
+      const userSession = {
+        get: jest.fn().mockReturnValue({
+          spIdentity: { email: "user@example.com" },
+          interactionId: "interaction123",
+          spAmr: undefined,
         }),
         set: jest.fn(),
         commit: jest.fn(),

--- a/back/apps/core-fca-low/src/controllers/email-verification.controller.ts
+++ b/back/apps/core-fca-low/src/controllers/email-verification.controller.ts
@@ -67,6 +67,7 @@ export class EmailVerificationController {
   ): Promise<void> {
     const { verify_email_token } = body;
     const {
+      spAmr,
       spIdentity: { email },
       interactionId,
     } = userSession.get();
@@ -74,8 +75,10 @@ export class EmailVerificationController {
 
     await this.emailVerification.verifyEmailToken(email, verify_email_token);
 
-    userSession.set({ isEmailVerifiedByPcf: true });
+    const newSpAmr = spAmr ? [...spAmr, "mail"] : ["mail"];
+    userSession.set({ isEmailVerifiedByPcf: true, spAmr: newSpAmr });
     await userSession.commit();
+
     await this.emailVerification.deleteEmailVerificationToken(email);
 
     const url = `${urlPrefix}/interaction/${interactionId}/verify`;

--- a/back/apps/core-fca-low/src/controllers/interaction.controller.ts
+++ b/back/apps/core-fca-low/src/controllers/interaction.controller.ts
@@ -218,7 +218,8 @@ export class InteractionController {
     userSessionService: ISessionService<AfterGetOidcCallbackSessionDto>,
   ) {
     const {
-      amr,
+      idpAmr,
+      spAmr,
       idpAcr,
       idpId,
       spIdentity: { sub, email, roles, siret, organization_label },
@@ -270,7 +271,7 @@ export class InteractionController {
       idpAcr,
       spEssentialAcr,
       isEmailVerifiedByPcf,
-      amr,
+      idpAmr,
     });
 
     if (!interactionAcr) {
@@ -278,7 +279,7 @@ export class InteractionController {
       const canAcrBeSatisfiedByPcf = this.oidcAcr.computeCanAcrBeSatisfiedByPcf(
         {
           spEssentialAcr,
-          amr,
+          idpAmr,
           isOtpEmailEnabled,
         },
       );
@@ -301,7 +302,7 @@ export class InteractionController {
     this.logger.track(TrackedEvent.FC_VERIFIED);
 
     return this.oidcProvider.finishInteraction(req, res, {
-      amr,
+      amr: spAmr,
       acr: interactionAcr,
     });
   }

--- a/back/apps/core-fca-low/src/controllers/oidc-client.controller.spec.ts
+++ b/back/apps/core-fca-low/src/controllers/oidc-client.controller.spec.ts
@@ -316,7 +316,8 @@ describe("OidcClientController", () => {
         "user@example.com",
       );
       expect(userSession.set).toHaveBeenNthCalledWith(2, {
-        amr: "amr-value",
+        spAmr: "amr-value",
+        idpAmr: "amr-value",
         idpIdToken: "id-token",
         idpAcr: "acr-value",
       });
@@ -449,7 +450,8 @@ describe("OidcClientController", () => {
         "idp123",
       );
       expect(userSession.set).toHaveBeenCalledWith({
-        amr: "amr-value",
+        idpAmr: "amr-value",
+        spAmr: "amr-value",
         idpIdToken: "id-token",
         idpAcr: "acr-value",
       });

--- a/back/apps/core-fca-low/src/controllers/oidc-client.controller.ts
+++ b/back/apps/core-fca-low/src/controllers/oidc-client.controller.ts
@@ -145,9 +145,11 @@ export class OidcClientController {
       spId,
       spName,
     });
+    const { amr } = claims;
 
     userSession.set({
-      amr: claims.amr,
+      idpAmr: amr,
+      spAmr: amr,
       idpIdToken: idToken,
       idpAcr: claims.acr,
     });

--- a/back/apps/core-fca-low/src/dto/user-session/user-session.dto.ts
+++ b/back/apps/core-fca-low/src/dto/user-session/user-session.dto.ts
@@ -41,7 +41,12 @@ export class UserSession {
   @IsOptional()
   @IsArray()
   @Expose()
-  readonly amr?: string[];
+  readonly idpAmr?: string[];
+
+  @IsOptional()
+  @IsArray()
+  @Expose()
+  readonly spAmr?: string[];
 
   @IsOptional()
   @IsBoolean()

--- a/back/libs/logger-plugins/src/services/logger-session.service.ts
+++ b/back/libs/logger-plugins/src/services/logger-session.service.ts
@@ -15,7 +15,8 @@ export class LoggerSessionService implements LoggerPluginServiceInterface {
 
     const sessionId = sessionService.getId();
     const {
-      amr,
+      spAmr,
+      idpAmr,
       browsingSessionId,
       interactionId,
       interactionAcr,
@@ -34,7 +35,8 @@ export class LoggerSessionService implements LoggerPluginServiceInterface {
     } = sessionService.get<UserSession>("User") || {};
 
     const context = {
-      amr,
+      spAmr,
+      idpAmr,
       browsingSessionId,
       idpAcr,
       idpBelongingPopulation: idpIdentity?.belonging_population,

--- a/back/libs/oidc-acr/src/oidc-acr.service.spec.ts
+++ b/back/libs/oidc-acr/src/oidc-acr.service.spec.ts
@@ -144,7 +144,7 @@ describe("OidcAcrService", () => {
 
       const result = service.computeCanAcrBeSatisfiedByPcf({
         spEssentialAcr: "openid eidas1-mfa",
-        amr: ["pwd"],
+        idpAmr: ["pwd"],
         isOtpEmailEnabled: true,
       });
 
@@ -154,7 +154,7 @@ describe("OidcAcrService", () => {
     it("should return false when eidas1-mfa is missing", () => {
       const result = service.computeCanAcrBeSatisfiedByPcf({
         spEssentialAcr: "openid",
-        amr: ["pwd"],
+        idpAmr: ["pwd"],
         isOtpEmailEnabled: true,
       });
 
@@ -163,7 +163,7 @@ describe("OidcAcrService", () => {
     it("should return false when spEssentialAcr is empty", () => {
       const result = service.computeCanAcrBeSatisfiedByPcf({
         spEssentialAcr: undefined,
-        amr: ["pwd"],
+        idpAmr: ["pwd"],
         isOtpEmailEnabled: true,
       });
 
@@ -173,7 +173,7 @@ describe("OidcAcrService", () => {
     it("should return false when amr contains mail", () => {
       const result = service.computeCanAcrBeSatisfiedByPcf({
         spEssentialAcr: "eidas1-mfa",
-        amr: ["mail"],
+        idpAmr: ["mail"],
         isOtpEmailEnabled: true,
       });
 
@@ -183,7 +183,7 @@ describe("OidcAcrService", () => {
     it("should return false when isOtpEmailEnabled is false", () => {
       const result = service.computeCanAcrBeSatisfiedByPcf({
         spEssentialAcr: "eidas1-mfa",
-        amr: ["pwd"],
+        idpAmr: ["pwd"],
         isOtpEmailEnabled: false,
       });
 
@@ -237,8 +237,8 @@ describe("OidcAcrService", () => {
       const userSessionMock = {
         idpAcr: "eidas1",
         isEmailVerifiedByPcf: false,
-        amr: ["pwd"],
-      } as Pick<UserSession, "idpAcr" | "isEmailVerifiedByPcf" | "amr">;
+        idpAmr: ["pwd"],
+      } as Pick<UserSession, "idpAcr" | "isEmailVerifiedByPcf" | "idpAmr">;
 
       // When
       const result = service.isEssentialAcrSatisfied(
@@ -270,8 +270,8 @@ describe("OidcAcrService", () => {
       const userSessionMock = {
         idpAcr: "eidas1",
         isEmailVerifiedByPcf: true,
-        amr: ["pwd"],
-      } as Pick<UserSession, "idpAcr" | "isEmailVerifiedByPcf" | "amr">;
+        idpAmr: ["pwd"],
+      } as Pick<UserSession, "idpAcr" | "isEmailVerifiedByPcf" | "idpAmr">;
 
       // When
       const result = service.isEssentialAcrSatisfied(
@@ -303,8 +303,8 @@ describe("OidcAcrService", () => {
       const userSessionMock = {
         idpAcr: "eidas2",
         isEmailVerifiedByPcf: true,
-        amr: ["pwd"],
-      } as Pick<UserSession, "idpAcr" | "isEmailVerifiedByPcf" | "amr">;
+        idpAmr: ["pwd"],
+      } as Pick<UserSession, "idpAcr" | "isEmailVerifiedByPcf" | "idpAmr">;
 
       // When
       const result = service.isEssentialAcrSatisfied(
@@ -336,8 +336,8 @@ describe("OidcAcrService", () => {
       const userSessionMock = {
         idpAcr: "eidas1",
         isEmailVerifiedByPcf: true,
-        amr: ["pwd"],
-      } as Pick<UserSession, "idpAcr" | "isEmailVerifiedByPcf" | "amr">;
+        idpAmr: ["pwd"],
+      } as Pick<UserSession, "idpAcr" | "isEmailVerifiedByPcf" | "idpAmr">;
 
       // When
       const result = service.isEssentialAcrSatisfied(

--- a/back/libs/oidc-acr/src/oidc-acr.service.ts
+++ b/back/libs/oidc-acr/src/oidc-acr.service.ts
@@ -27,10 +27,10 @@ export class OidcAcrService {
     idpAcr,
     spEssentialAcr,
     isEmailVerifiedByPcf,
-    amr,
+    idpAmr,
   }: Pick<
     UserSession,
-    "idpAcr" | "spEssentialAcr" | "isEmailVerifiedByPcf" | "amr"
+    "idpAcr" | "spEssentialAcr" | "isEmailVerifiedByPcf" | "idpAmr"
   >): string | undefined {
     const spEssentialAcrValues = spEssentialAcr?.split(" ") || [];
     const { supportedAcrValues } =
@@ -50,7 +50,7 @@ export class OidcAcrService {
       return supportedIdpAcr;
     }
 
-    if (amr?.includes("mail") || !isEmailVerifiedByPcf) {
+    if (idpAmr?.includes("mail") || !isEmailVerifiedByPcf) {
       return undefined;
     }
 
@@ -70,15 +70,15 @@ export class OidcAcrService {
 
   computeCanAcrBeSatisfiedByPcf({
     spEssentialAcr,
-    amr,
+    idpAmr,
     isOtpEmailEnabled,
   }: {
     spEssentialAcr?: string;
-    amr?: string[];
+    idpAmr?: string[];
     isOtpEmailEnabled: boolean;
   }) {
     const spEssentialAcrValues = spEssentialAcr?.split(" ") || [];
-    if (amr?.includes("mail")) {
+    if (idpAmr?.includes("mail")) {
       return false;
     }
     if (!isOtpEmailEnabled) {
@@ -114,7 +114,10 @@ export class OidcAcrService {
 
   isEssentialAcrSatisfied(
     interaction: ExtendedInteraction,
-    userSession: Pick<UserSession, "idpAcr" | "isEmailVerifiedByPcf" | "amr">,
+    userSession: Pick<
+      UserSession,
+      "idpAcr" | "isEmailVerifiedByPcf" | "idpAmr"
+    >,
   ) {
     const areThereEssentialAcrRequested =
       this.computeAreThereEssentialAcrRequested(interaction);
@@ -131,7 +134,7 @@ export class OidcAcrService {
       idpAcr: userSession.idpAcr,
       spEssentialAcr,
       isEmailVerifiedByPcf: userSession.isEmailVerifiedByPcf,
-      amr: userSession.amr,
+      idpAmr: userSession.idpAmr,
     });
 
     if (!interactionAcr) {

--- a/quality/cypress/integration/usager/connexion-email-verification.feature
+++ b/quality/cypress/integration/usager/connexion-email-verification.feature
@@ -39,14 +39,15 @@ Fonctionnalité: Connexion Usager - Email verification
     Et que je rentre le code de confirmation " 00000000 "
     Alors je vois le message d'erreur "Le code rentré est invalide ou expiré."
 
-
   Scénario: on vérifie mon e-mail, je rentre le bon code
     Etant donné que je navigue sur la page fournisseur de service
     Et que la base de données est réinitialisée
     Et que le fournisseur de service requiert le claim "acr" avec les valeurs "eidas0-mfa eidas1-mfa eidas2 eidas3"
+    Et que le fournisseur de service requiert le claim "amr"
     Et que je clique sur le bouton ProConnect
     Et que j'entre l'email "pc@fia2.fr"
     Et que je clique sur le bouton de connexion
+    Et que j'utilise un compte usager dont le FI fournit un amr "pwd"
     Et que le fournisseur d'identité garantit un niveau de sécurité "eidas1"
     Et que la page du FI n'affiche pas de requestedAcrs
     Et que je m'authentifie
@@ -55,6 +56,7 @@ Fonctionnalité: Connexion Usager - Email verification
     Et que je vois un bouton "Recevoir un nouveau code" désactivé
     Et que je rentre le code de confirmation reçu par e-mail
     Alors la cinématique a utilisé le niveau de sécurité "eidas1-mfa"
+    Et la cinématique a renvoyé l'amr "pwd,mail"
 
   Scénario: la session est ré-utilisée si un autre fournisseur de service demande le même ACR
     Etant donné que je navigue sur la page fournisseur de service "premier FS"

--- a/quality/cypress/support/common/helpers/sp-claims-helper.ts
+++ b/quality/cypress/support/common/helpers/sp-claims-helper.ts
@@ -8,6 +8,12 @@ const defaultUserClaims = getDefaultUser();
 const getUserInfo = (): ChainableElement =>
   cy.get("#userinfo").invoke("text").then(JSON.parse);
 
+export const getIdToken = (): ChainableElement =>
+  cy.get("#idtoken").invoke("text").then(JSON.parse);
+
+export const getIdTokenProperty = (property: string): ChainableElement =>
+  getIdToken().then((idToken) => idToken[property]);
+
 export const getUserInfoProperty = (property: string): ChainableElement =>
   getUserInfo().then((userInfo) => userInfo[property]);
 

--- a/quality/cypress/support/common/helpers/sp-custom-params-helper.ts
+++ b/quality/cypress/support/common/helpers/sp-custom-params-helper.ts
@@ -97,6 +97,7 @@ export const setAsRequestedClaims = (
 ): void => {
   updateCustomParams((customParams) => {
     customParams["claims"]["id_token"] = {
+      ...customParams["claims"]["id_token"],
       [claim]: { essential: true },
     };
 

--- a/quality/cypress/support/usager/steps/service-provider-steps.ts
+++ b/quality/cypress/support/usager/steps/service-provider-steps.ts
@@ -5,6 +5,8 @@ import {
   checkMandatoryData,
   checkNoExtraClaims,
   getIdentityProviderByDescription,
+  getIdToken,
+  getIdTokenProperty,
   getScopeByDescription,
   getServiceProviderByDescription,
   getUserInfoProperty,
@@ -202,11 +204,13 @@ Then(
 );
 
 Then("la cinématique a renvoyé l'amr {string}", function (amrValue: string) {
-  cy.contains(`"amr": [\n    "${amrValue}"\n  ],`);
+  getIdTokenProperty("amr").should("deep.equal", amrValue.split(","));
 });
 
 Then("la cinématique n'a pas renvoyé d'amr", function () {
-  cy.get("#idtoken").contains('"amr": ').should("not.exist");
+  getIdToken().then((idToken) => {
+    expect(idToken).to.not.have.property("amr");
+  });
 });
 
 Then(


### PR DESCRIPTION
**Problem**
When ProConnect Fédération sends an email OTP to the user for MFA, the Service Provider is not informed that an email verification was performed.

**Proposal**
Add `mail` to the `amr` claim returned to the Service Provider to indicate that the user's email address was verified.