### PR TITLE
💚 Fixing grist communication errors in CI

### DIFF
--- a/admin/src/grist-publisher/grist-publisher.service.spec.ts
+++ b/admin/src/grist-publisher/grist-publisher.service.spec.ts
@@ -52,6 +52,47 @@ describe("GristPublisherService", () => {
   });
 
   describe("publishIdentityProviders", () => {
+    it("should return false when Grist records response does not contain a records array", async () => {
+      const mockGristConfig = {
+        ...baseMockGristConfig,
+        gristIdentityProvidersTableId: "identity-providers-table",
+        gristNetworkName: "test-network",
+        gristEnvironmentName: "test-env",
+      };
+      (configService.get as jest.Mock).mockReturnValue(mockGristConfig);
+
+      (global.fetch as jest.Mock).mockResolvedValueOnce({
+        ok: true,
+        json: jest.fn().mockResolvedValue({ message: "unexpected payload" }),
+      });
+
+      await expect(service.publishIdentityProviders([])).resolves.toBe(false);
+      expect(loggerService.error).toHaveBeenCalledWith(
+        "Unexpected Grist records response shape for table identity-providers-table",
+      );
+    });
+
+    it("should return false when Grist records fetch fails", async () => {
+      const mockGristConfig = {
+        ...baseMockGristConfig,
+        gristIdentityProvidersTableId: "identity-providers-table",
+        gristNetworkName: "test-network",
+        gristEnvironmentName: "test-env",
+      };
+      (configService.get as jest.Mock).mockReturnValue(mockGristConfig);
+
+      (global.fetch as jest.Mock).mockResolvedValueOnce({
+        ok: false,
+        statusText: "Unauthorized",
+        text: jest.fn().mockResolvedValue("invalid api key"),
+      });
+
+      await expect(service.publishIdentityProviders([])).resolves.toBe(false);
+      expect(loggerService.error).toHaveBeenCalledWith(
+        "Could not fetch Grist records: Unauthorized (invalid api key)",
+      );
+    });
+
     it("should add a new identity provider when it does not exist in Grist", async () => {
       const mockGristConfig = {
         ...baseMockGristConfig,

--- a/admin/src/grist-publisher/grist-publisher.service.ts
+++ b/admin/src/grist-publisher/grist-publisher.service.ts
@@ -15,12 +15,17 @@ export class GristPublisherService {
     private readonly config: ConfigService,
   ) {}
 
-  async publishServiceProviders(serviceProviders: ServiceProviderFromDb[]) {
+  async publishServiceProviders(
+    serviceProviders: ServiceProviderFromDb[],
+  ): Promise<boolean> {
     const { gristServiceProvidersTableId } = this.config.get("grist");
     const previousServiceProviderRecords =
       await this.getProviderRecordsFromGrist<ServiceProviderGristRecord>(
         gristServiceProvidersTableId,
       );
+    if (!previousServiceProviderRecords) {
+      return false;
+    }
 
     const nextServiceProviderRecords = serviceProviders.map((serviceProvider) =>
       this.transformServiceProviderToGristRecord(serviceProvider),
@@ -37,13 +42,18 @@ export class GristPublisherService {
     );
   }
 
-  async publishIdentityProviders(identityProviders: IdentityProviderFromDb[]) {
+  async publishIdentityProviders(
+    identityProviders: IdentityProviderFromDb[],
+  ): Promise<boolean> {
     const { gristIdentityProvidersTableId } = this.config.get("grist");
 
     const previousIdentityProviderRecords =
       await this.getProviderRecordsFromGrist<IdentityProviderGristRecord>(
         gristIdentityProvidersTableId,
       );
+    if (!previousIdentityProviderRecords) {
+      return false;
+    }
 
     const nextIdentityProviderRecords = identityProviders.map(
       (identityProvider) =>
@@ -113,8 +123,8 @@ export class GristPublisherService {
   private computeRecordUpdates<
     providerT extends { UID: string; Reseau: string; Environnement: string },
   >(
-    previousGristRecords: GristRecord<providerT>[],
-    nextProviderRecords: providerT[],
+    previousGristRecords: GristRecord<providerT>[] = [],
+    nextProviderRecords: providerT[] = [],
   ) {
     const recordIdsToDelete: number[] = [];
     const recordsToUpsert: providerT[] = [];
@@ -173,7 +183,7 @@ export class GristPublisherService {
       recordsToUpsert: providerT[];
     },
     tableId: string,
-  ) {
+  ): Promise<boolean> {
     const successes = await Promise.all([
       this.deleteGristRecords(recordIdsToDelete, tableId),
       this.upsertGristRecords(recordsToUpsert, tableId),
@@ -182,7 +192,9 @@ export class GristPublisherService {
     return successes.every((success) => success);
   }
 
-  private async getProviderRecordsFromGrist<providerT>(tableId: string) {
+  private async getProviderRecordsFromGrist<providerT>(
+    tableId: string,
+  ): Promise<GristRecord<providerT>[] | null> {
     const {
       gristDomain,
       gristDocId,
@@ -203,8 +215,21 @@ export class GristPublisherService {
         Authorization: `Bearer ${gristApiKey}`,
       },
     });
+    if (!response.ok) {
+      const responseText = await response.text();
+      this.logger.error(
+        `Could not fetch Grist records: ${response.statusText} (${responseText})`,
+      );
+      return null;
+    }
 
     const data = await response.json();
+    if (!Array.isArray(data?.records)) {
+      this.logger.error(
+        `Unexpected Grist records response shape for table ${tableId}`,
+      );
+      return null;
+    }
 
     return data.records as GristRecord<providerT>[];
   }

--- a/admin/src/service-provider/service-provider.service.ts
+++ b/admin/src/service-provider/service-provider.service.ts
@@ -264,7 +264,7 @@ export class ServiceProviderService {
     };
   }
 
-  private async publishServiceProvidersToGrist() {
+  private async publishServiceProvidersToGrist(): Promise<boolean> {
     const allServiceProviders = await this.serviceProviderRepository.find();
     return this.gristPublisherService.publishServiceProviders(
       allServiceProviders,


### PR DESCRIPTION
**Context**

The CI fails consistently whenever upsert operations occur in the admin panel. When a new entity is created, a call is made to Grist expecting a list in response. However, Grist currently returns {"message": "document worker not present"} instead.

As a result, GristPublisherService attempts to iterate over this object, raising a previousGristRecords is not iterable error and failing the test suite. The API call to Grist itself succeeds, but the response body is an error payload rather than an iterable array.

**Proposed Solution**

This PR introduces a workaround to prevent hard failures—at least temporarily—when the Grist connection is established but no document worker is available.

- Updates the function to check the response structure and return false early, before any iteration is attempted.
- Relying on existing failure handling, returning false prevents the code from crashing and allows the application to gracefully display the standard "Grist sync failed" notification, without blocking the core entity creation event.
- Log the grist error message