### PR TITLE
✨ feat: enable discovery URL by default

### DIFF
--- a/admin/cypress/integration/identity-provider/identity-provider-create.spec.js
+++ b/admin/cypress/integration/identity-provider/identity-provider-create.spec.js
@@ -25,8 +25,8 @@ describe("Identity provider creation", () => {
     it("should set the identity provider to default values when created", () => {
       cy.url().should("eq", `${BASE_URL}/identity-provider`);
       cy.contains("Créer un fournisseur d'identité").click();
-      cy.get('[name="discovery"]:checked').should("have.value", "false");
-      cy.get('[name="discoveryUrl"]').should("be.disabled");
+      cy.get('[name="discovery"]:checked').should("have.value", "true");
+      cy.get('[name="discoveryUrl"]').should("not.be.disabled");
     });
 
     it("if all fields are provided", () => {
@@ -69,10 +69,7 @@ describe("Identity provider creation", () => {
         name: "MonSuperFI-2",
         title: "Mon Super FI 2 mais mieux écrit",
         issuer: "https://issuer.fr",
-        authorizationUrl: "https://issuer.fr/auth",
-        jwksUrl: "https://issuer.fr/jwks",
-        tokenUrl: "https://issuer.fr/token",
-        userInfoUrl: "https://issuer.fr/me",
+        discoveryUrl: "https://issuer.fr/discovery",
         clientId: "09a1a257648c1742c74d6a3d84b31943",
         client_secret: "1234567890AZERTYUIOP",
         token_endpoint_auth_method: "client_secret_post",
@@ -93,10 +90,7 @@ describe("Identity provider creation", () => {
         name: "MonSuperFI-2",
         title: "Mon Super FI 2 mais mieux écrit",
         issuer: "https://issuer.fr",
-        authorizationUrl: "https://issuer.fr/auth",
-        jwksUrl: "https://issuer.fr/jwks",
-        tokenUrl: "https://issuer.fr/token",
-        userInfoUrl: "https://issuer.fr/me",
+        discoveryUrl: "https://issuer.fr/discovery",
         clientId: "09a1a257648c1742c74d6a3d84b31943",
         client_secret: "1234567890AZERTYUIOP",
         token_endpoint_auth_method: "client_secret_post",
@@ -232,13 +226,9 @@ describe("Identity provider creation", () => {
       )
         .scrollIntoView()
         .should("exist");
+
       cy.contains(
         `Veuillez mettre une issuer URL valide au format https://issuer.fr`,
-      )
-        .scrollIntoView()
-        .should("exist");
-      cy.contains(
-        `Veuillez mettre une token URL valide au format https://issuer.fr/token`,
       )
         .scrollIntoView()
         .should("exist");

--- a/admin/public/javascript/change-discovery.js
+++ b/admin/public/javascript/change-discovery.js
@@ -4,18 +4,18 @@ export function changeDiscovery() {
   document
     .querySelector("#no-discovery")
     .addEventListener("change", function () {
-      _handleState("discoveryUrl", true);
-      _handleState("userInfoUrl", false);
-      _handleState("authorizationUrl", false);
-      _handleState("tokenUrl", false);
+      _handleState("discovery-url-row", true);
+      _handleState("userinfo-url-row", false);
+      _handleState("authorization-url-row", false);
+      _handleState("token-url-row", false);
       displayJwksUrlField();
     });
 
   document.querySelector("#discovery").addEventListener("change", function () {
-    _handleState("discoveryUrl", false);
-    _handleState("userInfoUrl", true);
-    _handleState("authorizationUrl", true);
-    _handleState("tokenUrl", true);
+    _handleState("discovery-url-row", false);
+    _handleState("userinfo-url-row", true);
+    _handleState("authorization-url-row", true);
+    _handleState("token-url-row", true);
     displayJwksUrlField();
   });
 }
@@ -57,22 +57,25 @@ export function displayJwksUrlField() {
     asymmetricSignature.includes(userInfoSignedResponseAlgValue);
 
   const isJwksUrlOptional = discovery || !useAsymmetricSignature;
-  _handleState("jwksUrl", isJwksUrlOptional);
+  _handleState("jwks-url-row", isJwksUrlOptional);
 }
 
 // Handle changes for input state & label wording
-const _handleState = (inputName, isDisabled) => {
-  const requiredLabel = document.querySelector(`label[for=${inputName}] span`);
-  const input = document.querySelector(`input[name=${inputName}]`);
+const _handleState = (rowName, isDisabled) => {
+  const row = document.getElementById(rowName);
+  const requiredLabel = document.querySelector(`#${rowName} label span`);
+  const input = document.querySelector(`#${rowName} input`);
   input.disabled = isDisabled;
   input.required = !isDisabled;
   if (isDisabled) {
+    row.classList.add("d-none");
     requiredLabel.classList.add("d-none");
     if (input.classList.contains("is-invalid")) {
       input.classList.add("is-invalid-disabled");
       input.classList.remove("is-invalid");
     }
   } else {
+    row.classList.remove("d-none");
     requiredLabel.classList.remove("d-none");
     if (input.classList.contains("is-invalid-disabled")) {
       input.classList.add("is-invalid");

--- a/admin/views/identity-provider/creation.ejs
+++ b/admin/views/identity-provider/creation.ejs
@@ -183,10 +183,48 @@
               </div>
             </div>
 
+
+            <%
+            var isUseDiscoveryUrlChecked = (locals.messages.values && messages.values[0].discovery === true) || !locals.messages.values 
+            %>
+            
             <div class="mb-3 row">
-              <label class="col-2 col-form-label" for="jwksUrl"> JWKS URL <span class=<%= locals.messages.values && messages.values[0].discovery === true ? 'd-none' : '' %>>*</span> : </label>
+              <label class="col-2 col-form-label">Utiliser la discovery URL : </label>
+              <div class="mb-3 col-4 d-flex align-items-end">
+                <div class="form-check form-check-inline">
+                  <input type="radio" class="form-check-input is-valid" id="discovery" name="discovery" value="true" <%= isUseDiscoveryUrlChecked ? 'checked' : '' %>>
+                  <label class="form-check-label" for="discovery">oui</label>
+                </div>
+                <div class="form-check form-check-inline">
+                  <input type="radio" class="form-check-input is-valid" id="no-discovery" name="discovery" value="false" <%= !isUseDiscoveryUrlChecked ? 'checked' :'' %>>
+                  <label class="form-check-label" for="no-discovery">non</label>
+                </div>
+              </div>
+            </div>
+
+             <div class="mb-3 row <%= isUseDiscoveryUrlChecked ? '' : 'd-none' %>" id="discovery-url-row">
+              <label class="col-2 col-form-label" for="discoveryUrl">Discovery URL <span class=<%= isUseDiscoveryUrlChecked ? '' : 'd-none' %>>*</span> :</label>
               <div class="col-10">
-                <input id="jwksUrl" type="text" <%= locals.messages.values && messages.values[0].discovery ? 'disabled' : 'required' %> class="form-control <%= locals.messages.errors && messages.errors[0].jwksUrl && 'is-invalid' %>" name="jwksUrl" value="<%= locals.messages.values && messages.values[0].jwksUrl %>" pattern="^https?:\/\/[^/].+$">
+                <input id="discoveryUrl" <%= isUseDiscoveryUrlChecked ? 'required' :'disabled' %> type="text" class="form-control <%= locals.messages.errors && messages.errors[0].discoveryUrl && 'is-invalid' %>" name="discoveryUrl" value="<%= locals.messages.values && messages.values[0].discoveryUrl %>" pattern="^https?:\/\/[^/].+$">
+                <div class="invalid-feedback">
+                  <% if (locals.messages.errors && messages.errors[0].discoveryUrl) { %>
+                  <p>
+                    <% messages.errors[0].discoveryUrl.forEach((error) => { %>
+                    <%= error %>
+                    <br>
+                    <% }) %>
+                  </p>
+                  <% } else { %>
+                  Veuillez mettre une discovery URL valide au format https://issuer.fr/.well-known/openid-configuration
+                  <% } %>
+                </div>
+              </div>
+            </div>
+
+            <div class="mb-3 row <%= !isUseDiscoveryUrlChecked ? '' : 'd-none' %>" id="jwks-url-row">
+              <label class="col-2 col-form-label" for="jwksUrl"> JWKS URL <span class=<%= isUseDiscoveryUrlChecked ? 'd-none' : '' %>>*</span> : </label>
+              <div class="col-10">
+                <input id="jwksUrl" type="text" <%= isUseDiscoveryUrlChecked ? 'disabled' : 'required' %> class="form-control <%= locals.messages.errors && messages.errors[0].jwksUrl && 'is-invalid' %>" name="jwksUrl" value="<%= locals.messages.values && messages.values[0].jwksUrl %>" pattern="^https?:\/\/[^/].+$">
                 <div class="invalid-feedback">
                   <% if (locals.messages.errors && messages.errors[0].jwksUrl) { %>
                   <p>
@@ -201,10 +239,10 @@
                 </div>
               </div>
             </div>
-            <div class="mb-3 row">
-              <label class="col-2 col-form-label" for="tokenUrl">Token URL <span class=<%= locals.messages.values && messages.values[0].discovery === true ? 'd-none' : '' %>>*</span> :</label>
+            <div class="mb-3 row <%= !isUseDiscoveryUrlChecked ? '' : 'd-none' %>" id="token-url-row">
+              <label class="col-2 col-form-label" for="tokenUrl">Token URL <span class=<%= isUseDiscoveryUrlChecked ? 'd-none' : '' %>>*</span> :</label>
               <div class="col-10">
-                <input id="tokenUrl" type="text" <%= locals.messages.values && messages.values[0].discovery ? 'disabled' : 'required' %> class="form-control <%= locals.messages.errors && messages.errors[0].tokenUrl && 'is-invalid' %>" name="tokenUrl" value="<%= locals.messages.values && messages.values[0].tokenUrl %>" pattern="^https?:\/\/[^/].+$">
+                <input id="tokenUrl" type="text" <%= isUseDiscoveryUrlChecked ? 'disabled' : 'required' %> class="form-control <%= locals.messages.errors && messages.errors[0].tokenUrl && 'is-invalid' %>" name="tokenUrl" value="<%= locals.messages.values && messages.values[0].tokenUrl %>" pattern="^https?:\/\/[^/].+$">
                 <div class="invalid-feedback">
                   <% if (locals.messages.errors && messages.errors[0].tokenUrl) { %>
                   <p>
@@ -219,10 +257,10 @@
                 </div>
               </div>
             </div>
-            <div class="mb-3 row">
-              <label class="col-2 col-form-label" for="userInfoUrl">UserInfo URL <span class=<%= locals.messages.values && messages.values[0].discovery === true ? 'd-none' : '' %>>*</span> :</label>
+            <div class="mb-3 row <%= !isUseDiscoveryUrlChecked ? '' : 'd-none' %>" id="userinfo-url-row">
+              <label class="col-2 col-form-label" for="userInfoUrl">UserInfo URL <span class=<%= isUseDiscoveryUrlChecked ? 'd-none' : '' %>>*</span> :</label>
               <div class="col-10">
-                <input id="userInfoUrl" <%= locals.messages.values && messages.values[0].discovery ? 'disabled' : 'required' %> type="text" class="form-control userInfoUrl <%= locals.messages.errors && messages.errors[0].userInfoUrl && 'is-invalid' %>" name="userInfoUrl" value="<%= locals.messages.values && messages.values[0].userInfoUrl %>" pattern="^https?:\/\/[^/].+$">
+                <input id="userInfoUrl" <%= isUseDiscoveryUrlChecked ? 'disabled' : 'required' %> type="text" class="form-control userInfoUrl <%= locals.messages.errors && messages.errors[0].userInfoUrl && 'is-invalid' %>" name="userInfoUrl" value="<%= locals.messages.values && messages.values[0].userInfoUrl %>" pattern="^https?:\/\/[^/].+$">
                 <div class="invalid-feedback">
                   <% if (locals.messages.errors && messages.errors[0].userInfoUrl) { %>
                   <p>
@@ -237,10 +275,10 @@
                 </div>
               </div>
             </div>
-            <div class="mb-3 row">
-              <label class="col-2 col-form-label" for="authorizationUrl">Authorization URL <span class=<%= locals.messages.values && messages.values[0].discovery === true ? 'd-none' : '' %>>*</span> :</label>
+            <div class="mb-3 row <%= !isUseDiscoveryUrlChecked ? '' : 'd-none' %>" id="authorization-url-row">
+              <label class="col-2 col-form-label" for="authorizationUrl">Authorization URL <span class=<%= isUseDiscoveryUrlChecked ? 'd-none' : '' %>>*</span> :</label>
               <div class="col-10">
-                <input id="authorizationUrl" <%= locals.messages.values && messages.values[0].discovery ? 'disabled' : 'required' %> type="text" class="form-control <%= locals.messages.errors && messages.errors[0].authorizationUrl && 'is-invalid' %>" name="authorizationUrl" value="<%= locals.messages.values && messages.values[0].authorizationUrl %>" pattern="^https?:\/\/[^/].+$">
+                <input id="authorizationUrl" <%= isUseDiscoveryUrlChecked ? 'disabled' : 'required' %> type="text" class="form-control <%= locals.messages.errors && messages.errors[0].authorizationUrl && 'is-invalid' %>" name="authorizationUrl" value="<%= locals.messages.values && messages.values[0].authorizationUrl %>" pattern="^https?:\/\/[^/].+$">
                 <div class="invalid-feedback">
                   <% if (locals.messages.errors && messages.errors[0].authorizationUrl) { %>
                   <p>
@@ -291,37 +329,7 @@
                 </div>
               </div>
             </div>
-            <div class="mb-3 row">
-              <label class="col-2 col-form-label">Utiliser la discovery URL : </label>
-              <div class="mb-3 col-4 d-flex align-items-end">
-                <div class="form-check form-check-inline">
-                  <input type="radio" class="form-check-input is-valid" id="discovery" name="discovery" value="true" <%= locals.messages.values && messages.values[0].discovery ? 'checked' : '' %>>
-                  <label class="form-check-label" for="discovery">oui</label>
-                </div>
-                <div class="form-check form-check-inline">
-                  <input type="radio" class="form-check-input is-valid" id="no-discovery" name="discovery" value="false" <%= !locals.messages.values || !messages.values[0].discovery ? 'checked' :'' %>>
-                  <label class="form-check-label" for="no-discovery">non</label>
-                </div>
-              </div>
-            </div>
-            <div class="mb-3 row">
-              <label class="col-2 col-form-label" for="discoveryUrl">Discovery URL <span class=<%= locals.messages.values && messages.values[0].discovery === false ? 'd-none' : '' %>>*</span> :</label>
-              <div class="col-10">
-                <input id="discoveryUrl" <%= locals.messages.values && !messages.values[0].discovery ? 'required' :'disabled' %> type="text" class="form-control <%= locals.messages.errors && messages.errors[0].discoveryUrl && 'is-invalid' %>" name="discoveryUrl" value="<%= locals.messages.values && messages.values[0].discoveryUrl %>" pattern="^https?:\/\/[^/].+$">
-                <div class="invalid-feedback">
-                  <% if (locals.messages.errors && messages.errors[0].discoveryUrl) { %>
-                  <p>
-                    <% messages.errors[0].discoveryUrl.forEach((error) => { %>
-                    <%= error %>
-                    <br>
-                    <% }) %>
-                  </p>
-                  <% } else { %>
-                  Veuillez mettre une discovery URL valide au format https://issuer.fr/.well-known/openid-configuration
-                  <% } %>
-                </div>
-              </div>
-            </div>
+           
             <div class="mb-3 row">
               <label class="col-2 col-form-label" for="clientId">Client ID * :</label>
               <div class="col-10">

--- a/admin/views/identity-provider/update.ejs
+++ b/admin/views/identity-provider/update.ejs
@@ -183,10 +183,49 @@
                 </div>
               </div>
             </div>
+
+
+            <%
+            var isUseDiscoveryUrlChecked = (locals.messages.values && messages.values[0].discovery === true) || !locals.messages.values 
+            %>
+            
             <div class="mb-3 row">
-              <label class="col-2 col-form-label" for="jwksUrl"> JWKS URL <span class=<%= locals.messages.values && messages.values[0].discovery === true ? 'd-none' : '' %>>*</span> : </label>
+              <label class="col-2 col-form-label">Utiliser la discovery URL : </label>
+              <div class="mb-3 col-4 d-flex align-items-end">
+                <div class="form-check form-check-inline">
+                  <input type="radio" class="form-check-input is-valid" id="discovery" name="discovery" value="true" <%= isUseDiscoveryUrlChecked ? 'checked' : '' %>>
+                  <label class="form-check-label" for="discovery">oui</label>
+                </div>
+                <div class="form-check form-check-inline">
+                  <input type="radio" class="form-check-input is-valid" id="no-discovery" name="discovery" value="false" <%= !isUseDiscoveryUrlChecked ? 'checked' :'' %>>
+                  <label class="form-check-label" for="no-discovery">non</label>
+                </div>
+              </div>
+            </div>
+
+             <div class="mb-3 row <%= isUseDiscoveryUrlChecked ? '' : 'd-none' %>" id="discovery-url-row">
+              <label class="col-2 col-form-label" for="discoveryUrl">Discovery URL <span class=<%= isUseDiscoveryUrlChecked ? '' : 'd-none' %>>*</span> :</label>
               <div class="col-10">
-                <input id="jwksUrl" type="text" <%= locals.messages.values && messages.values[0].discovery ? 'disabled' : 'required'%> class="form-control <%= locals.messages.errors && messages.errors[0].jwksUrl && 'is-invalid' %>" name="jwksUrl" value="<%= locals.messages.values && messages.values[0].jwksUrl %>" pattern="^https?:\/\/[^/].+$">
+                <input id="discoveryUrl" <%= isUseDiscoveryUrlChecked ? 'required' :'disabled' %> type="text" class="form-control <%= locals.messages.errors && messages.errors[0].discoveryUrl && 'is-invalid' %>" name="discoveryUrl" value="<%= locals.messages.values && messages.values[0].discoveryUrl %>" pattern="^https?:\/\/[^/].+$">
+                <div class="invalid-feedback">
+                  <% if (locals.messages.errors && messages.errors[0].discoveryUrl) { %>
+                  <p>
+                    <% messages.errors[0].discoveryUrl.forEach((error) => { %>
+                    <%= error %>
+                    <br>
+                    <% }) %>
+                  </p>
+                  <% } else { %>
+                  Veuillez mettre une discovery URL valide au format https://issuer.fr/.well-known/openid-configuration
+                  <% } %>
+                </div>
+              </div>
+            </div>
+
+            <div class="mb-3 row <%= !isUseDiscoveryUrlChecked ? '' : 'd-none' %>" id="jwks-url-row">
+              <label class="col-2 col-form-label" for="jwksUrl"> JWKS URL <span class=<%= isUseDiscoveryUrlChecked ? 'd-none' : '' %>>*</span> : </label>
+              <div class="col-10">
+                <input id="jwksUrl" type="text" <%= isUseDiscoveryUrlChecked ? 'disabled' : 'required' %> class="form-control <%= locals.messages.errors && messages.errors[0].jwksUrl && 'is-invalid' %>" name="jwksUrl" value="<%= locals.messages.values && messages.values[0].jwksUrl %>" pattern="^https?:\/\/[^/].+$">
                 <div class="invalid-feedback">
                   <% if (locals.messages.errors && messages.errors[0].jwksUrl) { %>
                   <p>
@@ -201,11 +240,10 @@
                 </div>
               </div>
             </div>
-
-            <div class="mb-3 row">
-              <label class="col-2 col-form-label" for="tokenUrl">Token URL <span class=<%= locals.messages.values && messages.values[0].discovery === true ? 'd-none' : '' %>>*</span> :</label>
+            <div class="mb-3 row <%= !isUseDiscoveryUrlChecked ? '' : 'd-none' %>" id="token-url-row">
+              <label class="col-2 col-form-label" for="tokenUrl">Token URL <span class=<%= isUseDiscoveryUrlChecked ? 'd-none' : '' %>>*</span> :</label>
               <div class="col-10">
-                <input id="tokenUrl" type="text" <%= locals.messages.values && messages.values[0].discovery ? 'disabled' : 'required'%> class="form-control <%= locals.messages.errors && messages.errors[0].tokenUrl && 'is-invalid' %>" name="tokenUrl" value="<%= locals.messages.values && messages.values[0].tokenUrl %>" pattern="^https?:\/\/[^/].+$">
+                <input id="tokenUrl" type="text" <%= isUseDiscoveryUrlChecked ? 'disabled' : 'required' %> class="form-control <%= locals.messages.errors && messages.errors[0].tokenUrl && 'is-invalid' %>" name="tokenUrl" value="<%= locals.messages.values && messages.values[0].tokenUrl %>" pattern="^https?:\/\/[^/].+$">
                 <div class="invalid-feedback">
                   <% if (locals.messages.errors && messages.errors[0].tokenUrl) { %>
                   <p>
@@ -220,10 +258,10 @@
                 </div>
               </div>
             </div>
-            <div class="mb-3 row">
-              <label class="col-2 col-form-label" for="userInfoUrl">UserInfo URL <span class=<%= locals.messages.values && messages.values[0].discovery === true ? 'd-none' : '' %>>*</span>:</label>
+            <div class="mb-3 row <%= !isUseDiscoveryUrlChecked ? '' : 'd-none' %>" id="userinfo-url-row">
+              <label class="col-2 col-form-label" for="userInfoUrl">UserInfo URL <span class=<%= isUseDiscoveryUrlChecked ? 'd-none' : '' %>>*</span> :</label>
               <div class="col-10">
-                <input id="userInfoUrl" <%= locals.messages.values && messages.values[0].discovery ? 'disabled' : 'required' %> type="text" class="form-control userInfoUrl <%= locals.messages.errors && messages.errors[0].userInfoUrl && 'is-invalid' %>" name="userInfoUrl" value="<%= locals.messages.values && messages.values[0].userInfoUrl %>" pattern="^https?:\/\/[^/].+$">
+                <input id="userInfoUrl" <%= isUseDiscoveryUrlChecked ? 'disabled' : 'required' %> type="text" class="form-control userInfoUrl <%= locals.messages.errors && messages.errors[0].userInfoUrl && 'is-invalid' %>" name="userInfoUrl" value="<%= locals.messages.values && messages.values[0].userInfoUrl %>" pattern="^https?:\/\/[^/].+$">
                 <div class="invalid-feedback">
                   <% if (locals.messages.errors && messages.errors[0].userInfoUrl) { %>
                   <p>
@@ -238,10 +276,10 @@
                 </div>
               </div>
             </div>
-            <div class="mb-3 row">
-              <label class="col-2 col-form-label" for="authorizationUrl">Authorization URL <span class=<%= locals.messages.values && messages.values[0].discovery === true ? 'd-none' : '' %>>*</span> : </label>
+            <div class="mb-3 row <%= !isUseDiscoveryUrlChecked ? '' : 'd-none' %>" id="authorization-url-row">
+              <label class="col-2 col-form-label" for="authorizationUrl">Authorization URL <span class=<%= isUseDiscoveryUrlChecked ? 'd-none' : '' %>>*</span> :</label>
               <div class="col-10">
-                <input id="authorizationUrl" <%= locals.messages.values && messages.values[0].discovery ? 'disabled' : 'required' %> type="text" class="form-control <%= locals.messages.errors && messages.errors[0].authorizationUrl && 'is-invalid' %>" name="authorizationUrl" value="<%= locals.messages.values && messages.values[0].authorizationUrl %>" pattern="^https?:\/\/[^/].+$">
+                <input id="authorizationUrl" <%= isUseDiscoveryUrlChecked ? 'disabled' : 'required' %> type="text" class="form-control <%= locals.messages.errors && messages.errors[0].authorizationUrl && 'is-invalid' %>" name="authorizationUrl" value="<%= locals.messages.values && messages.values[0].authorizationUrl %>" pattern="^https?:\/\/[^/].+$">
                 <div class="invalid-feedback">
                   <% if (locals.messages.errors && messages.errors[0].authorizationUrl) { %>
                   <p>
@@ -292,37 +330,9 @@
                 </div>
               </div>
             </div>
-            <div class="mb-3 row">
-              <label class="col-2 col-form-label">Utiliser la discovery URL : </label>
-              <div class="mb-3 col-4 d-flex align-items-end">
-                <div class="form-check form-check-inline">
-                  <input type="radio" class="form-check-input is-valid" id="discovery" name="discovery" value="true" <%= locals.messages.values && messages.values[0].discovery ? 'checked' : '' %>>
-                  <label class="form-check-label" for="discovery">oui</label>
-                </div>
-                <div class="form-check form-check-inline">
-                  <input type="radio" class="form-check-input is-valid" id="no-discovery" name="discovery" value="false" <%= locals.messages.values && !messages.values[0].discovery ? 'checked' :'' %>>
-                  <label class="form-check-label" for="no-discovery">non</label>
-                </div>
-              </div>
-            </div>
-            <div class="mb-3 row">
-              <label class="col-2 col-form-label" for="discoveryUrl">Discovery URL <span class=<%= locals.messages.values && messages.values[0].discovery === false ? 'd-none' : '' %>>*</span> :</label>
-              <div class="col-10">
-                <input id="discoveryUrl" <%= messages.values[0].discovery === false ? 'disabled' : 'required' %> type="text" class="form-control <%= locals.messages.errors && messages.errors[0].discoveryUrl && 'is-invalid' %>" name="discoveryUrl" value="<%= locals.messages.values && messages.values[0].discoveryUrl %>" pattern="^https?:\/\/[^/].+$">
-                <div class="invalid-feedback">
-                  <% if (locals.messages.errors && messages.errors[0].discoveryUrl) { %>
-                  <p>
-                    <% messages.errors[0].discoveryUrl.forEach((error) => { %>
-                    <%= error %>
-                    <br>
-                    <% }) %>
-                  </p>
-                  <% } else { %>
-                  Veuillez mettre une discovery URL valide au format https://issuer.fr/.well-known/openid-configuration
-                  <% } %>
-                </div>
-              </div>
-            </div>
+           
+
+
             <div class="mb-3 row">
               <label class="col-2 col-form-label" for="clientId">Client ID * :</label>
               <div class="col-10">


### PR DESCRIPTION
**Problem**
In the admin interface, using a discovery URL is not enabled by default, resulting in unnecessary clicks when creating an Identity Provider.

**Proposal**
Enable discovery URL usage by default and hide the fields that are no longer needed.