### PR TITLE
🚸expose Grist errors to users

### DIFF
--- a/admin/src/grist-publisher/grist-publisher.service.spec.ts
+++ b/admin/src/grist-publisher/grist-publisher.service.spec.ts
@@ -66,9 +66,10 @@ describe("GristPublisherService", () => {
         json: jest.fn().mockResolvedValue({ message: "unexpected payload" }),
       });
 
-      await expect(service.publishIdentityProviders([])).resolves.toBe(false);
-      expect(loggerService.error).toHaveBeenCalledWith(
-        "Unexpected Grist records response shape for table identity-providers-table",
+      await expect(service.publishIdentityProviders([])).rejects.toEqual(
+        new Error(
+          `Unexpected Grist records response shape for table identity-providers-table: {"message":"unexpected payload"}`,
+        ),
       );
     });
 
@@ -87,9 +88,10 @@ describe("GristPublisherService", () => {
         text: jest.fn().mockResolvedValue("invalid api key"),
       });
 
-      await expect(service.publishIdentityProviders([])).resolves.toBe(false);
-      expect(loggerService.error).toHaveBeenCalledWith(
-        "Could not fetch Grist records: Unauthorized (invalid api key)",
+      expect(service.publishIdentityProviders([])).rejects.toEqual(
+        new Error(
+          "Could not fetch Grist records: Unauthorized (invalid api key)",
+        ),
       );
     });
 

