### PR TITLE
🐛 Recompute countdown from end date instead of decrementing on each tick

### DIFF
--- a/back/apps/core-fca-low/src/public/js/disabled-with-countdown.js
+++ b/back/apps/core-fca-low/src/public/js/disabled-with-countdown.js
@@ -10,8 +10,13 @@ document.addEventListener(
 
       try {
         const endDateInSeconds = new Date(rawEndDate).getTime() / 1000;
-        const nowInSeconds = new Date().getTime() / 1000;
-        let secondsToEndDate = Math.round(endDateInSeconds - nowInSeconds);
+
+        const getSecondsToEndDate = () => {
+          const nowInSeconds = new Date().getTime() / 1000;
+          return Math.round(endDateInSeconds - nowInSeconds);
+        };
+
+        let secondsToEndDate = getSecondsToEndDate();
 
         if (secondsToEndDate <= 0) {
           element.disabled = false;
@@ -21,6 +26,7 @@ document.addEventListener(
         countdownContainer.classList.remove("fr-hidden");
         element.disabled = true;
         const updateCountdown = () => {
+          secondsToEndDate = getSecondsToEndDate();
           if (secondsToEndDate > 0) {
             const minutes = Math.floor(secondsToEndDate / 60);
             const seconds = String(secondsToEndDate % 60).padStart(2, "0");
@@ -34,10 +40,7 @@ document.addEventListener(
 
         updateCountdown();
 
-        let intervalId = setInterval(function () {
-          secondsToEndDate--;
-          updateCountdown();
-        }, 1000);
+        let intervalId = setInterval(updateCountdown, 1000);
       } catch (error) {
         console.error(error);
         // silently fails

--- a/back/apps/core-fca-low/src/public/js/disabled-with-countdown.js
+++ b/back/apps/core-fca-low/src/public/js/disabled-with-countdown.js
@@ -1,3 +1,27 @@
+const getSecondsUntil = (endDateInSeconds) =>
+  Math.round(endDateInSeconds - Date.now() / 1000);
+
+const updateCountdown = (
+  endDateInSeconds,
+  countdownContainer,
+  countdownText,
+  element,
+  intervalId,
+) => {
+  const secondsToEndDate = getSecondsUntil(endDateInSeconds);
+
+  if (secondsToEndDate > 0) {
+    const minutes = Math.floor(secondsToEndDate / 60);
+    const seconds = String(secondsToEndDate % 60).padStart(2, "0");
+    countdownText.textContent = `Disponible dans ${minutes}:${seconds}min`;
+    return;
+  }
+
+  countdownContainer.classList.add("fr-hidden");
+  element.disabled = false;
+  if (intervalId) clearInterval(intervalId);
+};
+
 document.addEventListener(
   "DOMContentLoaded",
   function () {
@@ -11,36 +35,33 @@ document.addEventListener(
       try {
         const endDateInSeconds = new Date(rawEndDate).getTime() / 1000;
 
-        const getSecondsToEndDate = () => {
-          const nowInSeconds = new Date().getTime() / 1000;
-          return Math.round(endDateInSeconds - nowInSeconds);
-        };
+        const secondsToEndDate = getSecondsUntil(endDateInSeconds);
 
-        let secondsToEndDate = getSecondsToEndDate();
-
-        if (secondsToEndDate <= 0) {
+        if (secondsToEndDate < 1) {
           element.disabled = false;
           return;
         }
 
         countdownContainer.classList.remove("fr-hidden");
         element.disabled = true;
-        const updateCountdown = () => {
-          secondsToEndDate = getSecondsToEndDate();
-          if (secondsToEndDate > 0) {
-            const minutes = Math.floor(secondsToEndDate / 60);
-            const seconds = String(secondsToEndDate % 60).padStart(2, "0");
-            countdownText.textContent = `Disponible dans ${minutes}:${seconds}min`;
-          } else {
-            countdownContainer.classList.add("fr-hidden");
-            element.disabled = false;
-            clearInterval(intervalId);
-          }
-        };
+        let intervalId;
+        updateCountdown(
+          endDateInSeconds,
+          countdownContainer,
+          countdownText,
+          element,
+          intervalId,
+        );
 
-        updateCountdown();
-
-        let intervalId = setInterval(updateCountdown, 1000);
+        intervalId = setInterval(() => {
+          updateCountdown(
+            endDateInSeconds,
+            countdownContainer,
+            countdownText,
+            element,
+            intervalId,
+          );
+        }, 1000);
       } catch (error) {
         console.error(error);
         // silently fails


### PR DESCRIPTION
**Problem:**
setInterval decremented a local counter each tick instead of recalculating
from the end date, causing the countdown to drift over time.

**Fix:**
Recompute remaining seconds from the end date on every tick instead of
decrementing manually.