### PR TITLE
🐛 Handle API Entreprise downtime correctly

### DIFF
--- a/back/apps/core-fca-low/src/services/identity.sanitizer.ts
+++ b/back/apps/core-fca-low/src/services/identity.sanitizer.ts
@@ -11,7 +11,10 @@ import { LoggerService } from "@fc/logger";
 import { ApiEntrepriseConfig } from "@fc/api-entreprise";
 import { CachedOrganizationService } from "@fc/cached-organization";
 import { IdentityProviderMetadata } from "@fc/oidc";
-import { ApiEntrepriseConnectionError } from "@proconnect-gouv/proconnect.api_entreprise/types";
+import {
+  ApiEntrepriseConnectionError,
+  ApiEntrepriseError,
+} from "@proconnect-gouv/proconnect.api_entreprise/types";
 import { AppConfig, IdentityForSpDto, IdentityFromIdpDto } from "../dto";
 import {
   ApiEntrepriseConnectionException,
@@ -96,7 +99,10 @@ export class IdentitySanitizer {
           cachedOrganizationErrorType: error?.constructor?.name,
         });
 
-        if (error instanceof ApiEntrepriseConnectionError) {
+        if (
+          error instanceof ApiEntrepriseConnectionError ||
+          error instanceof ApiEntrepriseError
+        ) {
           throw new ApiEntrepriseConnectionException();
         }
 

--- a/back/libs/cached-organization/src/services/cached-organization.service.ts
+++ b/back/libs/cached-organization/src/services/cached-organization.service.ts
@@ -10,7 +10,10 @@ import { ApiEntrepriseConfig, ApiEntrepriseService } from "@fc/api-entreprise";
 import { ConfigService } from "@fc/config";
 
 import { LoggerService } from "@fc/logger";
-import { ApiEntrepriseConnectionError } from "@proconnect-gouv/proconnect.api_entreprise/types";
+import {
+  ApiEntrepriseConnectionError,
+  ApiEntrepriseError,
+} from "@proconnect-gouv/proconnect.api_entreprise/types";
 import { CachedOrganization } from "../schemas";
 
 @Injectable()
@@ -66,7 +69,8 @@ export class CachedOrganizationService {
     } catch (error) {
       if (
         !isEmpty(storedCachedOrganization) &&
-        error instanceof ApiEntrepriseConnectionError &&
+        (error instanceof ApiEntrepriseConnectionError ||
+          error instanceof ApiEntrepriseError) &&
         this.isFallbackCacheValid(storedCachedOrganization)
       ) {
         return storedCachedOrganization;


### PR DESCRIPTION
**Context**

When API Entreprise is down, `ApiEntrepriseConnectionException` is supposed to be thrown and the special `CachedOrganization` cache should be used, but that is not currently the case.

**Proposal**

In this PR, we catch an additional error to ensure the expected behavior.

**Manual tests**

I tested locally:
- When I disable the mock for ApiEntreprise_SHOULD_MOCK_API, I clearly see the dedicated error Y500028.
- When a cache exists and is less than 24 hours old, I can still log in without error when the API Entreprise token is invalid.
- When a cache has existed for more than 90 days, the Y500028 error is thrown.
- When a cache has existed for more than 24 hours but less than 90 days, I can still log in without error.
- When there is no cache, the Y500028 error is thrown.