### PR TITLE
✨ feat: preselect the last used identity provider

### DIFF
--- a/back/apps/core-fca-low/src/public/js/multifi-preselection.js
+++ b/back/apps/core-fca-low/src/public/js/multifi-preselection.js
@@ -1,0 +1,33 @@
+const LOCAL_STORAGE_LAST_FI_SELECTED = "proConnectLastFISelected";
+
+function init() {
+  const localStorageLastFISelected = localStorage.getItem(
+    LOCAL_STORAGE_LAST_FI_SELECTED,
+  );
+  if (!!localStorageLastFISelected) {
+    const idpRadioButton = document.querySelector(
+      `#idp-${localStorageLastFISelected}`,
+    );
+    if (idpRadioButton) {
+      idpRadioButton.checked = true;
+    }
+  }
+
+  const submitButton = document.querySelector(
+    "#select-identity-provider-submit-button",
+  );
+
+  submitButton.addEventListener("click", () => {
+    const selectedIdpRadioButton = document.querySelector(
+      'input[name="identityProviderUid"]:checked',
+    );
+    if (selectedIdpRadioButton) {
+      localStorage.setItem(
+        LOCAL_STORAGE_LAST_FI_SELECTED,
+        selectedIdpRadioButton.value,
+      );
+    }
+  });
+}
+
+init();

--- a/back/apps/core-fca-low/src/views/identity-provider-selection.ejs
+++ b/back/apps/core-fca-low/src/views/identity-provider-selection.ejs
@@ -41,7 +41,7 @@
 
             </fieldset>
 
-            <button class="fr-btn btn--fullwidth" type="submit">
+            <button id="select-identity-provider-submit-button" class="fr-btn btn--fullwidth" type="submit">
               Continuer
             </button>
             <div class="fr-mt-2w fr-grid-row fr-grid-row--center">
@@ -60,6 +60,8 @@
     </div>
   </main>
   <script type="text/javascript" src="/js/go-back.js"></script>
+  <script type="text/javascript" src="/js/multifi-preselection.js" defer></script>
+
   <%- include('includes/footer.ejs') %> <%- include('includes/scripts.ejs') %>
 </body>
 

--- a/quality/cypress/integration/usager/connexion-usager-multi-fi.feature
+++ b/quality/cypress/integration/usager/connexion-usager-multi-fi.feature
@@ -86,6 +86,23 @@ Fonctionnalité: Connexion Usager dont le domaine email attaché est lié à plu
     Quand je suis redirigé vers la page permettant la selection d'un fournisseur d'identité
     Alors le fournisseur d'identité "Autre (via ProConnect Identité)" est positionné en dernier dans la liste des fournisseurs d'identité
 
+  Scénario: Le dernier FI utilisé est présélectionné 
+    Etant donné que je navigue sur la page fournisseur de service
+    Et que je clique sur le bouton ProConnect
+    Et que j'entre l'email "test@polyfi.fr"
+    Et que je clique sur le bouton de connexion
+    Et que je suis redirigé vers la page permettant la selection d'un fournisseur d'identité
+    Et que je choisis le fournisseur d'identité "Identity Provider 1 - eIDAS faible - ES256"
+    Et que je suis redirigé vers la page login du fournisseur d'identité "par défaut"
+    Et que je m'authentifie
+    Et que je suis redirigé vers la page fournisseur de service "par défaut"
+    Et que je clique sur le bouton de déconnexion
+    Et que je suis redirigé vers la page fournisseur de service "par défaut"
+    Et que je clique sur le bouton ProConnect
+    Et que j'entre l'email "test@polyfi.fr"
+    Quand je clique sur le bouton de connexion
+    Alors le fournisseur d'identité "Identity Provider 1 - eIDAS faible - ES256" est sélectionné
+
   @ignoreInteg01
   Plan du Scénario: Retour en arrière après une connexion multi FI réussie
     Étant donné que je navigue sur la page fournisseur de service

--- a/quality/cypress/support/usager/steps/interaction-idp-selection-steps.ts
+++ b/quality/cypress/support/usager/steps/interaction-idp-selection-steps.ts
@@ -16,6 +16,15 @@ Then("je choisis le fournisseur d'identité {string}", function (text: string) {
 });
 
 Then(
+  "le fournisseur d'identité {string} est sélectionné",
+  function (text: string) {
+    cy.get('input[name="identityProviderUid"]:checked')
+      .next("label")
+      .should("contain", text);
+  },
+);
+
+Then(
   "je clique sur le fournisseur d'identité {string}",
   function (text: string) {
     cy.contains("label", text).click();


### PR DESCRIPTION
**Problem**
When a user's email domain is associated with multiple Identity Providers, they have to select their Identity Provider again at each login.

**Proposal**
Preselect the last Identity Provider used by the user.