### PR TITLE
✨ Adding a fallback to get cachedOrganization when API are down

### DIFF
--- a/back/apps/core-fca-low/src/config/api-entreprise.ts
+++ b/back/apps/core-fca-low/src/config/api-entreprise.ts
@@ -10,6 +10,7 @@ const apiEntrepriseConfig: ApiEntrepriseConfig = {
   featureFetchOrganizationData: env.boolean("FEATURE_FETCH_ORGANIZATION_DATA"),
   organizationSiret: "13002526500013",
   cachedTTL: 86400000, // 24h
+  cacheTTLWhenApiEntrepriseIsDown: 7776000000, // 90 days
 };
 
 export default apiEntrepriseConfig;

--- a/back/libs/api-entreprise/src/dto/api-entreprise.config.ts
+++ b/back/libs/api-entreprise/src/dto/api-entreprise.config.ts
@@ -19,4 +19,7 @@ export class ApiEntrepriseConfig {
 
   @IsNumber()
   readonly cachedTTL: number;
+
+  @IsNumber()
+  readonly cacheTTLWhenApiEntrepriseIsDown: number;
 }

--- a/back/libs/api-entreprise/src/services/api-entreprise.service.ts
+++ b/back/libs/api-entreprise/src/services/api-entreprise.service.ts
@@ -1,6 +1,7 @@
 import { LoggerService } from "@fc/logger";
 import { Injectable } from "@nestjs/common";
 import { toOrganizationInfo } from "@proconnect-gouv/proconnect.identite/managers/organization";
+import { OrganizationInfo } from "@proconnect-gouv/proconnect.identite/types";
 import { ApiEntrepriseClientService } from "./api-entreprise-client.service";
 
 @Injectable()
@@ -10,7 +11,7 @@ export class ApiEntrepriseService {
     private readonly logger: LoggerService,
   ) {}
 
-  async getOrganizationBySiret(siret: string) {
+  async getOrganizationBySiret(siret: string): Promise<OrganizationInfo> {
     let establishment;
     try {
       establishment = await this.apiEntrepriseClient.findBySiret(siret);

--- a/back/libs/cached-organization/src/services/cached-organization.service.spec.ts
+++ b/back/libs/cached-organization/src/services/cached-organization.service.spec.ts
@@ -3,6 +3,10 @@ import { ConfigService } from "@fc/config";
 import { LoggerService } from "@fc/logger";
 import { getModelToken } from "@nestjs/mongoose";
 import { Test, TestingModule } from "@nestjs/testing";
+import {
+  ApiEntrepriseConnectionError,
+  ApiEntrepriseInvalidSiret,
+} from "@proconnect-gouv/proconnect.api_entreprise/types";
 import { Model } from "mongoose";
 import { CachedOrganization } from "../schemas";
 import { CachedOrganizationService } from "./cached-organization.service";
@@ -47,7 +51,10 @@ describe("CachedOrganizationService", () => {
       ],
     }).compile();
 
-    configService.get.mockReturnValue({ cachedTTL: 24 * 60 * 60 * 1000 }); // 24 hours TTL
+    configService.get.mockReturnValue({
+      cachedTTL: 24 * 60 * 60 * 1000, // 24 hours
+      cacheTTLWhenApiEntrepriseIsDown: 90 * 24 * 60 * 60 * 1000, // 90 days
+    });
 
     service = module.get<CachedOrganizationService>(CachedOrganizationService);
     model = module.get<Model<CachedOrganization>>(
@@ -143,6 +150,95 @@ describe("CachedOrganizationService", () => {
         { $set: { ...organizationInfo } },
         { returnDocument: "after", upsert: true },
       );
+    });
+
+    it("should fall back to cached data when API Entreprise is down and cache is within cacheTTLWhenApiEntrepriseIsDown", async () => {
+      const siret = "12345678901234";
+      const now = Date.now();
+      const storedOrganization = {
+        siret,
+        libelle: "Test Org",
+        updatedAt: new Date(now - 60 * 24 * 60 * 60 * 1000), // 60 days ago
+      };
+
+      jest.spyOn(model, "findOne").mockResolvedValue(storedOrganization as any);
+      jest
+        .spyOn(apiEntrepriseService, "getOrganizationBySiret")
+        .mockRejectedValue(
+          new ApiEntrepriseConnectionError("API Entreprise is down"),
+        );
+
+      const result = await service.getCachedOrganizationBySiret(siret);
+
+      expect(result).toEqual(storedOrganization);
+      expect(model.create).not.toHaveBeenCalled();
+      expect(model.findOneAndUpdate).not.toHaveBeenCalled();
+    });
+
+    it("should throw error if getOrganizationBySiret fails with an error other than ApiEntrepriseConnectionError", async () => {
+      const siret = "12345678901234";
+      const now = Date.now();
+      const storedOrganization = {
+        siret,
+        libelle: "Test Org",
+        updatedAt: new Date(now - 60 * 24 * 60 * 60 * 1000), // 60 days ago
+      };
+      const invalidSiretError = new ApiEntrepriseInvalidSiret(
+        "API Entreprise is up but SIRET is invalid",
+      );
+
+      jest.spyOn(model, "findOne").mockResolvedValue(storedOrganization as any);
+      jest
+        .spyOn(apiEntrepriseService, "getOrganizationBySiret")
+        .mockRejectedValue(invalidSiretError);
+
+      await expect(service.getCachedOrganizationBySiret(siret)).rejects.toThrow(
+        invalidSiretError,
+      );
+
+      expect(model.create).not.toHaveBeenCalled();
+      expect(model.findOneAndUpdate).not.toHaveBeenCalled();
+    });
+
+    it("should throw error if API Entreprise is down and cached data is older than cacheTTLWhenApiEntrepriseIsDown", async () => {
+      const siret = "12345678901234";
+      const now = Date.now();
+      const storedOrganization = {
+        siret,
+        libelle: "Test Org",
+        updatedAt: new Date(now - 91 * 24 * 60 * 60 * 1000), // 91 days ago
+      };
+      const connectionError = new ApiEntrepriseConnectionError(
+        "API Entreprise is down",
+      );
+
+      jest.spyOn(model, "findOne").mockResolvedValue(storedOrganization as any);
+      jest
+        .spyOn(apiEntrepriseService, "getOrganizationBySiret")
+        .mockRejectedValue(connectionError);
+
+      await expect(service.getCachedOrganizationBySiret(siret)).rejects.toThrow(
+        connectionError,
+      );
+      expect(model.create).not.toHaveBeenCalled();
+      expect(model.findOneAndUpdate).not.toHaveBeenCalled();
+    });
+
+    it("should throw error if cached data does not exist and API Entreprise fails", async () => {
+      const connectionError = new ApiEntrepriseConnectionError(
+        "API Entreprise is down",
+      );
+
+      jest.spyOn(model, "findOne").mockResolvedValue(null);
+      jest
+        .spyOn(apiEntrepriseService, "getOrganizationBySiret")
+        .mockRejectedValue(connectionError);
+
+      await expect(
+        service.getCachedOrganizationBySiret("12345678901234"),
+      ).rejects.toThrow(connectionError);
+      expect(model.create).not.toHaveBeenCalled();
+      expect(model.findOneAndUpdate).not.toHaveBeenCalled();
     });
   });
 });

