### PR TITLE
🚑️ Build back docker image with assets and css

### DIFF
--- a/back/Dockerfile
+++ b/back/Dockerfile
@@ -39,6 +39,7 @@ COPY libs ./libs
 
 RUN yarn run build
 COPY apps/core-fca-low/src/views dist/apps/core-fca-low/views
+COPY apps/core-fca-low/src/public dist/apps/core-fca-low/public
 
 FROM node:24.16.0-alpine AS production
 


### PR DESCRIPTION
## Context 

Public folder content is not deployed when the Docker image is built. The federation app does not work correctly: CSS and images fail to load.

No tests could verify this because we do not test image builds with Federation, and the Kubernetes CI does not test snapshots.

## Propostion

As a first quickfix, to be able to deploy again, we propose to add the missing public folder in back Dockerfile.