### PR TITLE
🐛 fix: rewrite attached email domains migration

### DIFF
--- a/back/migrations/20260807183716-rename_fqdns_to_attachedEmailDomains.ts
+++ b/back/migrations/20260807183716-rename_fqdns_to_attachedEmailDomains.ts
@@ -1,11 +1,20 @@
 import type { Db } from "mongodb";
 
 export const up = async (db: Db) => {
-  await db
-    .collection("provider")
-    .updateMany({ fqdns: { $exists: true } }, [
-      { $set: { attachedEmailDomains: "$fqdns" } },
-    ]);
+  const collection = db.collection("provider");
+  const identityProviders = await collection
+    .find({ fqdns: { $exists: true } })
+    .toArray();
+  console.log(
+    `Found ${identityProviders.length} identity providers with fqdns field.`,
+  );
+  for (const identityProvider of identityProviders) {
+    const fqdns = identityProvider.fqdns;
+    await collection.updateOne(
+      { _id: identityProvider._id },
+      { $set: { attachedEmailDomains: fqdns } },
+    );
+  }
 };
 
 export const down = async (db: Db) => {


### PR DESCRIPTION
**Problem**
The migration from `fqdns` to `attachedEmailDomains` failed, leaving `attachedEmailDomains` empty for all Identity Providers.

**Proposal**
Rewrite the migration in JavaScript instead of using a pure MongoDB query, and add logs to track the migration and facilitate troubleshooting.