--- a/back/libs/cached-organization/src/services/cached-organization.service.ts
+++ b/back/libs/cached-organization/src/services/cached-organization.service.ts
@@ -4,11 +4,13 @@ import { Model } from "mongoose";
 import { Injectable } from "@nestjs/common";
 import { InjectModel } from "@nestjs/mongoose";
 import { computeServicePublicInfo } from "@proconnect-gouv/proconnect.identite/services/organization";
+import { OrganizationInfo } from "@proconnect-gouv/proconnect.identite/types";
 
 import { ApiEntrepriseConfig, ApiEntrepriseService } from "@fc/api-entreprise";
 import { ConfigService } from "@fc/config";
 
 import { LoggerService } from "@fc/logger";
+import { ApiEntrepriseConnectionError } from "@proconnect-gouv/proconnect.api_entreprise/types";
 import { CachedOrganization } from "../schemas";
 
 @Injectable()
@@ -56,8 +58,22 @@ export class CachedOrganizationService {
       return storedCachedOrganization;
     }
 
-    const organizationInfo =
-      await this.apiEntrepriseService.getOrganizationBySiret(siret);
+    let organizationInfo: OrganizationInfo;
+
+    try {
+      organizationInfo =
+        await this.apiEntrepriseService.getOrganizationBySiret(siret);
+    } catch (error) {
+      if (
+        !isEmpty(storedCachedOrganization) &&
+        error instanceof ApiEntrepriseConnectionError &&
+        this.isFallbackCacheValid(storedCachedOrganization)
+      ) {
+        return storedCachedOrganization;
+      }
+
+      throw error;
+    }
 
     const updatedCachedOrganization = await this.model.findOneAndUpdate(
       {
@@ -72,6 +88,15 @@ export class CachedOrganizationService {
     );
 
     return updatedCachedOrganization;
+  }
+
+  private isFallbackCacheValid(cachedOrganization: CachedOrganization) {
+    const { cacheTTLWhenApiEntrepriseIsDown } =
+      this.configService.get<ApiEntrepriseConfig>("ApiEntreprise");
+    return (
+      Date.now() - cachedOrganization.updatedAt.getTime() <=
+      cacheTTLWhenApiEntrepriseIsDown
+    );
   }
 
   private isExpired(cachedOrganization: CachedOrganization) {


### PR DESCRIPTION
**Context**

When API Entreprise is down, a large number of users in Internet-facing instances cannot connect because the API error is directly thrown, even though we have an Organization cache in MongoDB.

**Proposal**

When a cache for the requested organization exists, even if it is expired (as long as it does not exceed the max age accepted), catch the connection error from API Entreprise and return the cached value.

**About e2e tests**

I considered adding an e2e test for this fallback scenario, but opted against it due to complexity. quality/cypress currently only tests API reachability; simulating API Entreprise being down would require dedicated Docker Compose overrides or network mocks.
