### PR TITLE
✨ Allows custom user-info properties on IDP mocks

### DIFF
--- a/mock-identity-provider/src/app.ts
+++ b/mock-identity-provider/src/app.ts
@@ -12,7 +12,6 @@ import {
   parseFormDataValue,
   userAttributesSchema,
 } from "./user-data.ts";
-
 export type { EnvConfig };
 
 const loginBodySchema = userAttributesSchema.extend({
@@ -52,18 +51,32 @@ export function createApp(config: EnvConfig) {
     const defaultUser = getDefaultUser();
 
     if (prompt.name === "login") {
+      const acr =
+        get(prompt.details, "acr.value") ||
+        get(prompt.details, "acr.values.0") ||
+        (params?.["acr_values"] as string | undefined)?.split(" ")[0] ||
+        "eidas1";
+      const amr = "pwd";
+      const email = params?.["login_hint"] || defaultUser.email;
+
       return res.render("index", {
         title: config.APP_NAME,
         stylesheetUrl: config.STYLESHEET_URL,
         uid,
-        email: params?.["login_hint"] || defaultUser.email,
+        email,
         defaultUser,
-        acr:
-          get(prompt.details, "acr.value") ||
-          get(prompt.details, "acr.values.0") ||
-          (params?.["acr_values"] as string | undefined)?.split(" ")[0] ||
-          "eidas1",
-        amr: "pwd",
+        acr,
+        amr,
+        defaultAttributes: {
+          email,
+          given_name: defaultUser.given_name,
+          usual_name: defaultUser.usual_name,
+          siret: defaultUser.siret,
+          sub: defaultUser.sub,
+          phone_number: defaultUser.phone_number,
+          acr,
+          amr,
+        },
         debugInfo: JSON.stringify(
           {
             oidcProviderPrompt: prompt,
@@ -80,12 +93,38 @@ export function createApp(config: EnvConfig) {
     return next(new Error("unsupported_prompt"));
   });
 
+  function parseAttributesJson(raw: unknown): Record<string, unknown> {
+    if (typeof raw !== "string" || raw.trim() === "") return {};
+
+    try {
+      const parsed = JSON.parse(raw);
+      if (
+        typeof parsed !== "object" ||
+        parsed === null ||
+        Array.isArray(parsed)
+      ) {
+        throw new Error("Le JSON doit représenter un objet");
+      }
+      return parsed as Record<string, unknown>;
+    } catch (err) {
+      throw new Error(
+        `Impossible de parser le champ "attributes" : ${(err as Error).message}`,
+      );
+    }
+  }
+
   async function normalLogin(req: Request, res: Response) {
     const {
       prompt: { name },
     } = await provider.interactionDetails(req, res);
     assert.equal(name, "login");
-    const { acr, amr, ...userAttributes } = loginBodySchema.parse(req.body);
+
+    const { error, error_description, ...formFields } = req.body;
+    const attributes = parseAttributesJson(req.body["attributes"]);
+    const { acr, amr, ...userAttributes } = loginBodySchema.parse({
+      ...formFields,
+      ...attributes,
+    });
     const userId = createUser(userAttributes);
 
     const loginResult: {
@@ -114,7 +153,6 @@ export function createApp(config: EnvConfig) {
     };
     return result;
   }
-
   app.post(
     "/interaction/:uid/login",
     urlencoded({ extended: false }),
@@ -130,7 +168,58 @@ export function createApp(config: EnvConfig) {
     },
   );
 
+  app.post(
+    "/interaction/:uid/login/advanced",
+    urlencoded({ extended: false }),
+    async (req, res) => {
+      let result;
+      try {
+        result = await advancedLogin(req, res);
+      } catch (err) {
+        result = {
+          error: "invalid_request",
+          error_description: (err as Error).message,
+        };
+      }
+      await provider.interactionFinished(req, res, result);
+    },
+  );
+
   app.use(provider.callback());
+
+  async function advancedLogin(req: Request, res: Response) {
+    const {
+      prompt: { name },
+    } = await provider.interactionDetails(req, res);
+    assert.equal(name, "login");
+
+    const attributes = parseAttributesJson(req.body["attributes"]);
+    const { acr, amr, ...userAttributes } = loginBodySchema.parse(attributes);
+    const userId = createUser(userAttributes);
+
+    const loginResult: {
+      accountId: string;
+      acr?: any;
+      amr?: string[];
+      ts: number;
+    } = {
+      accountId: userId,
+      ts: Date.now(),
+    };
+
+    if (acr !== "") {
+      loginResult.acr = parseFormDataValue(acr);
+    }
+
+    if (amr !== "") {
+      loginResult.amr = amr.split(",");
+    }
+
+    return {
+      login: loginResult,
+      consent: {},
+    };
+  }
 
   return { app };
 }

--- a/mock-identity-provider/src/app.ts
+++ b/mock-identity-provider/src/app.ts
@@ -12,6 +12,8 @@ import {
   parseFormDataValue,
   userAttributesSchema,
 } from "./user-data.ts";
+import type { UserAttributes } from "./user-data.ts";
+
 export type { EnvConfig };
 
 const loginBodySchema = userAttributesSchema.extend({
@@ -34,11 +36,55 @@ export function createApp(config: EnvConfig) {
     res.json({ status: "ok" });
   });
 
-  const provider = new Provider(`https://${config.FQDN}`, {
-    adapter: MemoryAdapter,
-    ...configuration(config),
-  });
-  provider.proxy = true;
+  const customClaimNames = new Set<string>();
+
+  const createProvider = () => {
+    const providerConfig = configuration(config);
+    // We let users add custom fields in advanced login mode to simulate
+    // custom IdP user info properties.
+    // Reusing the default `openid` scope lets us carry them without adding
+    // admin-facing configuration just for the mock.
+    const openidClaims = [...(providerConfig.claims?.["openid"] ?? [])];
+
+    customClaimNames.forEach((claimName) => {
+      openidClaims.push(claimName);
+    });
+
+    providerConfig.claims = {
+      ...providerConfig.claims,
+      openid: openidClaims,
+    };
+
+    const provider = new Provider(`https://${config.FQDN}`, {
+      adapter: MemoryAdapter,
+      ...providerConfig,
+    });
+    provider.proxy = true;
+    return provider;
+  };
+
+  let provider = createProvider();
+
+  const registerCustomClaims = (userAttributes: Record<string, unknown>) => {
+    Object.keys(userAttributes).forEach((claimName) => {
+      if (
+        !customClaimNames.has(claimName) &&
+        ![
+          "email",
+          "given_name",
+          "usual_name",
+          "siret",
+          "sub",
+          "phone_number",
+          "acr",
+          "amr",
+        ].includes(claimName)
+      ) {
+        customClaimNames.add(claimName);
+        provider = createProvider();
+      }
+    });
+  };
 
   app.get("/interaction/:uid", async (req, res, next) => {
     const { uid, prompt, params, session } = await provider.interactionDetails(
@@ -67,16 +113,20 @@ export function createApp(config: EnvConfig) {
         defaultUser,
         acr,
         amr,
-        defaultAttributes: {
-          email,
-          given_name: defaultUser.given_name,
-          usual_name: defaultUser.usual_name,
-          siret: defaultUser.siret,
-          sub: defaultUser.sub,
-          phone_number: defaultUser.phone_number,
-          acr,
-          amr,
-        },
+        defaultParamsValue: JSON.stringify(
+          {
+            email,
+            given_name: defaultUser.given_name,
+            usual_name: defaultUser.usual_name,
+            siret: defaultUser.siret,
+            sub: defaultUser.sub,
+            phone_number: defaultUser.phone_number,
+            acr,
+            amr,
+          },
+          null,
+          2,
+        ),
         debugInfo: JSON.stringify(
           {
             oidcProviderPrompt: prompt,
@@ -93,38 +143,12 @@ export function createApp(config: EnvConfig) {
     return next(new Error("unsupported_prompt"));
   });
 
-  function parseAttributesJson(raw: unknown): Record<string, unknown> {
-    if (typeof raw !== "string" || raw.trim() === "") return {};
-
-    try {
-      const parsed = JSON.parse(raw);
-      if (
-        typeof parsed !== "object" ||
-        parsed === null ||
-        Array.isArray(parsed)
-      ) {
-        throw new Error("Le JSON doit représenter un objet");
-      }
-      return parsed as Record<string, unknown>;
-    } catch (err) {
-      throw new Error(
-        `Impossible de parser le champ "attributes" : ${(err as Error).message}`,
-      );
-    }
-  }
-
-  async function normalLogin(req: Request, res: Response) {
+  async function handleBasicLogin(req: Request, res: Response) {
     const {
       prompt: { name },
     } = await provider.interactionDetails(req, res);
     assert.equal(name, "login");
-
-    const { error, error_description, ...formFields } = req.body;
-    const attributes = parseAttributesJson(req.body["attributes"]);
-    const { acr, amr, ...userAttributes } = loginBodySchema.parse({
-      ...formFields,
-      ...attributes,
-    });
+    const { acr, amr, ...userAttributes } = loginBodySchema.parse(req.body);
     const userId = createUser(userAttributes);
 
     const loginResult: {
@@ -161,7 +185,7 @@ export function createApp(config: EnvConfig) {
       if (req.body["error"]) {
         result = req.body;
       } else {
-        result = await normalLogin(req, res);
+        result = await handleBasicLogin(req, res);
       }
 
       await provider.interactionFinished(req, res, result);
@@ -169,12 +193,13 @@ export function createApp(config: EnvConfig) {
   );
 
   app.post(
-    "/interaction/:uid/login/advanced",
+    "/interaction/:uid/advanced-login",
     urlencoded({ extended: false }),
+
     async (req, res) => {
       let result;
       try {
-        result = await advancedLogin(req, res);
+        result = await handleAdvancedLogin(req, res);
       } catch (err) {
         result = {
           error: "invalid_request",
@@ -185,17 +210,23 @@ export function createApp(config: EnvConfig) {
     },
   );
 
-  app.use(provider.callback());
+  app.use((req, res, _next) => {
+    return provider.callback()(req, res);
+  });
 
-  async function advancedLogin(req: Request, res: Response) {
+  async function handleAdvancedLogin(req: Request, res: Response) {
     const {
       prompt: { name },
     } = await provider.interactionDetails(req, res);
     assert.equal(name, "login");
 
-    const attributes = parseAttributesJson(req.body["attributes"]);
-    const { acr, amr, ...userAttributes } = loginBodySchema.parse(attributes);
-    const userId = createUser(userAttributes);
+    const advancedLoginParams = JSON.parse(
+      req.body["advanced-login-params"] as string,
+    ) as Record<string, unknown>;
+
+    const { acr, amr, ...userAttributes } = advancedLoginParams;
+    const userId = createUser(userAttributes as UserAttributes);
+    registerCustomClaims(userAttributes);
 
     const loginResult: {
       accountId: string;
@@ -208,12 +239,14 @@ export function createApp(config: EnvConfig) {
     };
 
     if (acr !== "") {
-      loginResult.acr = parseFormDataValue(acr);
+      loginResult.acr = parseFormDataValue(acr as string);
     }
 
     if (amr !== "") {
-      loginResult.amr = amr.split(",");
+      loginResult.amr = (amr as string).split(",");
     }
+
+    console.log("loginResult:", loginResult);
 
     return {
       login: loginResult,

--- a/mock-identity-provider/src/index.ejs
+++ b/mock-identity-provider/src/index.ejs
@@ -17,7 +17,7 @@
             </div>
             <br>
             <details>
-                <summary id="open-custom-configuration">Usage avancé</summary>
+                <summary id="open-custom-configuration">Champs supplémentaires</summary>
                 <p><small>
                     Liste des valeurs qui seront typés en sortie de l'idp : 'true', 'false', 'null', 'undefined', 'empty', 'empty-array'. Les champs laissés vide ne seront pas renvoyés.
                 </small></p>
@@ -64,6 +64,22 @@
             <br>
             <button type="submit">Se connecter</button>
         </form>
+        <br>
+        <details>
+            <summary id="open-advanced-configuration">Usage avancé</summary>
+            <form action="/interaction/<%= locals.uid %>/login/advanced" method="post">
+                <p>
+                    Pour toute valeur custom, ajoutez ici vos clés/valeurs au format JSON.
+                </p>
+                <textarea
+                    name="attributes"
+                    cols="50"
+                    rows="12"
+                ><%= JSON.stringify(locals.defaultAttributes, null, 2) %></textarea>
+                <button id="advanced-connection">Connexion personnalisée</button>
+            </form>
+        </details>
+        <br>
         <details id="open-debug-info">
             <summary>Informations de débogage</summary>
             <pre><code><%= locals.debugInfo %></code></pre>

--- a/mock-identity-provider/src/index.ejs
+++ b/mock-identity-provider/src/index.ejs
@@ -67,15 +67,33 @@
         <br>
         <details>
             <summary id="open-advanced-configuration">Usage avancé</summary>
-            <form action="/interaction/<%= locals.uid %>/login/advanced" method="post">
-                <p>
-                    Pour toute valeur custom, ajoutez ici vos clés/valeurs au format JSON.
-                </p>
+            <form action="/interaction/<%= locals.uid %>/advanced-login" method="post">
                 <textarea
-                    name="attributes"
+                    name="advanced-login-params"
                     cols="50"
                     rows="12"
-                ><%= JSON.stringify(locals.defaultAttributes, null, 2) %></textarea>
+                ><%= locals.defaultParamsValue %></textarea>
+                </textarea>
+
+                <p>
+                    ProConnect Fédération reconnait par défaut
+                <a
+                    href="https://partenaires.proconnect.gouv.fr/docs/fournisseur-identite/format-user-info"
+                    target="_blank"
+                    rel="noopener external"
+                    >les valeurs suivantes</a
+                >.
+                </p>
+                <p>
+                    Les autres champs sont regroupés par ProConnect Fédération dans
+                <a
+                    href="https://partenaires.proconnect.gouv.fr/docs/fournisseur-service/custom-scope"
+                    target="_blank"
+                    rel="noopener external"
+                    >un champ custom</a
+                >.
+                </p>
+                
                 <button id="advanced-connection">Connexion personnalisée</button>
             </form>
         </details>

--- a/mock-identity-provider/src/oidc-provider-support/configuration.ts
+++ b/mock-identity-provider/src/oidc-provider-support/configuration.ts
@@ -45,7 +45,7 @@ export default function configuration(config: EnvConfig): Configuration {
         "website",
         "zoneinfo",
       ],
-      openid: ["sub"],
+      openid: ["sub", "idp_custom_attributes"],
       // ProConnect claims
       siret: ["siret"],
       // Deprecated ProConnect claims

--- a/mock-identity-provider/src/oidc-provider-support/configuration.ts
+++ b/mock-identity-provider/src/oidc-provider-support/configuration.ts
@@ -45,7 +45,7 @@ export default function configuration(config: EnvConfig): Configuration {
         "website",
         "zoneinfo",
       ],
-      openid: ["sub", "idp_custom_attributes"],
+      openid: ["sub"],
       // ProConnect claims
       siret: ["siret"],
       // Deprecated ProConnect claims

--- a/mock-identity-provider/src/user-data.ts
+++ b/mock-identity-provider/src/user-data.ts
@@ -50,19 +50,29 @@ export const getDefaultUser = () => {
 
 const userStorage = new QuickLRU({ maxSize: 1000 });
 
-export const userAttributesSchema = z.object({
-  email: z.string().optional().default(""),
-  given_name: z.string().optional().default(""),
-  usual_name: z.string().optional().default(""),
-  siret: z.string().optional().default(""),
-  sub: z.string().optional().default(""),
-  phone_number: z.string().optional().default(""),
-});
+export const userAttributesSchema = z
+  .object({
+    email: z.string().optional().default(""),
+    given_name: z.string().optional().default(""),
+    usual_name: z.string().optional().default(""),
+    siret: z.string().optional().default(""),
+    sub: z.string().optional().default(""),
+    phone_number: z.string().optional().default(""),
+  })
+  .passthrough();
 
 export type UserAttributes = z.infer<typeof userAttributesSchema>;
 
 export const createUser = (body: UserAttributes) => {
-  const { email, given_name, usual_name, siret, sub, phone_number } = body;
+  const {
+    email,
+    given_name,
+    usual_name,
+    siret,
+    sub,
+    phone_number,
+    ...customAttributes
+  } = body;
   const id = email + given_name + usual_name + siret + phone_number;
   // replace default property values, allowing substitution of a default value with an empty string
   const user = chain({
@@ -73,6 +83,9 @@ export const createUser = (body: UserAttributes) => {
     siret,
     sub,
     phone_number,
+    ...(Object.keys(customAttributes).length > 0
+      ? { idp_custom_attributes: customAttributes }
+      : {}),
   })
     // as per https://openid.net/specs/openid-connect-core-1_0.html#UserInfoResponse
     // > If a Claim is not returned, that Claim Name SHOULD be omitted from the JSON object representing the Claims;

--- a/mock-identity-provider/src/user-data.ts
+++ b/mock-identity-provider/src/user-data.ts
@@ -59,7 +59,7 @@ export const userAttributesSchema = z
     sub: z.string().optional().default(""),
     phone_number: z.string().optional().default(""),
   })
-  .passthrough();
+  .loose();
 
 export type UserAttributes = z.infer<typeof userAttributesSchema>;
 
@@ -73,6 +73,7 @@ export const createUser = (body: UserAttributes) => {
     phone_number,
     ...customAttributes
   } = body;
+
   const id = email + given_name + usual_name + siret + phone_number;
   // replace default property values, allowing substitution of a default value with an empty string
   const user = chain({
@@ -83,9 +84,7 @@ export const createUser = (body: UserAttributes) => {
     siret,
     sub,
     phone_number,
-    ...(Object.keys(customAttributes).length > 0
-      ? { idp_custom_attributes: customAttributes }
-      : {}),
+    ...(Object.keys(customAttributes).length > 0 ? customAttributes : {}),
   })
     // as per https://openid.net/specs/openid-connect-core-1_0.html#UserInfoResponse
     // > If a Claim is not returned, that Claim Name SHOULD be omitted from the JSON object representing the Claims;


### PR DESCRIPTION
**Context**

The mock IdP needed to simulate custom user-info properties returned by a FI, beyond the default user claims.
We also wanted to avoid adding new admin-facing OIDC configuration just for the mock.

**Solution**

Allow arbitrary custom fields in advanced login mode and register them dynamically in the provider config.
Reuse the default `openid` scope to carry those custom claims, so they can be returned without touching prod/admin config.
Add inline comments to explain the rationale and keep the behavior explicit.