### PR TITLE
🔒️ Fix go-back link blocked by strict CSP script-src

### DIFF
--- a/back/apps/core-fca-low/src/public/js/go-back.js
+++ b/back/apps/core-fca-low/src/public/js/go-back.js
@@ -1,0 +1,7 @@
+document.addEventListener("DOMContentLoaded", () => {
+  document.querySelectorAll(".go-back-link").forEach((el) => {
+    el.addEventListener("click", () => {
+      history.back();
+    });
+  });
+});

--- a/back/apps/core-fca-low/src/views/identity-provider-selection.ejs
+++ b/back/apps/core-fca-low/src/views/identity-provider-selection.ejs
@@ -45,9 +45,9 @@
               Continuer
             </button>
             <div class="fr-mt-2w fr-grid-row fr-grid-row--center">
-            <a href="javascript:history.back()" class="fr-btn fr-btn--tertiary-no-outline go-back-link">
+            <button type="button" class="fr-btn fr-btn--tertiary-no-outline go-back-link">
               Revenir à l'étape précédente
-            </a>
+            </button>
           </div>
           </form>
           <hr class="fr-mt-2w" />
@@ -59,6 +59,7 @@
       </div>
     </div>
   </main>
+  <script type="text/javascript" src="/js/go-back.js"></script>
   <%- include('includes/footer.ejs') %> <%- include('includes/scripts.ejs') %>
 </body>
 


### PR DESCRIPTION
**Problem:**
The go-back button used a `javascript:history.back()` href, which is blocked by the CSP's script-src directive since #1362 removed unsafe-inline.

**Fix:**
Replace the link with a `<button>` and move `history.back()` to an external script (go-back.js).