--- a/admin/src/grist-publisher/grist-publisher.service.ts
+++ b/admin/src/grist-publisher/grist-publisher.service.ts
@@ -17,15 +17,12 @@ export class GristPublisherService {
 
   async publishServiceProviders(
     serviceProviders: ServiceProviderFromDb[],
-  ): Promise<boolean> {
+  ): Promise<{ ok: true }> {
     const { gristServiceProvidersTableId } = this.config.get("grist");
     const previousServiceProviderRecords =
       await this.getProviderRecordsFromGrist<ServiceProviderGristRecord>(
         gristServiceProvidersTableId,
       );
-    if (!previousServiceProviderRecords) {
-      return false;
-    }
 
     const nextServiceProviderRecords = serviceProviders.map((serviceProvider) =>
       this.transformServiceProviderToGristRecord(serviceProvider),
@@ -44,16 +41,13 @@ export class GristPublisherService {
 
   async publishIdentityProviders(
     identityProviders: IdentityProviderFromDb[],
-  ): Promise<boolean> {
+  ): Promise<{ ok: true }> {
     const { gristIdentityProvidersTableId } = this.config.get("grist");
 
     const previousIdentityProviderRecords =
       await this.getProviderRecordsFromGrist<IdentityProviderGristRecord>(
         gristIdentityProvidersTableId,
       );
-    if (!previousIdentityProviderRecords) {
-      return false;
-    }
 
     const nextIdentityProviderRecords = identityProviders.map(
       (identityProvider) =>
@@ -183,18 +177,25 @@ export class GristPublisherService {
       recordsToUpsert: providerT[];
     },
     tableId: string,
-  ): Promise<boolean> {
-    const successes = await Promise.all([
+  ): Promise<{ ok: true }> {
+    const results = await Promise.all([
       this.deleteGristRecords(recordIdsToDelete, tableId),
       this.upsertGristRecords(recordsToUpsert, tableId),
     ]);
 
-    return successes.every((success) => success);
+    const errors = results
+      .filter((result) => !result.ok)
+      .map((e: { ok: false; error: string }) => e.error);
+    if (errors.length > 0) {
+      throw new Error(errors.join("\n"));
+    }
+
+    return { ok: true };
   }
 
   private async getProviderRecordsFromGrist<providerT>(
     tableId: string,
-  ): Promise<GristRecord<providerT>[] | null> {
+  ): Promise<GristRecord<providerT>[]> {
     const {
       gristDomain,
       gristDocId,
@@ -217,26 +218,26 @@ export class GristPublisherService {
     });
     if (!response.ok) {
       const responseText = await response.text();
-      this.logger.error(
+      throw new Error(
         `Could not fetch Grist records: ${response.statusText} (${responseText})`,
       );
-      return null;
     }
-
     const data = await response.json();
     if (!Array.isArray(data?.records)) {
-      this.logger.error(
-        `Unexpected Grist records response shape for table ${tableId}`,
+      throw new Error(
+        `Unexpected Grist records response shape for table ${tableId}: ${JSON.stringify(data)}`,
       );
-      return null;
     }
 
     return data.records as GristRecord<providerT>[];
   }
 
-  private async deleteGristRecords(recordIds: number[], tableId: string) {
+  private async deleteGristRecords(
+    recordIds: number[],
+    tableId: string,
+  ): Promise<{ ok: true } | { ok: false; error: string }> {
     if (recordIds.length === 0) {
-      return true;
+      return { ok: true };
     }
     const { gristDomain, gristDocId, gristApiKey } = this.config.get("grist");
     const gristDocUrl = `https://${gristDomain}/api/docs/${gristDocId}/tables/${tableId}/records/delete`;
@@ -250,26 +251,29 @@ export class GristPublisherService {
         body: JSON.stringify(recordIds),
       });
       if (deleteResponse.ok) {
-        return true;
+        return { ok: true };
       } else {
         const responseText = await deleteResponse.text();
+        const errorMessage = `Could not delete Grist records: ${deleteResponse.statusText} (${responseText})`;
 
-        this.logger.error(
-          `Could not delete Grist records: ${deleteResponse.statusText} (${responseText})`,
-        );
-        return false;
+        this.logger.error(errorMessage);
+        return { ok: false, error: errorMessage };
       }
-    } catch (error) {
-      this.logger.error(`Could not delete records from Grist: ${error}`);
-      return false;
+    } catch (error: any) {
+      this.logger.error(error);
+      const errorMessage = `Could not delete Grist records: ${error.message}`;
+      return { ok: false, error: errorMessage };
     }
   }
 
   private async upsertGristRecords<
     providerT extends { UID: string; Reseau: string; Environnement: string },
-  >(records: providerT[], tableId: string) {
+  >(
+    records: providerT[],
+    tableId: string,
+  ): Promise<{ ok: true } | { ok: false; error: string }> {
     if (records.length === 0) {
-      return true;
+      return { ok: true };
     }
     const MAX_RECORDS_PER_REQUEST = 100;
     const { gristDomain, gristDocId, gristApiKey } = this.config.get("grist");
@@ -285,17 +289,17 @@ export class GristPublisherService {
 
     const recordUpdatesChunks = chunk(recordUpdates, MAX_RECORDS_PER_REQUEST);
     for (const recordUpdatesChunk of recordUpdatesChunks) {
-      const success = await this.performGristUpsertRequest<providerT>({
+      const result = await this.performGristUpsertRequest<providerT>({
         gristDocUrl,
         gristApiKey,
         recordUpdates: recordUpdatesChunk,
       });
-      if (!success) {
-        return false;
+      if (!result.ok) {
+        return result;
       }
     }
 
-    return true;
+    return { ok: true };
   }
 
   private async performGristUpsertRequest<providerT>({
@@ -309,7 +313,7 @@ export class GristPublisherService {
       fields: providerT;
       require: { UID: string; Reseau: string; Environnement: string };
     }>;
-  }) {
+  }): Promise<{ ok: true } | { ok: false; error: string }> {
     this.logger.info(`Upserting ${recordUpdates.length} records to Grist...`);
     try {
       const response = await fetch(gristDocUrl, {
@@ -322,17 +326,17 @@ export class GristPublisherService {
       });
 
       if (response.ok) {
-        return true;
+        return { ok: true };
       } else {
         const responseText = await response.text();
-        this.logger.error(
-          `Could not update Grist: ${response.statusText} (${responseText})`,
-        );
-        return false;
+        const errorMessage = `Could not update Grist: ${response.statusText} (${responseText})`;
+        this.logger.error(errorMessage);
+        return { ok: false, error: errorMessage };
       }
-    } catch (error) {
-      this.logger.error(`Could not update Grist: ${error}`);
-      return false;
+    } catch (error: any) {
+      this.logger.error(error);
+      const errorMessage = `Could not update Grist: ${error.message}`;
+      return { ok: false, error: errorMessage };
     }
   }
 }

--- a/admin/src/identity-provider/identity-provider.controller.spec.ts
+++ b/admin/src/identity-provider/identity-provider.controller.spec.ts
@@ -199,7 +199,7 @@ describe("IdentityProviderController", () => {
     it("should call successfully the service provider create function", async () => {
       // set
       serviceMock.create.mockResolvedValueOnce({
-        hasGristPublicationSucceeded: true,
+        gristPublicationResult: { ok: true },
       });
       // action
       await identityProviderController.createIdentityProvider(
@@ -313,7 +313,7 @@ describe("IdentityProviderController", () => {
     it("should call the update function from the identity provider service", async () => {
       // set
       serviceMock.update.mockResolvedValueOnce({
-        hasGristPublicationSucceeded: true,
+        gristPublicationResult: { ok: true },
       });
 
       // action
@@ -363,8 +363,8 @@ describe("IdentityProviderController", () => {
       const body = { name: "name" };
 
       // action
-      serviceMock.deleteIdentityProvider.mockImplementationOnce(() => {
-        return {};
+      serviceMock.deleteIdentityProvider.mockResolvedValueOnce({
+        gristPublicationResult: { ok: true },
       });
       await identityProviderController.deleteIdentityProvider(
         id,

--- a/admin/src/identity-provider/identity-provider.controller.ts
+++ b/admin/src/identity-provider/identity-provider.controller.ts
@@ -119,13 +119,16 @@ export class IdentityProviderController {
     @Res() res,
   ) {
     try {
-      const { hasGristPublicationSucceeded } =
+      const { gristPublicationResult } =
         await this.identityProviderService.create(
           identityProviderDto,
           req.user.username,
         );
-      if (!hasGristPublicationSucceeded) {
-        req.flash("globalError", { code: "GRIST_PUBLICATION_FAILED" });
+      if (gristPublicationResult.ok === false) {
+        req.flash("globalError", {
+          code: "GRIST_PUBLICATION_FAILED",
+          details: gristPublicationResult.error,
+        });
       }
     } catch (error) {
       req.flash("globalError", error.message);
@@ -186,14 +189,17 @@ export class IdentityProviderController {
     @Res() res,
   ) {
     try {
-      const { hasGristPublicationSucceeded } =
+      const { gristPublicationResult } =
         await this.identityProviderService.update(
           id,
           identityProviderDto,
           req.user.username,
         );
-      if (!hasGristPublicationSucceeded) {
-        req.flash("globalError", { code: "GRIST_PUBLICATION_FAILED" });
+      if (gristPublicationResult.ok === false) {
+        req.flash("globalError", {
+          code: "GRIST_PUBLICATION_FAILED",
+          details: gristPublicationResult.error,
+        });
       }
     } catch (error) {
       req.flash("globalError", error.message);
@@ -220,13 +226,16 @@ export class IdentityProviderController {
     @Body() body,
   ) {
     try {
-      const { hasGristPublicationSucceeded } =
+      const { gristPublicationResult } =
         await this.identityProviderService.deleteIdentityProvider(
           id,
           req.user.username,
         );
-      if (!hasGristPublicationSucceeded) {
-        req.flash("globalError", { code: "GRIST_PUBLICATION_FAILED" });
+      if (gristPublicationResult.ok === false) {
+        req.flash("globalError", {
+          code: "GRIST_PUBLICATION_FAILED",
+          details: gristPublicationResult.error,
+        });
       }
     } catch (error) {
       req.flash("globalError", error.message);

--- a/admin/src/identity-provider/identity-provider.service.ts
+++ b/admin/src/identity-provider/identity-provider.service.ts
@@ -61,10 +61,9 @@ export class IdentityProviderService {
       name: identityProviderDto.name,
     });
 
-    const hasGristPublicationSucceeded =
-      await this.publishIdentityProvidersToGrist();
+    const gristPublicationResult = await this.publishIdentityProvidersToGrist();
 
-    return { identityProviderId, hasGristPublicationSucceeded };
+    return { identityProviderId, gristPublicationResult };
   }
 
   async findById(
@@ -122,10 +121,9 @@ export class IdentityProviderService {
     // Save the updated provider
     await this.identityProviderRepository.save(existingProvider);
 
-    const hasGristPublicationSucceeded =
-      await this.publishIdentityProvidersToGrist();
+    const gristPublicationResult = await this.publishIdentityProvidersToGrist();
 
-    return { identityProviderId, hasGristPublicationSucceeded };
+    return { identityProviderId, gristPublicationResult };
   }
 
   async deleteIdentityProvider(id: string, user: string) {
@@ -148,7 +146,13 @@ export class IdentityProviderService {
     const hasDeletionSucceeded = result.affected === 1;
 
     // we do not know how to update grist after a deletion
-    return { hasGristPublicationSucceeded: false, hasDeletionSucceeded };
+    return {
+      gristPublicationResult: {
+        ok: false,
+        error: "Deletion not handled by our grist publisher",
+      },
+      hasDeletionSucceeded,
+    };
   }
 
   async paginate(options: PaginationOptions) {
@@ -273,10 +277,15 @@ export class IdentityProviderService {
   }
 
   private async publishIdentityProvidersToGrist() {
-    const allIdentityProviders = await this.identityProviderRepository.find();
+    try {
+      const allIdentityProviders = await this.identityProviderRepository.find();
 
-    return this.gristPublisherService.publishIdentityProviders(
-      allIdentityProviders,
-    );
+      return await this.gristPublisherService.publishIdentityProviders(
+        allIdentityProviders,
+      );
+    } catch (error: any) {
+      this.logger.error(error);
+      return { ok: false, error: error.message as string };
+    }
   }
 }

--- a/admin/src/service-provider/service-provider.controller.spec.ts
+++ b/admin/src/service-provider/service-provider.controller.spec.ts
@@ -407,7 +407,7 @@ describe("ServiceProviderController", () => {
   describe("serviceProviderUpdate()", () => {
     it("should update a servicerProvider and return to the serviceProvider page", async () => {
       serviceProviderServiceMock.update.mockResolvedValue({
-        hasGristPublicationSucceeded: true,
+        gristPublicationResult: { ok: true },
       });
 
       await serviceProviderController.serviceProviderUpdate(
@@ -424,7 +424,7 @@ describe("ServiceProviderController", () => {
 
     it("should call serviceProviderService.update()", async () => {
       serviceProviderServiceMock.update.mockResolvedValue({
-        hasGristPublicationSucceeded: true,
+        gristPublicationResult: { ok: true },
       });
 
       // When
@@ -464,7 +464,7 @@ describe("ServiceProviderController", () => {
 
     it("should update a servicerProvider with URIScheme for redirectUri field and return to the serviceProvider page", async () => {
       serviceProviderServiceMock.update.mockResolvedValue({
-        hasGristPublicationSucceeded: true,
+        gristPublicationResult: { ok: true },
       });
       ((ServiceProviderDtoMock.redirectUri = [
         "https://url.com",
@@ -486,7 +486,7 @@ describe("ServiceProviderController", () => {
 
     it("should update a servicerProvider with URIScheme for redirectUriLogout field and return to the serviceProvider page", async () => {
       serviceProviderServiceMock.update.mockResolvedValue({
-        hasGristPublicationSucceeded: true,
+        gristPublicationResult: { ok: true },
       });
       ((ServiceProviderDtoMock.redirectUriLogout = [
         "https://url.com",
@@ -514,9 +514,9 @@ describe("ServiceProviderController", () => {
       const body = { name: "name" };
 
       // action
-      serviceProviderServiceMock.deleteServiceProviderById.mockReturnValueOnce(
-        {},
-      );
+      serviceProviderServiceMock.deleteServiceProviderById.mockReturnValueOnce({
+        gristPublicationResult: { ok: true },
+      });
       await serviceProviderController.deleteServiceProvider(
         key,
         req,
@@ -575,7 +575,7 @@ describe("ServiceProviderController", () => {
 
       // action
       serviceProviderServiceMock.deleteManyServiceProvidersById.mockReturnValueOnce(
-        {},
+        { gristPublicationResult: { ok: true } },
       );
       await serviceProviderController.deleteServiceProviders(
         deleteServiceProviderDto,

--- a/admin/src/service-provider/service-provider.controller.ts
+++ b/admin/src/service-provider/service-provider.controller.ts
@@ -136,13 +136,16 @@ export class ServiceProviderController {
     @Res() res,
   ) {
     try {
-      const { hasGristPublicationSucceeded } =
+      const { gristPublicationResult } =
         await this.serviceProviderService.createServiceProvider(
           createServiceProviderDto,
           req.user.username,
         );
-      if (!hasGristPublicationSucceeded) {
-        req.flash("globalError", { code: "GRIST_PUBLICATION_FAILED" });
+      if (gristPublicationResult.ok === false) {
+        req.flash("globalError", {
+          code: "GRIST_PUBLICATION_FAILED",
+          details: gristPublicationResult.error,
+        });
       }
     } catch (error) {
       req.flash(
@@ -225,14 +228,17 @@ export class ServiceProviderController {
     @Res() res,
   ) {
     try {
-      const { hasGristPublicationSucceeded } =
+      const { gristPublicationResult } =
         await this.serviceProviderService.update(
           id,
           updateServiceProviderDto,
           req.user.username,
         );
-      if (!hasGristPublicationSucceeded) {
-        req.flash("globalError", { code: "GRIST_PUBLICATION_FAILED" });
+      if (gristPublicationResult.ok === false) {
+        req.flash("globalError", {
+          code: "GRIST_PUBLICATION_FAILED",
+          details: gristPublicationResult.error,
+        });
       }
     } catch (error) {
       console.error(error);
@@ -260,13 +266,16 @@ export class ServiceProviderController {
     @Body() body,
   ) {
     try {
-      const { hasGristPublicationSucceeded } =
+      const { gristPublicationResult } =
         await this.serviceProviderService.deleteServiceProviderById(
           id,
           req.user.username,
         );
-      if (!hasGristPublicationSucceeded) {
-        req.flash("globalError", { code: "GRIST_PUBLICATION_FAILED" });
+      if (gristPublicationResult.ok === false) {
+        req.flash("globalError", {
+          code: "GRIST_PUBLICATION_FAILED",
+          details: gristPublicationResult.error,
+        });
       }
     } catch (error) {
       req.flash("globalError", error.message);
@@ -292,13 +301,16 @@ export class ServiceProviderController {
   ) {
     const { deleteItems = [], name } = body;
     try {
-      const { hasGristPublicationSucceeded } =
+      const { gristPublicationResult } =
         await this.serviceProviderService.deleteManyServiceProvidersById(
           deleteItems,
           req.user.username,
         );
-      if (!hasGristPublicationSucceeded) {
-        req.flash("globalError", { code: "GRIST_PUBLICATION_FAILED" });
+      if (gristPublicationResult.ok === false) {
+        req.flash("globalError", {
+          code: "GRIST_PUBLICATION_FAILED",
+          details: gristPublicationResult.error,
+        });
       }
     } catch (error) {
       req.flash("globalError", error.message);

--- a/admin/src/service-provider/service-provider.service.ts
+++ b/admin/src/service-provider/service-provider.service.ts
@@ -77,10 +77,9 @@ export class ServiceProviderService {
       id: saveOperation.identifiers[0].id,
     });
 
-    const hasGristPublicationSucceeded =
-      await this.publishServiceProvidersToGrist();
+    const gristPublicationResult = await this.publishServiceProvidersToGrist();
 
-    return { hasGristPublicationSucceeded };
+    return { gristPublicationResult };
   }
 
   async findById(id: string): Promise<ServiceProviderFromDb> {
@@ -143,10 +142,9 @@ export class ServiceProviderService {
 
     await this.serviceProviderRepository.save(serviceProvider);
 
-    const hasGristPublicationSucceeded =
-      await this.publishServiceProvidersToGrist();
+    const gristPublicationResult = await this.publishServiceProvidersToGrist();
 
-    return { hasGristPublicationSucceeded };
+    return { gristPublicationResult };
   }
 
   /**
@@ -160,10 +158,9 @@ export class ServiceProviderService {
       ids.map((id) => this.deleteServiceProviderById(id, user)),
     );
 
-    const hasGristPublicationSucceeded =
-      await this.publishServiceProvidersToGrist();
+    const gristPublicationResult = await this.publishServiceProvidersToGrist();
 
-    return { hasGristPublicationSucceeded };
+    return { gristPublicationResult };
   }
 
   async deleteServiceProviderById(id: string, user: string) {
@@ -185,10 +182,9 @@ export class ServiceProviderService {
       name: serviceProvider.key,
     });
 
-    const hasGristPublicationSucceeded =
-      await this.publishServiceProvidersToGrist();
+    const gristPublicationResult = await this.publishServiceProvidersToGrist();
 
-    return { hasGristPublicationSucceeded, hasDeletionSucceeded };
+    return { gristPublicationResult, hasDeletionSucceeded };
   }
 
   async generateNewSecret(
@@ -264,10 +260,17 @@ export class ServiceProviderService {
     };
   }
 
-  private async publishServiceProvidersToGrist(): Promise<boolean> {
-    const allServiceProviders = await this.serviceProviderRepository.find();
-    return this.gristPublisherService.publishServiceProviders(
-      allServiceProviders,
-    );
+  private async publishServiceProvidersToGrist(): Promise<
+    { ok: true } | { ok: false; error: string }
+  > {
+    try {
+      const allServiceProviders = await this.serviceProviderRepository.find();
+      return await this.gristPublisherService.publishServiceProviders(
+        allServiceProviders,
+      );
+    } catch (error: any) {
+      this.logger.error(error);
+      return { ok: false, error: error.message };
+    }
   }
 }

--- a/admin/views/partials/global-errors-handler.ejs
+++ b/admin/views/partials/global-errors-handler.ejs
@@ -1,5 +1,14 @@
 <% if (locals.messages.globalError) { %>
 <div class="alert alert-danger mt-3">
 <%= messages.globalError[0].code && ERROR_CODE_TRANSLATIONS[messages.globalError[0].code] ? ERROR_CODE_TRANSLATIONS[messages.globalError[0].code] : messages.globalError[0] %>
+<%
+if (messages.globalError[0].details) {%>
+    <details>
+        <summary>Details</summary>
+        <%= messages.globalError[0].details %>
+    </details>
+<%
+}
+%>
 </div>
 <% } %>


### PR DESCRIPTION
**Problem**
When a request to Grist fails, users only see a generic error message and must check the logs to identify the actual issue.

**Proposal**
Propagate the error thrown by Grist so that users can see the actual error message.

<img width="1440" height="275" alt="Capture d’écran 2026-08-31 à 17 59 01" src="https://github.com/user-attachments/assets/8a2a4756-60ae-41db-be51-3470337d604e" />
