### PR TITLE
🐛 fix: seed admin fixtures locally

### DIFF
--- a/docker/bash/commands/up.sh
+++ b/docker/bash/commands/up.sh
@@ -30,6 +30,8 @@ _up() {
       ${DOCKER_COMPOSE} exec ${NO_TTY} "admin" yarn typeorm schema:drop
       ${DOCKER_COMPOSE} exec ${NO_TTY} "admin" yarn migrations:run
       ${DOCKER_COMPOSE} exec ${NO_TTY} "admin" yarn fixtures:load
+      ${DOCKER_COMPOSE} run --rm --no-deps ${NO_TTY} core yarn run seed
+
 
       (cd ${FEDERATION_DIR}/admin/cypress/support/ && docker exec pc-pg-"admin"-1 bash -c "$(cat create-db-backup.sh)")
       ;;


### PR DESCRIPTION
**Problem**
Admin fixtures are no longer seeded automatically in the local environment.

**Proposal**
Add the fixture seeding command to `up.sh`.