### PR TITLE
♻️ Add rewrites and clarifications

### DIFF
--- a/back/apps/core-fca-low/src/controllers/email-verification.controller.spec.ts
+++ b/back/apps/core-fca-low/src/controllers/email-verification.controller.spec.ts
@@ -116,7 +116,6 @@ describe("EmailVerificationController", () => {
         get: jest.fn().mockReturnValue({
           spIdentity: { email: "user@example.com" },
           interactionId: "interaction123",
-          spAmr: ["pwd"],
         }),
         set: jest.fn(),
         commit: jest.fn(),
@@ -127,7 +126,6 @@ describe("EmailVerificationController", () => {
 
       expect(userSession.set).toHaveBeenCalledWith({
         isEmailVerifiedByPcf: true,
-        spAmr: ["pwd", "mail"],
       });
       expect(res.redirect).toHaveBeenCalledWith(
         "/prefix/interaction/interaction123/verify",

--- a/back/apps/core-fca-low/src/controllers/email-verification.controller.ts
+++ b/back/apps/core-fca-low/src/controllers/email-verification.controller.ts
@@ -67,7 +67,6 @@ export class EmailVerificationController {
   ): Promise<void> {
     const { verify_email_token } = body;
     const {
-      spAmr,
       spIdentity: { email },
       interactionId,
     } = userSession.get();
@@ -75,11 +74,8 @@ export class EmailVerificationController {
 
     await this.emailVerification.verifyEmailToken(email, verify_email_token);
 
-    const newSpAmr = spAmr ? [...spAmr, "mail"] : ["mail"];
-    userSession.set({ isEmailVerifiedByPcf: true, spAmr: newSpAmr });
+    userSession.set({ isEmailVerifiedByPcf: true });
     await userSession.commit();
-
-    await this.emailVerification.deleteEmailVerificationToken(email);
 
     const url = `${urlPrefix}/interaction/${interactionId}/verify`;
 

--- a/back/apps/core-fca-low/src/controllers/interaction.controller.spec.ts
+++ b/back/apps/core-fca-low/src/controllers/interaction.controller.spec.ts
@@ -63,6 +63,7 @@ describe("InteractionController", () => {
     oidcAcrMock = {
       getFilteredAcrParamsFromInteraction: jest.fn(),
       getInteractionAcr: jest.fn(),
+      getInteractionAmr: jest.fn(),
       areThereEssentialAcrRequested: jest.fn(),
       isEssentialAcrSatisfied: jest.fn(),
       computeCanAcrBeSatisfiedByPcf: jest.fn(),

--- a/back/apps/core-fca-low/src/controllers/interaction.controller.ts
+++ b/back/apps/core-fca-low/src/controllers/interaction.controller.ts
@@ -219,7 +219,6 @@ export class InteractionController {
   ) {
     const {
       idpAmr,
-      spAmr,
       idpAcr,
       idpId,
       spIdentity: { sub, email, roles, siret, organization_label },
@@ -294,7 +293,14 @@ export class InteractionController {
         error_description: "requested ACRs could not be satisfied",
       });
     }
+
+    const interactionAmr = this.oidcAcr.getInteractionAmr({
+      idpAmr,
+      isEmailVerifiedByPcf,
+    });
+
     const session: UserSession = {
+      interactionAmr,
       interactionAcr,
     };
     userSessionService.set(session);
@@ -302,7 +308,7 @@ export class InteractionController {
     this.logger.track(TrackedEvent.FC_VERIFIED);
 
     return this.oidcProvider.finishInteraction(req, res, {
-      amr: spAmr,
+      amr: interactionAmr,
       acr: interactionAcr,
     });
   }

--- a/back/apps/core-fca-low/src/controllers/oidc-client.controller.spec.ts
+++ b/back/apps/core-fca-low/src/controllers/oidc-client.controller.spec.ts
@@ -316,7 +316,6 @@ describe("OidcClientController", () => {
         "user@example.com",
       );
       expect(userSession.set).toHaveBeenNthCalledWith(2, {
-        spAmr: "amr-value",
         idpAmr: "amr-value",
         idpIdToken: "id-token",
         idpAcr: "acr-value",
@@ -451,7 +450,6 @@ describe("OidcClientController", () => {
       );
       expect(userSession.set).toHaveBeenCalledWith({
         idpAmr: "amr-value",
-        spAmr: "amr-value",
         idpIdToken: "id-token",
         idpAcr: "acr-value",
       });

--- a/back/apps/core-fca-low/src/controllers/oidc-client.controller.ts
+++ b/back/apps/core-fca-low/src/controllers/oidc-client.controller.ts
@@ -145,11 +145,9 @@ export class OidcClientController {
       spId,
       spName,
     });
-    const { amr } = claims;
 
     userSession.set({
-      idpAmr: amr,
-      spAmr: amr,
+      idpAmr: claims.amr,
       idpIdToken: idToken,
       idpAcr: claims.acr,
     });

--- a/back/apps/core-fca-low/src/dto/identity-for-sp.dto.ts
+++ b/back/apps/core-fca-low/src/dto/identity-for-sp.dto.ts
@@ -33,6 +33,7 @@ export class IdentityForSpDto extends IdentityFromIdpDto {
   idp_id: string;
 
   @IsString()
+  /** @deprecated This field is sent to some SP for historical reason and should not be used for new implementations */
   idp_acr: string;
 
   @IsString()

--- a/back/apps/core-fca-low/src/dto/user-session/user-session.dto.ts
+++ b/back/apps/core-fca-low/src/dto/user-session/user-session.dto.ts
@@ -41,12 +41,12 @@ export class UserSession {
   @IsOptional()
   @IsArray()
   @Expose()
-  readonly idpAmr?: string[];
+  readonly interactionAmr?: string[];
 
   @IsOptional()
   @IsArray()
   @Expose()
-  readonly spAmr?: string[];
+  readonly idpAmr?: string[];
 
   @IsOptional()
   @IsBoolean()

--- a/back/libs/email-verification/src/email-verification.service.spec.ts
+++ b/back/libs/email-verification/src/email-verification.service.spec.ts
@@ -388,17 +388,6 @@ describe(EmailVerificationService.name, () => {
     });
   });
 
-  describe("deleteEmailVerificationToken", () => {
-    it("should call deleteOne", async () => {
-      const email = "user@example.com";
-
-      await service.deleteEmailVerificationToken(email);
-
-      expect(emailVerificationRepositoryMock.deleteOne).toHaveBeenCalledWith(
-        "user@example.com",
-      );
-    });
-  });
   describe("getValidityDuration", () => {
     it("should return the validity duration in minutes if < 60 minutes", () => {
       configServiceMock.get.mockReturnValue({

--- a/back/libs/email-verification/src/email-verification.service.ts
+++ b/back/libs/email-verification/src/email-verification.service.ts
@@ -210,10 +210,8 @@ export class EmailVerificationService {
     ) {
       throw new InvalidEmailVerificationTokenException();
     }
-  }
 
-  async deleteEmailVerificationToken(email: string) {
-    return this.emailVerificationTokenRepository.deleteOne(email);
+    await this.emailVerificationTokenRepository.deleteOne(email);
   }
 
   private generateToken(): string {

--- a/back/libs/logger-plugins/src/services/logger-session.service.ts
+++ b/back/libs/logger-plugins/src/services/logger-session.service.ts
@@ -15,17 +15,17 @@ export class LoggerSessionService implements LoggerPluginServiceInterface {
 
     const sessionId = sessionService.getId();
     const {
-      spAmr,
-      idpAmr,
       browsingSessionId,
       interactionId,
       interactionAcr,
+      interactionAmr,
       spId,
       spEssentialAcr,
       spName,
       spIdentity,
       spSiretHint,
       spLoginHint,
+      idpAmr,
       idpId,
       idpAcr,
       idpName,
@@ -35,10 +35,9 @@ export class LoggerSessionService implements LoggerPluginServiceInterface {
     } = sessionService.get<UserSession>("User") || {};
 
     const context = {
-      spAmr,
-      idpAmr,
       browsingSessionId,
       idpAcr,
+      idpAmr,
       idpBelongingPopulation: idpIdentity?.belonging_population,
       idpEmail: idpIdentity?.email,
       idpEmailFqdn: idpIdentity?.email?.split("@").pop().toLowerCase(),
@@ -52,6 +51,7 @@ export class LoggerSessionService implements LoggerPluginServiceInterface {
       idpSub: idpIdentity?.sub,
       interactionAcr,
       interactionId,
+      interactionAmr,
       sessionId,
       spCustom: spIdentity?.custom,
       spEssentialAcr,

--- a/back/libs/oidc-acr/src/oidc-acr.service.spec.ts
+++ b/back/libs/oidc-acr/src/oidc-acr.service.spec.ts
@@ -136,6 +136,122 @@ describe("OidcAcrService", () => {
     });
   });
 
+  describe("getInteractionAmr()", () => {
+    it("should return undefined if idpAmr is undefined", () => {
+      // Given
+      const sessionDataMock: UserSession = {
+        idpAmr: undefined,
+        isEmailVerifiedByPcf: true,
+      };
+
+      // When
+      const result = service["getInteractionAmr"](sessionDataMock);
+
+      // Then
+      expect(result).toBeUndefined();
+    });
+
+    it("should return undefined if idpAmr is an empty array", () => {
+      // Given
+      const sessionDataMock: UserSession = {
+        idpAmr: [],
+        isEmailVerifiedByPcf: true,
+      };
+
+      // When
+      const result = service["getInteractionAmr"](sessionDataMock);
+
+      // Then
+      expect(result).toBeUndefined();
+    });
+
+    it("should return undefined if idpAmr is not an array", () => {
+      // Given
+      const sessionDataMock = {
+        idpAmr: "pwd",
+        isEmailVerifiedByPcf: true,
+      } as unknown as UserSession;
+
+      // When
+      const result = service["getInteractionAmr"](sessionDataMock);
+
+      // Then
+      expect(result).toBeUndefined();
+    });
+
+    it("should return idpAmr enriched with 'mail' if email is verified by PCF", () => {
+      // Given
+      const sessionDataMock: UserSession = {
+        idpAmr: ["pwd"],
+        isEmailVerifiedByPcf: true,
+      };
+
+      // When
+      const result = service["getInteractionAmr"](sessionDataMock);
+
+      // Then
+      expect(result).toEqual(["pwd", "mail"]);
+    });
+
+    it("should not mutate the original idpAmr when adding 'mail'", () => {
+      // Given
+      const idpAmr = ["pwd"];
+      const sessionDataMock: UserSession = {
+        idpAmr,
+        isEmailVerifiedByPcf: true,
+      };
+
+      // When
+      const result = service["getInteractionAmr"](sessionDataMock);
+
+      // Then
+      expect(idpAmr).toEqual(["pwd"]);
+      expect(result).not.toBe(idpAmr);
+    });
+
+    it("should return idpAmr unchanged if email is verified by PCF but 'mail' is already present", () => {
+      // Given
+      const sessionDataMock: UserSession = {
+        idpAmr: ["pwd", "mail"],
+        isEmailVerifiedByPcf: true,
+      };
+
+      // When
+      const result = service["getInteractionAmr"](sessionDataMock);
+
+      // Then
+      expect(result).toEqual(["pwd", "mail"]);
+    });
+
+    it("should return idpAmr unchanged if email is not verified by PCF", () => {
+      // Given
+      const sessionDataMock: UserSession = {
+        idpAmr: ["pwd"],
+        isEmailVerifiedByPcf: false,
+      };
+
+      // When
+      const result = service["getInteractionAmr"](sessionDataMock);
+
+      // Then
+      expect(result).toEqual(["pwd"]);
+    });
+
+    it("should return idpAmr unchanged if isEmailVerifiedByPcf is undefined", () => {
+      // Given
+      const sessionDataMock: UserSession = {
+        idpAmr: ["pwd"],
+        isEmailVerifiedByPcf: undefined,
+      };
+
+      // When
+      const result = service["getInteractionAmr"](sessionDataMock);
+
+      // Then
+      expect(result).toEqual(["pwd"]);
+    });
+  });
+
   describe("computeCanAcrBeSatisfiedByPcf", () => {
     it("should return true when all conditions are met", () => {
       configServiceMock.get.mockReturnValue({

--- a/back/libs/oidc-acr/src/oidc-acr.service.ts
+++ b/back/libs/oidc-acr/src/oidc-acr.service.ts
@@ -68,6 +68,21 @@ export class OidcAcrService {
     return undefined;
   }
 
+  getInteractionAmr({
+    idpAmr,
+    isEmailVerifiedByPcf,
+  }: Pick<UserSession, "idpAmr" | "isEmailVerifiedByPcf">) {
+    if (!idpAmr || isEmpty(idpAmr) || !isArray(idpAmr)) {
+      return undefined;
+    }
+
+    if (isEmailVerifiedByPcf && !idpAmr.includes("mail")) {
+      return [...idpAmr, "mail"];
+    }
+
+    return idpAmr;
+  }
+
   computeCanAcrBeSatisfiedByPcf({
     spEssentialAcr,
     idpAmr,


### PR DESCRIPTION
**Problem**

`spAmr` has a different lifecycle than `interactionAcr`, despite serving a very similar purpose.

`deleteEmailVerificationToken` exposes internal logic that should be handled by the email verification service.

`idp_acr` in `identityForSp` looks like it can be used like the `idpAcr` field in the user session, but it serves another, deprecated purpose.

**Proposal**

Rename `spAmr` to `interactionAmr`. Set its value during interaction verification and create a dedicated function to assign it.

Delete the consumed token at the end of the email verification flow.

Clarify the usage of the `idp_acr` attribute and mark it as deprecated to prevent future use.